### PR TITLE
fix(ci): unignore README.md — needed for uv sync

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,10 +32,11 @@ ENV/
 Thumbs.db
 
 # Documentation & local-only planning files
+# NOTE: README.md must NOT be excluded — pyproject.toml references it as
+# the `readme` field and the Dockerfile COPYs it for `uv sync`.
 CLAUDE.md
 AGENTS.md
 docs/
-README.md
 PROJECT_TRACKING.md
 Makefile
 .pre-commit-config.yaml


### PR DESCRIPTION
## Summary
- PR #54 added README.md to .dockerignore, breaking Docker builds
- pyproject.toml: `readme = "README.md"` — uv sync reads it during build
- Dockerfile:17 COPYs it → build failed with "README.md not found"

Failed deploy: https://github.com/vsem-azamat/supervisor-telegram/actions/runs/24555266906

## Test plan
- [x] Ruff/ty/pytest still pass locally (pre-commit hooks green)
- [ ] CI `test (3.12)` passes
- [ ] Deploy after merge rebuilds image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)