### PR TITLE
ci: optimize pipeline + Docker build (P0/P1 from review)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,10 +31,15 @@ ENV/
 .DS_Store
 Thumbs.db
 
-# Documentation
+# Documentation & local-only planning files
 CLAUDE.md
-docs/
 AGENTS.md
+docs/
+README.md
+PROJECT_TRACKING.md
+Makefile
+.pre-commit-config.yaml
+.env.example
 
 # Secrets & sessions
 .env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: deploy-main
+  cancel-in-progress: true
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,12 @@ name: Tests
 
 on:
   workflow_call:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -35,6 +37,8 @@ jobs:
       MODERATOR_BOT_TOKEN: "test_token"
       ADMIN_SUPER_ADMINS: "123456789"
 
+    # Matrix kept (even though single-versioned) so the required-status-check
+    # rule `test (3.12)` keeps matching.
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -43,49 +47,37 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v2
+      uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Install dependencies
-      run: |
-        uv sync --dev
+      run: uv sync --dev
 
-    - name: Run linting with ruff
+    - name: Lint + format check (ruff)
       run: |
         uv run ruff check app tests
-
-    - name: Run formatting check with ruff
-      run: |
         uv run ruff format --check app tests
 
-    - name: Run type checking with ty
-      run: |
-        uv run ty check app tests
+    - name: Type check (ty)
+      run: uv run ty check app tests
 
-    - name: Run unit tests
-      run: |
-        uv run pytest tests/unit -v --tb=short
-
-    - name: Run integration tests
-      run: |
-        uv run pytest tests/integration -v --tb=short
-
-    - name: Run end-to-end tests
-      run: |
-        uv run pytest tests/e2e -v --tb=short
-
-    - name: Run tests with coverage
-      run: |
-        uv run pytest --cov=app --cov-report=xml --cov-report=html --cov-fail-under=55
+    # Single pytest invocation covering all suites with coverage. Pytest
+    # auto-discovers from testpaths=["tests"] (unit + integration + e2e +
+    # handlers + middleware + performance). Previously each suite ran
+    # separately AND the full run was repeated with --cov, duplicating
+    # ~1.5 min of work.
+    - name: Pytest with coverage
+      run: uv run pytest --cov=app --cov-report=xml --cov-report=html --cov-fail-under=55
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       if: success()
       with:
         file: ./coverage.xml
@@ -99,58 +91,3 @@ jobs:
       with:
         name: coverage-reports
         path: htmlcov/
-
-  performance-tests:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    continue-on-error: true
-
-    services:
-      postgres:
-        image: pgvector/pgvector:pg18
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: test_moderator_bot_perf
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-    env:
-      DB_USER: postgres
-      DB_PASSWORD: postgres
-      DB_NAME: test_moderator_bot_perf
-      DB_HOST: localhost
-      DB_PORT: 5432
-      MODERATOR_BOT_TOKEN: "test_token"
-      ADMIN_SUPER_ADMINS: "123456789"
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.12"
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v2
-      with:
-        enable-cache: true
-
-    - name: Install dependencies
-      run: |
-        uv sync --dev
-
-    - name: Run performance tests
-      run: |
-        uv run pytest tests/performance -v --tb=short -m "performance and not slow"
-
-    - name: Run slow performance tests
-      run: |
-        uv run pytest tests/performance -v --tb=short -m "slow"
-      continue-on-error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # Multi-stage build for optimized production image
 FROM ghcr.io/astral-sh/uv:0.8.11-alpine AS dependencies
 
@@ -15,41 +16,11 @@ WORKDIR /app
 # Copy dependency files for better caching
 COPY pyproject.toml uv.lock README.md ./
 
-# Install dependencies to virtual environment
-RUN uv sync --frozen --no-dev
-
-# Development stage
-FROM ghcr.io/astral-sh/uv:0.8.11-alpine AS development
-
-# Install system dependencies
-RUN apk add --no-cache \
-    postgresql-client \
-    gcc \
-    python3-dev \
-    musl-dev \
-    linux-headers
-
-WORKDIR /app
-
-# Copy dependency files for better caching
-COPY pyproject.toml uv.lock README.md ./
-
-# Install ALL dependencies including dev for development
-RUN uv sync --frozen
-
-# Copy application source code
-COPY app/ ./app/
-COPY alembic/ ./alembic/
-COPY alembic.ini ./
-COPY scripts/ ./scripts/
-
-# Make sure we use venv
-ENV PATH="/app/.venv/bin:$PATH"
-
-# Make scripts executable
-RUN chmod +x scripts/*.sh
-
-# Development doesn't need to change user - keep as root for easier volume mounting
+# Install dependencies. BuildKit cache mount keeps uv's wheel cache across
+# builds even when the layer above invalidates (pyproject.toml / uv.lock
+# changed) — avoids redownloading every dep from PyPI on uncached builds.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
 
 # Production stage
 FROM python:3.12-alpine AS production


### PR DESCRIPTION
## Summary
Applies P0/P1 items from the pipeline review.

### Docker
- **`--mount=type=cache` for `uv sync`** in the `dependencies` stage. GHA builds on cache-miss (e.g. `uv.lock` changed) currently redownload every wheel. Cache mount preserves uv's wheel cache across those misses.
- **Delete dead `development` stage** — never targeted; duplicated apk + uv sync work.

### CI tests (`test.yml`)
- **Delete `performance-tests` job.** Every test in `tests/performance` has both `@pytest.mark.performance` and `@pytest.mark.slow`, so the filter `-m "performance and not slow"` matched zero → pytest exit 5 → always a noisy failure.
- **Single `pytest --cov=app` run** replacing 4 redundant invocations (unit/integration/e2e + repeat with --cov). Coverage now 56.94% (threshold 55%) locally.
- **Combine ruff lint + format** into one step.
- **Drop duplicate `push: main` trigger** on test.yml (deploy invokes tests via `workflow_call`).
- **Bump actions to Node 24 versions** (setup-python v5, setup-uv v4, codecov v5) + `cache-dependency-glob: "uv.lock"`.
- **`concurrency` groups** on both test and deploy workflows.

### `.dockerignore`
Added PROJECT_TRACKING.md, Makefile, .pre-commit-config.yaml, .env.example, README.md.

## Expected impact
- CI test job: ~4 pytest passes → 1; lint + format 2 steps → 1. Estimated -40% wall time (~3m → ~1m45s).
- Docker build on uv.lock change: ~3 min dep download → ~30-60 s with cache mount.
- Deploy: supersedes in-flight rebuild instead of racing.

## Test plan
- [x] Local: `uv run pytest --cov=app --cov-fail-under=55` → 56.94% passed
- [x] Local: `uv run ruff check app tests && uv run ruff format --check app tests` — clean (pre-existing datetime warnings untouched)
- [ ] CI on this PR
- [ ] Compare post-merge deploy time against current 10+ min run

## Skipped (not in scope)
- P1#7 GHCR cache registry switch — needs a real miss/hit audit first
- P1#8 `psycopg2-binary` removal — only if confirmed Alembic doesn't need it
- P2#11 `wait_for_postgres.sh` — DB is remote managed, not blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)