### PR TITLE
fix: terminal-status guards in review approve/reject/delete

### DIFF
--- a/app/channel/review/service.py
+++ b/app/channel/review/service.py
@@ -196,6 +196,10 @@ async def approve_post(
             return "Already published.", None
         if post.status == PostStatus.SCHEDULED:
             return "Post is scheduled. Use 'Publish now' to send immediately.", None
+        if post.status == PostStatus.REJECTED:
+            return "Post was rejected — cannot publish.", None
+        if post.status == PostStatus.SKIPPED:
+            return "Post was skipped — cannot publish.", None
 
         source_urls = extract_source_urls(post)
 
@@ -254,6 +258,8 @@ async def reject_post(
             return "Already rejected."
         if post.status == PostStatus.APPROVED:
             return "Already published — cannot reject."
+        if post.status == PostStatus.SKIPPED:
+            return "Post was skipped — cannot reject."
 
         was_scheduled = post.status == PostStatus.SCHEDULED
         scheduled_tg_id = post.scheduled_telegram_id if was_scheduled else None
@@ -306,6 +312,8 @@ async def delete_post(
             return "Already published — cannot delete.", None
         if post.status == PostStatus.SKIPPED:
             return "Already skipped.", None
+        if post.status == PostStatus.REJECTED:
+            return "Post was rejected — cannot delete.", None
 
         post.skip()
         await session.commit()

--- a/tests/integration/test_review_for_update_pg.py
+++ b/tests/integration/test_review_for_update_pg.py
@@ -115,14 +115,8 @@ class TestConcurrentReviewActions:
         assert final.status == PostStatus.APPROVED
         assert final.telegram_message_id == 99
 
-    async def test_delete_vs_approve_serializes(self, pg_session_maker):
-        """delete + approve fired together — FOR UPDATE serializes them, both complete.
-
-        Note: `approve_post` has no SKIPPED/REJECTED guard today, so when delete
-        wins the lock first, approve still publishes. This test pins the
-        serialization invariant (two real transactions, no deadlock) without
-        asserting on which one wins — revisit if the status guards are tightened.
-        """
+    async def test_delete_vs_approve_single_winner(self, pg_session_maker):
+        """delete + approve fired together — FOR UPDATE picks one winner, other is rejected."""
         await _insert_channel(pg_session_maker, max_posts_per_day=5)
         post_id = await _insert_post(pg_session_maker)
 
@@ -130,12 +124,21 @@ class TestConcurrentReviewActions:
 
         delete_task = asyncio.create_task(delete_post(post_id, pg_session_maker))
         approve_task = asyncio.create_task(approve_post(post_id, _CHANNEL_TG_ID, publish_fn, pg_session_maker))
-        results = await asyncio.gather(delete_task, approve_task, return_exceptions=True)
-        assert not any(isinstance(r, Exception) for r in results)
+        (del_msg, _), (app_msg, _) = await asyncio.gather(delete_task, approve_task)
 
         final = await _read_post(pg_session_maker, post_id)
-        # Final status is one of the two transitions (never stuck as DRAFT).
         assert final.status in (PostStatus.APPROVED, PostStatus.SKIPPED)
+
+        if final.status == PostStatus.APPROVED:
+            # approve won; delete saw APPROVED
+            assert del_msg == "Already published — cannot delete."
+            assert app_msg.startswith("Published")
+            assert publish_fn.call_count == 1
+        else:
+            # delete won; approve saw SKIPPED and refused to publish
+            assert del_msg == "Post skipped."
+            assert app_msg == "Post was skipped — cannot publish."
+            assert publish_fn.call_count == 0
 
 
 class TestDailySlotReservationAtomic:

--- a/tests/unit/test_channel_agent.py
+++ b/tests/unit/test_channel_agent.py
@@ -819,6 +819,83 @@ class TestReviewFlow:
         assert result == "Post is scheduled. Use 'Publish now' to send immediately."
         mock_bot.send_message.assert_not_called()
 
+    async def test_handle_approve_post_rejected(
+        self,
+        mock_bot: AsyncMock,
+        session_maker: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Approving a REJECTED post must not publish — guards a delete/reject-then-approve race."""
+        from app.channel.review import handle_approve
+
+        async with session_maker() as session:
+            post = ChannelPost(
+                channel_id=-1001234567890, external_id="ext1", title="T", post_text="text", status="rejected"
+            )
+            session.add(post)
+            await session.commit()
+            post_id = post.id
+
+        result = await handle_approve(mock_bot, post_id, -1001111111111, session_maker)
+        assert result == "Post was rejected — cannot publish."
+        mock_bot.send_message.assert_not_called()
+
+    async def test_handle_approve_post_skipped(
+        self,
+        mock_bot: AsyncMock,
+        session_maker: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Approving a SKIPPED (soft-deleted) post must not publish."""
+        from app.channel.review import handle_approve
+
+        async with session_maker() as session:
+            post = ChannelPost(
+                channel_id=-1001234567890, external_id="ext1", title="T", post_text="text", status="skipped"
+            )
+            session.add(post)
+            await session.commit()
+            post_id = post.id
+
+        result = await handle_approve(mock_bot, post_id, -1001111111111, session_maker)
+        assert result == "Post was skipped — cannot publish."
+        mock_bot.send_message.assert_not_called()
+
+    async def test_handle_reject_post_skipped(
+        self,
+        session_maker: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Rejecting a SKIPPED post is a no-op — nothing to reject once deleted."""
+        from app.channel.review import handle_reject
+
+        async with session_maker() as session:
+            post = ChannelPost(
+                channel_id=-1001234567890, external_id="ext1", title="T", post_text="text", status="skipped"
+            )
+            session.add(post)
+            await session.commit()
+            post_id = post.id
+
+        result = await handle_reject(post_id, session_maker, reason="late")
+        assert result == "Post was skipped — cannot reject."
+
+    async def test_handle_delete_post_rejected(
+        self,
+        mock_bot: AsyncMock,
+        session_maker: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Deleting a REJECTED post is redundant — reject is already terminal."""
+        from app.channel.review import handle_delete
+
+        async with session_maker() as session:
+            post = ChannelPost(
+                channel_id=-1001234567890, external_id="ext1", title="T", post_text="text", status="rejected"
+            )
+            session.add(post)
+            await session.commit()
+            post_id = post.id
+
+        result = await handle_delete(mock_bot, post_id, -1001111111111, None, session_maker)
+        assert result == "Post was rejected — cannot delete."
+
     async def test_handle_edit_request_already_approved(
         self,
         mock_bot: AsyncMock,


### PR DESCRIPTION
## Summary

Surfaces a real defect found while writing the FOR UPDATE concurrency tests in #60: the three terminal review actions had inconsistent status guards, so a delete-wins race against approve could still publish a soft-deleted post.

| Function | APPROVED | SCHEDULED | REJECTED | SKIPPED |
|---|---|---|---|---|
| `approve_post` (before) | ✅ | ✅ | ❌ | ❌ |
| `approve_post` (after)  | ✅ | ✅ | ✅ new | ✅ new |
| `reject_post` (before)  | ✅ | — | ✅ | ❌ |
| `reject_post` (after)   | ✅ | — | ✅ | ✅ new |
| `delete_post` (before)  | ✅ | — | ❌ | ✅ |
| `delete_post` (after)   | ✅ | — | ✅ new | ✅ |

All three terminal states now produce consistent `"Post was X — cannot Y."` messages, matching the pre-existing pattern in `edit_post_text` / `regen_post_text`.

## Tests

- **New unit tests** (4): `handle_approve` on REJECTED / SKIPPED, `handle_reject` on SKIPPED, `handle_delete` on REJECTED — each pins the new guard message.
- **Updated integration test**: `test_delete_vs_approve_single_winner` now asserts the winner deterministically. When delete wins the lock, approve refuses with `"Post was skipped — cannot publish."` and `publish_fn` is not called — previously, it would have published.

## Test plan

- [x] `uv run -m pytest` → 629 passed, 2 skipped, ~22s
- [x] `uv run ruff check` + `uv run ty check` on changed files → clean
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)