### PR TITLE
Fix UnblockUser import error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+uv.lock

--- a/app/presentation/telegram/utils/__init__.py
+++ b/app/presentation/telegram/utils/__init__.py
@@ -1,1 +1,6 @@
-from .callback_data import BlacklistConfirm
+from .callback_data import BlacklistConfirm, UnblockUser
+
+__all__ = [
+    "BlacklistConfirm",
+    "UnblockUser",
+]


### PR DESCRIPTION
## Summary
- export `UnblockUser` from the telegram utilities so imports succeed
- ignore `uv.lock`

## Testing
- `ruff check tests`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889dde8f9508322ac441b900db560d6