### PR TITLE
feat(review): show full album during review (Sprint 1.5)

### DIFF
--- a/alembic/versions/21c84750b5db_add_review_album_message_ids_to_channel_.py
+++ b/alembic/versions/21c84750b5db_add_review_album_message_ids_to_channel_.py
@@ -1,0 +1,28 @@
+"""add review_album_message_ids to channel_posts
+
+Revision ID: 21c84750b5db
+Revises: 3e8dba58c88d
+Create Date: 2026-04-17 14:56:43.757137
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "21c84750b5db"
+down_revision: str | None = "3e8dba58c88d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "channel_posts",
+        sa.Column("review_album_message_ids", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("channel_posts", "review_album_message_ids")

--- a/app/channel/review/agent.py
+++ b/app/channel/review/agent.py
@@ -5,7 +5,6 @@ that has tools and memory, enabling multi-turn editing sessions per post.
 """
 
 import asyncio
-import contextlib
 import functools
 import time
 from dataclasses import dataclass
@@ -458,58 +457,48 @@ def create_review_agent(model_name: str = "") -> Agent[ReviewAgentDeps, str]:
         return msg
 
     async def _refresh_review_message(ctx: RunContext[ReviewAgentDeps], post: Any) -> str | None:
-        """Delete old review message and send a new one with updated image/text.
+        """Delegate to the telegram_io rebuild helper.
 
-        Returns a warning string if refresh failed, None on success.
+        The ``post`` argument is unused — the helper re-fetches from DB to avoid
+        stale state. Kept for API compatibility with earlier callers.
         """
-        from app.channel.review.telegram_io import (
-            _send_review_message,
-            build_review_keyboard,
-            extract_source_btn_data,
-        )
+        del post
+        from sqlalchemy import select as _select
 
-        if not post.review_message_id:
-            return None
-
-        bot = ctx.deps.bot
-        review_chat_id = ctx.deps.review_chat_id
+        from app.channel.review.service import extract_source_btn_data
+        from app.channel.review.telegram_io import _rebuild_review_message, build_review_keyboard
+        from app.db.models import ChannelPost
 
         try:
-            # Delete old message
-            with contextlib.suppress(Exception):
-                await bot.delete_message(chat_id=review_chat_id, message_id=post.review_message_id)
+            async with ctx.deps.session_maker() as session:
+                r = await session.execute(_select(ChannelPost).where(ChannelPost.id == ctx.deps.post_id))
+                fresh_post = r.scalar_one_or_none()
 
-            # Send new message with current image
-            source_btn_data = extract_source_btn_data(post)
+            if fresh_post is None:
+                return "Warning: post not found during refresh."
+
             keyboard = build_review_keyboard(
                 ctx.deps.post_id,
-                source_items=source_btn_data,
+                source_items=extract_source_btn_data(fresh_post),
                 channel_name=ctx.deps.channel_name,
                 channel_username=ctx.deps.channel_username,
             )
-            new_msg = await _send_review_message(
-                bot,
-                review_chat_id,
-                post.post_text,
+            await _rebuild_review_message(
+                ctx.deps.bot,
+                ctx.deps.review_chat_id,
+                ctx.deps.post_id,
+                ctx.deps.session_maker,
                 keyboard,
-                post.image_url,
             )
 
-            # Update review_message_id in DB + register in reply chain
+            # Register the new pult in the reply chain (post.review_message_id was
+            # updated inside _rebuild_review_message).
             async with ctx.deps.session_maker() as session:
-                from sqlalchemy import select as sa_select
-
-                from app.db.models import ChannelPost
-
-                r = await session.execute(sa_select(ChannelPost).where(ChannelPost.id == ctx.deps.post_id))
-                db_post = r.scalar_one_or_none()
-                if db_post:
-                    db_post.review_message_id = new_msg.message_id
-                    await session.commit()
-
-            # Register new message in reply chain (in-memory + DB)
-            register_message(new_msg.message_id, ctx.deps.post_id)
-            await persist_message_to_db(ctx.deps.session_maker, ctx.deps.post_id, new_msg.message_id)
+                r = await session.execute(_select(ChannelPost).where(ChannelPost.id == ctx.deps.post_id))
+                refreshed = r.scalar_one_or_none()
+            if refreshed and refreshed.review_message_id:
+                register_message(refreshed.review_message_id, ctx.deps.post_id)
+                await persist_message_to_db(ctx.deps.session_maker, ctx.deps.post_id, refreshed.review_message_id)
 
             return None
         except Exception:
@@ -592,16 +581,8 @@ def create_review_agent(model_name: str = "") -> Agent[ReviewAgentDeps, str]:
         return out
 
     async def _refresh_after_change(ctx: RunContext[ReviewAgentDeps]) -> None:
-        """Re-fetch the post and call the existing _refresh_review_message helper."""
-        from sqlalchemy import select as _select
-
-        from app.db.models import ChannelPost
-
-        async with ctx.deps.session_maker() as session:
-            r = await session.execute(_select(ChannelPost).where(ChannelPost.id == ctx.deps.post_id))
-            post = r.scalar_one_or_none()
-        if post:
-            await _refresh_review_message(ctx, post)
+        """Re-fetch the post and rebuild the review message."""
+        await _refresh_review_message(ctx, None)
 
     return agent
 

--- a/app/channel/review/telegram_io.py
+++ b/app/channel/review/telegram_io.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import calendar
 from typing import TYPE_CHECKING, Any
 
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message, URLInputFile
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, InputMediaPhoto, Message, URLInputFile
 
 from app.channel.review.service import (
     CB_APPROVE,
@@ -170,24 +170,54 @@ def build_schedule_picker_keyboard(
 # ── Telegram message send/edit helpers ──
 
 
-async def _send_review_message(
+async def _render_review_message(
     bot: Bot,
     chat_id: int | str,
-    text: str,
+    post_text: str,
+    image_urls: list[str] | None,
     keyboard: InlineKeyboardMarkup,
-    image_url: str | None = None,
-) -> Message:
-    """Send review message — photo with caption if image available, else text.
+) -> tuple[int, list[int] | None]:
+    """Send a review message in the right mode based on image count.
 
-    NOTE: parse_mode=None is required to override the bot's default parse_mode="HTML",
-    otherwise caption_entities / entities are silently ignored by Telegram.
+    Returns (pult_message_id, album_message_ids | None).
+    - 0 images → text message (pult = that message; album = None)
+    - 1 image, caption ≤ 1024 → photo with caption (pult = that photo; album = None)
+    - 1 image, caption > 1024 → text-only fallback (image dropped; pult = text msg)
+    - 2+ images → media group + separate pult text message as reply to first photo
+
+    parse_mode=None is required everywhere to preserve entities past the bot's
+    default HTML mode.
     """
-    plain, entities = md_to_entities(text)
+    plain, entities = md_to_entities(post_text)
+    urls = list(image_urls or [])
 
-    if image_url and len(plain) <= 1024:
+    if len(urls) >= 2:
+        input_media = [InputMediaPhoto(media=URLInputFile(u)) for u in urls[:10]]
         try:
-            photo = URLInputFile(image_url)
-            return await bot.send_photo(
+            photos = await bot.send_media_group(chat_id=chat_id, media=input_media)
+        except Exception:
+            logger.exception("review_album_send_failed_fallback_to_single")
+            photos = []
+
+        if photos:
+            pult_msg = await bot.send_message(
+                chat_id=chat_id,
+                text=plain,
+                entities=entities,
+                reply_markup=keyboard,
+                reply_to_message_id=photos[0].message_id,
+                disable_web_page_preview=True,
+                parse_mode=None,
+            )
+            return pult_msg.message_id, [m.message_id for m in photos]
+
+        # album failed — fall through to single-image path using the first url
+
+    first_url = urls[0] if urls else None
+    if first_url and len(plain) <= 1024:
+        try:
+            photo = URLInputFile(first_url)
+            msg = await bot.send_photo(
                 chat_id=chat_id,
                 photo=photo,
                 caption=plain,
@@ -195,10 +225,11 @@ async def _send_review_message(
                 reply_markup=keyboard,
                 parse_mode=None,
             )
+            return msg.message_id, None
         except Exception:
             logger.exception("review_photo_failed_fallback_to_text")
 
-    return await bot.send_message(
+    msg = await bot.send_message(
         chat_id=chat_id,
         text=plain,
         entities=entities,
@@ -206,6 +237,26 @@ async def _send_review_message(
         disable_web_page_preview=True,
         parse_mode=None,
     )
+    return msg.message_id, None
+
+
+async def _send_review_message(
+    bot: Bot,
+    chat_id: int | str,
+    text: str,
+    keyboard: InlineKeyboardMarkup,
+    image_url: str | None = None,
+) -> Message:
+    """Back-compat wrapper that returns the pult Message only.
+
+    Callers that still use this helper get single-message semantics (they cannot
+    support album mode — they get the old behaviour). New code should use
+    `_render_review_message` directly.
+    """
+    image_urls = [image_url] if image_url else []
+    pult_id, _ = await _render_review_message(bot, chat_id, text, image_urls, keyboard)
+    # Synthesise a minimal Message-like object; callers only use .message_id.
+    return type("_StubMsg", (), {"message_id": pult_id})()  # type: ignore[return-value]
 
 
 async def _edit_review_message(

--- a/app/channel/review/telegram_io.py
+++ b/app/channel/review/telegram_io.py
@@ -346,10 +346,19 @@ async def send_for_review(
                 channel_username=channel_username,
             )
 
-            msg = await _send_review_message(bot, review_chat_id, post.text, keyboard, post.image_url)
-            db_post.review_message_id = msg.message_id
+            image_urls = post.image_urls or ([post.image_url] if post.image_url else [])
+            msg_pult_id, msg_album_ids = await _render_review_message(
+                bot, review_chat_id, post.text, image_urls, keyboard
+            )
+            db_post.review_message_id = msg_pult_id
+            db_post.review_album_message_ids = msg_album_ids
             await session.commit()
-            logger.info("review_sent", post_id=post_id, review_msg=msg.message_id)
+            logger.info(
+                "review_sent",
+                post_id=post_id,
+                review_msg=msg_pult_id,
+                album=len(msg_album_ids) if msg_album_ids else 0,
+            )
             return post_id
         except EmbeddingError as exc:
             # create_review_post already rolled back the session; surface as None

--- a/app/channel/review/telegram_io.py
+++ b/app/channel/review/telegram_io.py
@@ -240,6 +240,52 @@ async def _render_review_message(
     return msg.message_id, None
 
 
+async def _rebuild_review_message(
+    bot: Bot,
+    chat_id: int | str,
+    post_id: int,
+    session_maker: async_sessionmaker[AsyncSession],
+    keyboard: InlineKeyboardMarkup,
+) -> None:
+    """Rebuild the review message for ``post_id``: new-first-then-delete.
+
+    1. Fetch current post + old (pult_id, album_ids) from DB.
+    2. Call ``_render_review_message`` with the post's current text/images.
+    3. Commit the new ids to DB (callbacks on the new pult work immediately).
+    4. Best-effort delete all old messages. Delete failures are logged, not raised.
+
+    No-op when the post has no existing ``review_message_id``.
+    """
+    from sqlalchemy import select
+
+    from app.db.models import ChannelPost
+
+    async with session_maker() as session:
+        r = await session.execute(select(ChannelPost).where(ChannelPost.id == post_id))
+        post = r.scalar_one_or_none()
+        if post is None or not post.review_message_id:
+            return
+        old_ids: list[int] = [post.review_message_id]
+        old_ids.extend(post.review_album_message_ids or [])
+        post_text = post.post_text
+        image_urls = list(post.image_urls or [])
+
+    new_pult_id, new_album_ids = await _render_review_message(bot, chat_id, post_text, image_urls, keyboard)
+
+    async with session_maker() as session:
+        r = await session.execute(select(ChannelPost).where(ChannelPost.id == post_id))
+        post = r.scalar_one_or_none()
+        if post is not None:
+            post.review_message_id = new_pult_id
+            post.review_album_message_ids = new_album_ids
+            await session.commit()
+
+    try:
+        await bot.delete_messages(chat_id=chat_id, message_ids=old_ids)
+    except Exception:
+        logger.warning("review_rebuild_delete_failed", post_id=post_id, old_ids=old_ids, exc_info=True)
+
+
 async def _send_review_message(
     bot: Bot,
     chat_id: int | str,

--- a/app/channel/review/telegram_io.py
+++ b/app/channel/review/telegram_io.py
@@ -527,7 +527,7 @@ async def handle_regen(
     channel_name: str = "",
     channel_username: str | None = None,
 ) -> str:
-    """Regenerate a post from its original sources."""
+    """Regenerate a post from its original sources. Always rebuilds the review message."""
     status_msg, updated_post = await regen_post_text(
         post_id=post_id,
         api_key=api_key,
@@ -537,7 +537,6 @@ async def handle_regen(
         footer=footer,
     )
 
-    # Update Telegram review message if regen succeeded
     if updated_post and updated_post.review_message_id:
         source_btn_data = extract_source_btn_data(updated_post)
         keyboard = build_review_keyboard(
@@ -547,16 +546,8 @@ async def handle_regen(
             channel_username=channel_username,
         )
         try:
-            regen_plain, regen_entities = md_to_entities(updated_post.post_text)
-            await _edit_review_message(
-                bot,
-                review_chat_id,
-                updated_post.review_message_id,
-                regen_plain,
-                regen_entities,
-                keyboard,
-            )
+            await _rebuild_review_message(bot, review_chat_id, post_id, session_maker, keyboard)
         except Exception:
-            logger.exception("review_update_error")
+            logger.exception("review_regen_rebuild_error")
 
     return status_msg

--- a/app/channel/review/telegram_io.py
+++ b/app/channel/review/telegram_io.py
@@ -449,15 +449,33 @@ async def handle_delete(
     review_message_id: int | None,
     session_maker: async_sessionmaker[AsyncSession],
 ) -> str:
-    """Skip a post (soft-delete) and remove the review message from chat."""
+    """Skip a post (soft-delete) and remove the review messages from chat."""
+    from sqlalchemy import select
+
+    from app.db.models import ChannelPost
+
+    album_ids: list[int] = []
+    async with session_maker() as session:
+        r = await session.execute(select(ChannelPost).where(ChannelPost.id == post_id))
+        post = r.scalar_one_or_none()
+        if post and post.review_album_message_ids:
+            album_ids = list(post.review_album_message_ids)
+
     status_msg, skipped_post = await delete_post(post_id, session_maker)
 
-    # Remove review message from chat (Telegram-specific)
-    if skipped_post and review_message_id:
-        try:
-            await bot.delete_message(chat_id=review_chat_id, message_id=review_message_id)
-        except Exception:
-            logger.warning("review_message_delete_failed", post_id=post_id, exc_info=True)
+    if skipped_post:
+        # Delete album photos in bulk (best-effort).
+        if album_ids:
+            try:
+                await bot.delete_messages(chat_id=review_chat_id, message_ids=album_ids)
+            except Exception:
+                logger.warning("review_album_delete_failed", post_id=post_id, exc_info=True)
+        # Delete pult.
+        if review_message_id:
+            try:
+                await bot.delete_message(chat_id=review_chat_id, message_id=review_message_id)
+            except Exception:
+                logger.warning("review_message_delete_failed", post_id=post_id, exc_info=True)
 
     return status_msg
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -417,6 +417,7 @@ class ChannelPost(Base):
     scheduled_telegram_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     published_at: Mapped[datetime.datetime | None] = mapped_column(DateTime, nullable=True)
     reply_chain_message_ids: Mapped[list[int] | None] = mapped_column(JSON, nullable=True)
+    review_album_message_ids: Mapped[list[int] | None] = mapped_column(JSON, nullable=True)
     embedding: Mapped[Any | None] = mapped_column(Vector(768), nullable=True)
     embedding_model: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(DateTime, default=utc_now)
@@ -432,6 +433,7 @@ class ChannelPost(Base):
         telegram_message_id: int | None = None,
         review_message_id: int | None = None,
         review_chat_id: int | None = None,
+        review_album_message_ids: list[int] | None = None,
         image_url: str | None = None,
         image_urls: list[str] | None = None,
         image_candidates: list[dict[str, Any]] | None = None,
@@ -455,6 +457,7 @@ class ChannelPost(Base):
         self.image_phashes = image_phashes
         self.status = status
         self.reply_chain_message_ids: list[int] | None = None
+        self.review_album_message_ids = review_album_message_ids
         self.embedding = embedding
         self.embedding_model = embedding_model
 

--- a/docs/superpowers/plans/2026-04-17-review-album-ui.md
+++ b/docs/superpowers/plans/2026-04-17-review-album-ui.md
@@ -1,0 +1,1490 @@
+# Review Album UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a review post has 2+ images, show every image to the reviewer instead of just the first — by switching that case to a Telegram media group + a separate "pult" text message with the action buttons.
+
+**Architecture:** New render helper in `telegram_io.py` picks one of three modes (`text` / `single` / `album`) based on `len(image_urls)`. A new rebuild helper does new-first-then-delete to swap album state without leaving dead callbacks. The existing `_refresh_after_change` seam in `agent.py` funnels into the new rebuild. DB gains a nullable `review_album_message_ids` JSON column.
+
+**Tech Stack:** aiogram 3.x (`send_media_group`, `InputMediaPhoto`, `delete_messages`), SQLAlchemy 2.x async, Alembic, pytest + `FakeTelegramServer`.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-review-album-ui-design.md`
+
+**Branch:** `feat/review-album-ui` (already checked out)
+
+---
+
+## File Structure
+
+### Modified files
+
+- `app/db/models.py` — add `review_album_message_ids: Mapped[list[int] | None]` column + `__init__` kwarg.
+- `app/channel/review/telegram_io.py` — new `_render_review_message`, `_rebuild_review_message`; `send_for_review` persists new ids; `handle_regen` triggers rebuild; `handle_delete` cleans album.
+- `app/channel/review/agent.py` — `_refresh_review_message` delegates to `_rebuild_review_message`.
+- `tests/fake_telegram.py` — add `sendMediaGroup` and `deleteMessages` handlers with per-method recording of params.
+
+### New files
+
+- `alembic/versions/<auto>_add_review_album_message_ids.py` — migration.
+- `tests/unit/test_review_render_modes.py` — unit tests for `_render_review_message`.
+- `tests/unit/test_review_rebuild.py` — unit tests for `_rebuild_review_message`.
+- `tests/unit/test_channel_post_album_ids.py` — ORM round-trip for the new field.
+- `tests/e2e/test_review_album_e2e.py` — full flow via `FakeTelegramServer`.
+
+---
+
+## Task 1: DB column — `review_album_message_ids`
+
+**Files:**
+- Modify: `app/db/models.py:411-413` and `__init__` around `app/db/models.py:424-459`
+- Create: `alembic/versions/<auto>_add_review_album_message_ids.py`
+- Test: `tests/unit/test_channel_post_album_ids.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_channel_post_album_ids.py`:
+
+```python
+"""ORM round-trip for ChannelPost.review_album_message_ids."""
+
+from __future__ import annotations
+
+import pytest
+from app.core.enums import PostStatus
+from app.db.models import ChannelPost
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_review_album_message_ids_roundtrips_list_of_ints(session_maker):
+    async with session_maker() as s:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="x",
+            title="t",
+            post_text="b",
+            status=PostStatus.DRAFT,
+            review_album_message_ids=[1001, 1002, 1003],
+        )
+        s.add(p)
+        await s.commit()
+        await s.refresh(p)
+        pid = p.id
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+        assert row.review_album_message_ids == [1001, 1002, 1003]
+
+
+async def test_review_album_message_ids_defaults_to_none(session_maker):
+    async with session_maker() as s:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="y",
+            title="t",
+            post_text="b",
+            status=PostStatus.DRAFT,
+        )
+        s.add(p)
+        await s.commit()
+        await s.refresh(p)
+        assert p.review_album_message_ids is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run -m pytest tests/unit/test_channel_post_album_ids.py -v`
+Expected: FAIL with `TypeError: __init__() got an unexpected keyword argument 'review_album_message_ids'` or `AttributeError`.
+
+- [ ] **Step 3: Add the column and __init__ kwarg**
+
+In `app/db/models.py`, after the line `image_phashes: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)` (currently line 413), add:
+
+```python
+    review_album_message_ids: Mapped[list[int] | None] = mapped_column(JSON, nullable=True)
+```
+
+In `__init__` (currently around line 424-442), add parameter `review_album_message_ids: list[int] | None = None,` to the signature (group with the other `review_*` parameters), and `self.review_album_message_ids = review_album_message_ids` inside the body (group with the other assignments).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run -m pytest tests/unit/test_channel_post_album_ids.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Generate the Alembic migration**
+
+Run: `uv run alembic revision --autogenerate -m "add review_album_message_ids to channel_posts"`
+
+Expected: a new file under `alembic/versions/` named like `<hex>_add_review_album_message_ids_to_.py`.
+
+- [ ] **Step 6: Verify migration contents**
+
+Open the generated file. It should look structurally like:
+
+```python
+"""add review_album_message_ids to channel_posts
+
+Revision ID: <hex>
+Revises: 3e8dba58c88d
+Create Date: ...
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '<hex>'
+down_revision: Union[str, None] = '3e8dba58c88d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'channel_posts',
+        sa.Column('review_album_message_ids', sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('channel_posts', 'review_album_message_ids')
+```
+
+If autogenerate added anything else (other tables/columns), **delete the extra ops** — the migration must only touch this one column. Confirm `down_revision` matches the latest existing migration (`3e8dba58c88d`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/db/models.py alembic/versions/*add_review_album_message_ids*.py tests/unit/test_channel_post_album_ids.py
+git commit -m "feat(db): add review_album_message_ids column for album review mode"
+```
+
+---
+
+## Task 2: FakeTelegramServer — `sendMediaGroup` and `deleteMessages`
+
+**Files:**
+- Modify: `tests/fake_telegram.py:68-213`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/e2e/test_fake_tg_album_endpoints.py`:
+
+```python
+"""Smoke test: FakeTelegramServer handles sendMediaGroup and deleteMessages."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from aiogram import Bot
+from aiogram.client.session.aiohttp import AiohttpSession
+from aiogram.client.telegram import TelegramAPIServer
+from aiogram.types import InputMediaPhoto
+
+from tests.fake_telegram import FakeTelegramServer
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_send_media_group_returns_distinct_message_ids():
+    async with FakeTelegramServer() as server:
+        bot = Bot(
+            token="123:fake",
+            session=AiohttpSession(api=TelegramAPIServer.from_base(server.base_url)),
+        )
+        try:
+            media = [
+                InputMediaPhoto(media="https://example.com/a.jpg"),
+                InputMediaPhoto(media="https://example.com/b.jpg"),
+            ]
+            messages = await bot.send_media_group(chat_id=-100, media=media)
+        finally:
+            await bot.session.close()
+
+        assert len(messages) == 2
+        assert messages[0].message_id != messages[1].message_id
+
+        calls = server.get_calls("sendMediaGroup")
+        assert len(calls) == 1
+        media_param = calls[0].params.get("media")
+        # aiogram serialises media as JSON string in multipart form
+        parsed = json.loads(media_param) if isinstance(media_param, str) else media_param
+        assert len(parsed) == 2
+
+
+async def test_delete_messages_records_ids():
+    async with FakeTelegramServer() as server:
+        bot = Bot(
+            token="123:fake",
+            session=AiohttpSession(api=TelegramAPIServer.from_base(server.base_url)),
+        )
+        try:
+            ok = await bot.delete_messages(chat_id=-100, message_ids=[1001, 1002, 1003])
+        finally:
+            await bot.session.close()
+
+        assert ok is True
+        calls = server.get_calls("deleteMessages")
+        assert len(calls) == 1
+        ids_param = calls[0].params.get("message_ids")
+        parsed = json.loads(ids_param) if isinstance(ids_param, str) else ids_param
+        assert list(parsed) == [1001, 1002, 1003]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run -m pytest tests/e2e/test_fake_tg_album_endpoints.py -v`
+Expected: FAIL. The generic fallback returns `{"ok": True, "result": True}` but `send_media_group` expects `result` to be a list of Message objects; aiogram will raise a validation error.
+
+- [ ] **Step 3: Add handlers to FakeTelegramServer**
+
+In `tests/fake_telegram.py`, after `_handle_deleteMessage` (currently around line 151-152) add two new methods:
+
+```python
+    def _handle_sendMediaGroup(self, params: dict[str, Any]) -> web.Response:
+        """Return one minimal Message per item in the media list, with distinct ids."""
+        import json as _json
+
+        media_raw = params.get("media", "[]")
+        try:
+            media = _json.loads(media_raw) if isinstance(media_raw, str) else list(media_raw)
+        except Exception:
+            media = []
+        chat_id = int(params.get("chat_id", 0))
+        messages: list[dict[str, Any]] = []
+        for _ in media:
+            self._message_id_counter += 1
+            messages.append(
+                {
+                    "message_id": self._message_id_counter,
+                    "from": {"id": 5145935834, "is_bot": True, "first_name": "Test Bot"},
+                    "chat": {"id": chat_id, "type": "supergroup", "title": "Test Chat"},
+                    "date": 1700000000,
+                    "photo": [
+                        {
+                            "file_id": f"photo-{self._message_id_counter}",
+                            "file_unique_id": f"u-{self._message_id_counter}",
+                            "width": 800,
+                            "height": 600,
+                            "file_size": 1024,
+                        }
+                    ],
+                }
+            )
+        return web.json_response({"ok": True, "result": messages})
+
+    def _handle_deleteMessages(self, params: dict[str, Any]) -> web.Response:
+        """Bulk delete. Accept and record the list; return success."""
+        return web.json_response({"ok": True, "result": True})
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run -m pytest tests/e2e/test_fake_tg_album_endpoints.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fake_telegram.py tests/e2e/test_fake_tg_album_endpoints.py
+git commit -m "test: FakeTelegramServer handlers for sendMediaGroup and deleteMessages"
+```
+
+---
+
+## Task 3: `_render_review_message` — the mode-aware renderer
+
+**Files:**
+- Modify: `app/channel/review/telegram_io.py:170-208` (replace `_send_review_message`)
+- Test: `tests/unit/test_review_render_modes.py`
+
+This task replaces the single-photo-or-text helper `_send_review_message` with a mode-aware `_render_review_message` that returns `(pult_message_id, album_message_ids | None)`. Call sites updated in later tasks.
+
+- [ ] **Step 1: Write the failing test — text mode**
+
+Create `tests/unit/test_review_render_modes.py`:
+
+```python
+"""Unit tests for _render_review_message: chooses the right mode based on image count."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from app.channel.review.telegram_io import _render_review_message
+
+pytestmark = pytest.mark.asyncio
+
+
+def _kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[[InlineKeyboardButton(text="ok", callback_data="x")]])
+
+
+async def test_render_text_mode_no_images():
+    bot = SimpleNamespace()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=2001))
+    bot.send_photo = AsyncMock()
+    bot.send_media_group = AsyncMock()
+
+    pult_id, album_ids = await _render_review_message(
+        bot, chat_id=-100, post_text="hello", image_urls=[], keyboard=_kb()
+    )
+
+    assert pult_id == 2001
+    assert album_ids is None
+    bot.send_message.assert_awaited_once()
+    bot.send_photo.assert_not_awaited()
+    bot.send_media_group.assert_not_awaited()
+
+
+async def test_render_single_mode_one_image():
+    bot = SimpleNamespace()
+    bot.send_message = AsyncMock()
+    bot.send_photo = AsyncMock(return_value=SimpleNamespace(message_id=2002))
+    bot.send_media_group = AsyncMock()
+
+    pult_id, album_ids = await _render_review_message(
+        bot, chat_id=-100, post_text="hello", image_urls=["https://x/a.jpg"], keyboard=_kb()
+    )
+
+    assert pult_id == 2002
+    assert album_ids is None
+    bot.send_photo.assert_awaited_once()
+    # parse_mode must be None to preserve entities past the bot's default HTML mode
+    kwargs = bot.send_photo.await_args.kwargs
+    assert kwargs.get("parse_mode") is None
+    bot.send_message.assert_not_awaited()
+    bot.send_media_group.assert_not_awaited()
+
+
+async def test_render_album_mode_two_or_more_images():
+    bot = SimpleNamespace()
+    album_msgs = [SimpleNamespace(message_id=3001), SimpleNamespace(message_id=3002)]
+    bot.send_media_group = AsyncMock(return_value=album_msgs)
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=3003))
+    bot.send_photo = AsyncMock()
+
+    pult_id, album_ids = await _render_review_message(
+        bot,
+        chat_id=-100,
+        post_text="hello",
+        image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+        keyboard=_kb(),
+    )
+
+    assert pult_id == 3003
+    assert album_ids == [3001, 3002]
+    bot.send_media_group.assert_awaited_once()
+    # pult must reply to the first album photo so Telegram visually groups them
+    pult_kwargs = bot.send_message.await_args.kwargs
+    assert pult_kwargs.get("reply_to_message_id") == 3001
+    assert pult_kwargs.get("parse_mode") is None
+    bot.send_photo.assert_not_awaited()
+
+
+async def test_render_single_mode_long_text_falls_back_to_text_message():
+    """Existing behaviour: if caption > 1024 chars, image is dropped (text-only msg)."""
+    bot = SimpleNamespace()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=4001))
+    bot.send_photo = AsyncMock()
+    bot.send_media_group = AsyncMock()
+
+    long_text = "x" * 1100
+    pult_id, album_ids = await _render_review_message(
+        bot, chat_id=-100, post_text=long_text, image_urls=["https://x/a.jpg"], keyboard=_kb()
+    )
+
+    assert pult_id == 4001
+    assert album_ids is None
+    bot.send_message.assert_awaited_once()
+    bot.send_photo.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_review_render_modes.py -v`
+Expected: FAIL with `ImportError: cannot import name '_render_review_message'`.
+
+- [ ] **Step 3: Implement `_render_review_message`**
+
+In `app/channel/review/telegram_io.py`, replace the existing `_send_review_message` function (currently lines ~173-208) with the new helper plus a thin back-compat wrapper. Put this in place of the existing `_send_review_message` body; keep `_edit_review_message` untouched below it.
+
+```python
+async def _render_review_message(
+    bot: Bot,
+    chat_id: int | str,
+    post_text: str,
+    image_urls: list[str] | None,
+    keyboard: InlineKeyboardMarkup,
+) -> tuple[int, list[int] | None]:
+    """Send a review message in the right mode based on image count.
+
+    Returns (pult_message_id, album_message_ids | None).
+    - 0 images → text message (pult = that message; album = None)
+    - 1 image, caption ≤ 1024 → photo with caption (pult = that photo; album = None)
+    - 1 image, caption > 1024 → text-only fallback (image dropped; pult = text msg)
+    - 2+ images → media group + separate pult text message as reply to first photo
+
+    parse_mode=None is required everywhere to preserve entities past the bot's
+    default HTML mode.
+    """
+    plain, entities = md_to_entities(post_text)
+    urls = list(image_urls or [])
+
+    if len(urls) >= 2:
+        media = [URLInputFile(u) for u in urls[:10]]
+        input_media = [InputMediaPhoto(media=p) for p in media]
+        try:
+            photos = await bot.send_media_group(chat_id=chat_id, media=input_media)
+        except Exception:
+            logger.exception("review_album_send_failed_fallback_to_single")
+            photos = []
+
+        if photos:
+            pult_msg = await bot.send_message(
+                chat_id=chat_id,
+                text=plain,
+                entities=entities,
+                reply_markup=keyboard,
+                reply_to_message_id=photos[0].message_id,
+                disable_web_page_preview=True,
+                parse_mode=None,
+            )
+            return pult_msg.message_id, [m.message_id for m in photos]
+
+        # album failed — fall through to single-image path using the first url
+
+    first_url = urls[0] if urls else None
+    if first_url and len(plain) <= 1024:
+        try:
+            photo = URLInputFile(first_url)
+            msg = await bot.send_photo(
+                chat_id=chat_id,
+                photo=photo,
+                caption=plain,
+                caption_entities=entities,
+                reply_markup=keyboard,
+                parse_mode=None,
+            )
+            return msg.message_id, None
+        except Exception:
+            logger.exception("review_photo_failed_fallback_to_text")
+
+    msg = await bot.send_message(
+        chat_id=chat_id,
+        text=plain,
+        entities=entities,
+        reply_markup=keyboard,
+        disable_web_page_preview=True,
+        parse_mode=None,
+    )
+    return msg.message_id, None
+
+
+async def _send_review_message(
+    bot: Bot,
+    chat_id: int | str,
+    text: str,
+    keyboard: InlineKeyboardMarkup,
+    image_url: str | None = None,
+) -> Message:
+    """Back-compat wrapper that returns the pult Message only.
+
+    Callers that still use this helper get single-message semantics (they cannot
+    support album mode — they get the old behaviour). New code should use
+    `_render_review_message` directly.
+    """
+    image_urls = [image_url] if image_url else []
+    pult_id, _ = await _render_review_message(bot, chat_id, text, image_urls, keyboard)
+    # Synthesise a minimal Message-like object; callers only use .message_id.
+    return type("_StubMsg", (), {"message_id": pult_id})()  # type: ignore[return-value]
+```
+
+At the top of the file, add the needed import near `URLInputFile`:
+
+```python
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, InputMediaPhoto, Message, URLInputFile
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_review_render_modes.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Check the whole existing test suite still passes**
+
+Run: `uv run -m pytest tests/unit tests/e2e -x -q`
+Expected: PASS. The `_send_review_message` back-compat wrapper keeps existing call sites working.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/channel/review/telegram_io.py tests/unit/test_review_render_modes.py
+git commit -m "feat(review): add _render_review_message with text/single/album modes"
+```
+
+---
+
+## Task 4: Wire `send_for_review` to persist album ids
+
+**Files:**
+- Modify: `app/channel/review/telegram_io.py:251-311` (`send_for_review`)
+- Test: `tests/unit/test_send_for_review_album.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_send_for_review_album.py`:
+
+```python
+"""send_for_review persists review_album_message_ids for 2+ image posts."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from app.channel.generator import GeneratedPost
+from app.channel.review.telegram_io import send_for_review
+from app.db.models import ChannelPost
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Item:
+    def __init__(self, title: str, url: str) -> None:
+        self.title = title
+        self.url = url
+        self.body = "b"
+        self.source_url = url
+        self.external_id = url
+        self.summary = "s"
+
+
+async def _bot_with_album(album_ids: list[int], pult_id: int):
+    bot = SimpleNamespace()
+    bot.send_media_group = AsyncMock(
+        return_value=[SimpleNamespace(message_id=mid) for mid in album_ids]
+    )
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=pult_id))
+    bot.send_photo = AsyncMock()
+    return bot
+
+
+async def test_album_message_ids_persisted_when_two_images(session_maker):
+    bot = await _bot_with_album(album_ids=[5001, 5002], pult_id=5003)
+    post = GeneratedPost(
+        text="Body\n\n——\n🔗 **Konnekt**",
+        image_url="https://x/a.jpg",
+        image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+    )
+    items = [_Item("News", "https://src/1")]
+
+    post_id = await send_for_review(
+        bot,
+        review_chat_id=-100,
+        channel_id=-100,
+        post=post,
+        source_items=items,
+        session_maker=session_maker,
+    )
+    assert post_id is not None
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one()
+        assert row.review_message_id == 5003
+        assert row.review_album_message_ids == [5001, 5002]
+
+
+async def test_album_message_ids_is_none_when_single_image(session_maker):
+    bot = SimpleNamespace()
+    bot.send_photo = AsyncMock(return_value=SimpleNamespace(message_id=6001))
+    bot.send_message = AsyncMock()
+    bot.send_media_group = AsyncMock()
+    post = GeneratedPost(
+        text="Body\n\n——\n🔗 **Konnekt**",
+        image_url="https://x/a.jpg",
+        image_urls=["https://x/a.jpg"],
+    )
+    items = [_Item("News", "https://src/1")]
+
+    post_id = await send_for_review(
+        bot,
+        review_chat_id=-100,
+        channel_id=-100,
+        post=post,
+        source_items=items,
+        session_maker=session_maker,
+    )
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one()
+        assert row.review_message_id == 6001
+        assert row.review_album_message_ids is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_send_for_review_album.py -v`
+Expected: FAIL — `review_album_message_ids` is currently never set.
+
+- [ ] **Step 3: Update `send_for_review`**
+
+In `app/channel/review/telegram_io.py`, in `send_for_review` (around lines 251-311), replace the `_send_review_message` call and DB update block with a `_render_review_message` call that captures both ids:
+
+```python
+            msg_pult_id, msg_album_ids = await _render_review_message(
+                bot, review_chat_id, post.text, post.image_urls or ([post.image_url] if post.image_url else []), keyboard
+            )
+            db_post.review_message_id = msg_pult_id
+            db_post.review_album_message_ids = msg_album_ids
+            await session.commit()
+            logger.info(
+                "review_sent",
+                post_id=post_id,
+                review_msg=msg_pult_id,
+                album=len(msg_album_ids) if msg_album_ids else 0,
+            )
+            return post_id
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_send_for_review_album.py tests/e2e/test_channel_review.py -v`
+Expected: PASS — both new tests and existing e2e review tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/review/telegram_io.py tests/unit/test_send_for_review_album.py
+git commit -m "feat(review): persist album message ids in send_for_review"
+```
+
+---
+
+## Task 5: `_rebuild_review_message` — new-first-then-delete
+
+**Files:**
+- Modify: `app/channel/review/telegram_io.py` (add new helper, near `_render_review_message`)
+- Test: `tests/unit/test_review_rebuild.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_review_rebuild.py`:
+
+```python
+"""Unit tests for _rebuild_review_message: new-first-then-delete semantics."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from app.channel.review.telegram_io import _rebuild_review_message
+from app.core.enums import PostStatus
+from app.db.models import ChannelPost
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+def _kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[[InlineKeyboardButton(text="ok", callback_data="x")]])
+
+
+async def _make_post(
+    session_maker,
+    *,
+    review_message_id: int | None,
+    album_ids: list[int] | None,
+    image_urls: list[str] | None,
+) -> int:
+    async with session_maker() as s:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="x",
+            title="t",
+            post_text="Body",
+            status=PostStatus.DRAFT,
+            review_message_id=review_message_id,
+            review_album_message_ids=album_ids,
+            image_urls=image_urls,
+        )
+        s.add(p)
+        await s.commit()
+        await s.refresh(p)
+        return p.id
+
+
+async def test_rebuild_album_to_album_commits_new_then_deletes_old(session_maker):
+    """Happy path: post has 2 images, rebuild sends new album+pult, commits, then deletes old."""
+    pid = await _make_post(
+        session_maker,
+        review_message_id=100,
+        album_ids=[200, 201],
+        image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+    )
+
+    call_order: list[str] = []
+    deleted_ids_capture: list[int] = []
+
+    bot = SimpleNamespace()
+
+    async def fake_send_media_group(**kwargs):
+        call_order.append("send_media_group")
+        return [SimpleNamespace(message_id=300), SimpleNamespace(message_id=301)]
+
+    async def fake_send_message(**kwargs):
+        call_order.append("send_message")
+        return SimpleNamespace(message_id=302)
+
+    async def fake_delete_messages(**kwargs):
+        call_order.append("delete_messages")
+        deleted_ids_capture.extend(kwargs["message_ids"])
+
+    bot.send_media_group = fake_send_media_group
+    bot.send_message = fake_send_message
+    bot.send_photo = AsyncMock()
+    bot.delete_messages = fake_delete_messages
+
+    await _rebuild_review_message(bot, -100, pid, session_maker, _kb())
+
+    # New messages went out before the old ones were deleted.
+    assert call_order == ["send_media_group", "send_message", "delete_messages"]
+    # Original pult + album — order may vary, compare as a set.
+    assert set(deleted_ids_capture) == {100, 200, 201}
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+        assert row.review_message_id == 302
+        assert row.review_album_message_ids == [300, 301]
+
+
+async def test_rebuild_single_to_album_deletes_old_single(session_maker):
+    """Post had 1 image, reviewer added another → rebuild flips to album, deletes old single."""
+    pid = await _make_post(
+        session_maker,
+        review_message_id=500,
+        album_ids=None,
+        image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+    )
+
+    deleted_ids: list[int] = []
+    bot = SimpleNamespace()
+    bot.send_media_group = AsyncMock(
+        return_value=[SimpleNamespace(message_id=600), SimpleNamespace(message_id=601)]
+    )
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=602))
+    bot.send_photo = AsyncMock()
+
+    async def fake_delete_messages(**kwargs):
+        deleted_ids.extend(kwargs["message_ids"])
+
+    bot.delete_messages = fake_delete_messages
+
+    await _rebuild_review_message(bot, -100, pid, session_maker, _kb())
+
+    assert deleted_ids == [500]  # only the old single pult
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+        assert row.review_message_id == 602
+        assert row.review_album_message_ids == [600, 601]
+
+
+async def test_rebuild_swallows_delete_errors(session_maker):
+    """If delete_messages raises, DB was already committed — rebuild must not bubble the error."""
+    pid = await _make_post(
+        session_maker,
+        review_message_id=700,
+        album_ids=[701, 702],
+        image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+    )
+
+    bot = SimpleNamespace()
+    bot.send_media_group = AsyncMock(
+        return_value=[SimpleNamespace(message_id=800), SimpleNamespace(message_id=801)]
+    )
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=802))
+    bot.send_photo = AsyncMock()
+
+    async def failing_delete(**kwargs):
+        raise RuntimeError("too old")
+
+    bot.delete_messages = failing_delete
+
+    # Must not raise
+    await _rebuild_review_message(bot, -100, pid, session_maker, _kb())
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+        assert row.review_message_id == 802
+        assert row.review_album_message_ids == [800, 801]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_review_rebuild.py -v`
+Expected: FAIL with `ImportError: cannot import name '_rebuild_review_message'`.
+
+- [ ] **Step 3: Implement `_rebuild_review_message`**
+
+In `app/channel/review/telegram_io.py`, add this function right after `_render_review_message`:
+
+```python
+async def _rebuild_review_message(
+    bot: Bot,
+    chat_id: int | str,
+    post_id: int,
+    session_maker: async_sessionmaker[AsyncSession],
+    keyboard: InlineKeyboardMarkup,
+) -> None:
+    """Rebuild the review message for ``post_id``: new-first-then-delete.
+
+    1. Fetch current post + old (pult_id, album_ids) from DB.
+    2. Call ``_render_review_message`` with the post's current text/images.
+    3. Commit the new ids to DB (callbacks on the new pult work immediately).
+    4. Best-effort delete all old messages. Delete failures are logged, not raised.
+
+    No-op when the post has no existing ``review_message_id``.
+    """
+    from sqlalchemy import select
+
+    from app.db.models import ChannelPost
+
+    async with session_maker() as session:
+        r = await session.execute(select(ChannelPost).where(ChannelPost.id == post_id))
+        post = r.scalar_one_or_none()
+        if post is None or not post.review_message_id:
+            return
+        old_ids: list[int] = [post.review_message_id]
+        old_ids.extend(post.review_album_message_ids or [])
+        post_text = post.post_text
+        image_urls = list(post.image_urls or [])
+
+    new_pult_id, new_album_ids = await _render_review_message(
+        bot, chat_id, post_text, image_urls, keyboard
+    )
+
+    async with session_maker() as session:
+        r = await session.execute(select(ChannelPost).where(ChannelPost.id == post_id))
+        post = r.scalar_one_or_none()
+        if post is not None:
+            post.review_message_id = new_pult_id
+            post.review_album_message_ids = new_album_ids
+            await session.commit()
+
+    try:
+        await bot.delete_messages(chat_id=chat_id, message_ids=old_ids)
+    except Exception:
+        logger.warning("review_rebuild_delete_failed", post_id=post_id, old_ids=old_ids, exc_info=True)
+```
+
+If `async_sessionmaker` / `AsyncSession` aren't already imported in the runtime block (only `TYPE_CHECKING`), the import inside the function is fine.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_review_rebuild.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/review/telegram_io.py tests/unit/test_review_rebuild.py
+git commit -m "feat(review): _rebuild_review_message with new-first-then-delete semantics"
+```
+
+---
+
+## Task 6: Route agent image tools through `_rebuild_review_message`
+
+**Files:**
+- Modify: `app/channel/review/agent.py:460-605` (`_refresh_review_message` and `_refresh_after_change`)
+- Test: `tests/unit/test_image_tool_rebuild_wiring.py`
+
+The agent currently has its own `_refresh_review_message` helper that does a per-single-image delete-and-resend. Replace it with a call to the new `_rebuild_review_message` from `telegram_io.py`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_image_tool_rebuild_wiring.py`:
+
+```python
+"""The agent's _refresh_review_message helper delegates to telegram_io._rebuild_review_message.
+
+We don't test via the PydanticAI toolset registry (internals change too often);
+we test the seam by reaching into the `create_review_agent` factory's closure —
+it binds `_refresh_after_change` as a nested function. That's brittle too, so
+instead we verify the agent module imports and calls `_rebuild_review_message`
+from telegram_io, and route through the public `review_agent_turn` in a later
+e2e test (Task 9 covers the end-to-end behaviour).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_agent_module_uses_telegram_io_rebuild():
+    """Lexical check: agent.py imports and references _rebuild_review_message."""
+    import app.channel.review.agent as agent_mod
+    import inspect
+
+    src = inspect.getsource(agent_mod)
+    assert "_rebuild_review_message" in src, (
+        "agent.py should route image-tool refresh through telegram_io._rebuild_review_message"
+    )
+    # The old per-message delete-and-single-send path must be gone.
+    assert "bot.delete_message(chat_id=review_chat_id, message_id=post.review_message_id)" not in src, (
+        "agent.py should no longer open-code single-message delete-and-resend; "
+        "that logic lives in telegram_io._rebuild_review_message now."
+    )
+```
+
+This is a lightweight regression-guard test. Task 9 (e2e) covers the full runtime behaviour end-to-end.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run -m pytest tests/unit/test_image_tool_rebuild_wiring.py -v`
+Expected: FAIL — `_rebuild_review_message` is never called from agent.py today.
+
+- [ ] **Step 3: Replace `_refresh_review_message` in agent.py**
+
+In `app/channel/review/agent.py`, replace the whole `_refresh_review_message` function (currently lines ~460-517) with a thin delegator, and update `_refresh_after_change` (currently lines ~594-604) to call it.
+
+```python
+    async def _refresh_review_message(ctx: RunContext[ReviewAgentDeps], post: Any) -> str | None:
+        """Delegate to the telegram_io rebuild helper.
+
+        The ``post`` argument is unused — the helper re-fetches from DB to avoid
+        stale state. Kept for API compatibility with earlier callers.
+        """
+        del post
+        from app.channel.review.telegram_io import _rebuild_review_message, build_review_keyboard
+
+        try:
+            # Re-fetch to build a fresh keyboard (source items may have changed).
+            from sqlalchemy import select as _select
+            from app.db.models import ChannelPost
+
+            async with ctx.deps.session_maker() as session:
+                r = await session.execute(_select(ChannelPost).where(ChannelPost.id == ctx.deps.post_id))
+                fresh_post = r.scalar_one_or_none()
+
+            if fresh_post is None:
+                return "Warning: post not found during refresh."
+
+            from app.channel.review.service import extract_source_btn_data
+
+            keyboard = build_review_keyboard(
+                ctx.deps.post_id,
+                source_items=extract_source_btn_data(fresh_post),
+                channel_name=ctx.deps.channel_name,
+                channel_username=ctx.deps.channel_username,
+            )
+            await _rebuild_review_message(
+                ctx.deps.bot,
+                ctx.deps.review_chat_id,
+                ctx.deps.post_id,
+                ctx.deps.session_maker,
+                keyboard,
+            )
+
+            # Register the new pult in the reply chain (post.review_message_id now updated)
+            async with ctx.deps.session_maker() as session:
+                r = await session.execute(_select(ChannelPost).where(ChannelPost.id == ctx.deps.post_id))
+                refreshed = r.scalar_one_or_none()
+            if refreshed and refreshed.review_message_id:
+                register_message(refreshed.review_message_id, ctx.deps.post_id)
+                await persist_message_to_db(
+                    ctx.deps.session_maker, ctx.deps.post_id, refreshed.review_message_id
+                )
+
+            return None
+        except Exception:
+            logger.exception("review_message_refresh_failed", post_id=ctx.deps.post_id)
+            return "Warning: review message could not be refreshed."
+
+    async def _refresh_after_change(ctx: RunContext[ReviewAgentDeps]) -> None:
+        """Re-fetch the post and rebuild the review message."""
+        await _refresh_review_message(ctx, None)
+```
+
+Drop the no-longer-needed imports at the top of the old `_refresh_review_message` (`_send_review_message`, `extract_source_btn_data`) — the delegator fetches them lazily.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_image_tool_rebuild_wiring.py tests/unit/test_review_agent.py tests/e2e/test_channel_review.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/review/agent.py tests/unit/test_image_tool_rebuild_wiring.py
+git commit -m "refactor(review): route image tool refresh through _rebuild_review_message"
+```
+
+---
+
+## Task 7: `handle_regen` triggers a full rebuild
+
+**Files:**
+- Modify: `app/channel/review/telegram_io.py:411-457` (`handle_regen`)
+- Test: `tests/unit/test_handle_regen_rebuild.py`
+
+Regen may change both text **and** images (image pipeline runs again inside `regen_post_text`). The existing `handle_regen` only edits the pult caption — broken for album. Route it through `_rebuild_review_message`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_handle_regen_rebuild.py`:
+
+```python
+"""handle_regen rebuilds the review message when images changed."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from app.channel.review.telegram_io import handle_regen
+from app.core.enums import PostStatus
+from app.db.models import ChannelPost
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_post(session_maker) -> int:
+    async with session_maker() as s:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="x",
+            title="t",
+            post_text="Body",
+            status=PostStatus.DRAFT,
+            image_urls=["https://x/a.jpg"],
+            review_message_id=1000,
+            review_album_message_ids=None,
+            source_items=[{"title": "t", "url": "https://src", "source_url": "https://src", "external_id": "x"}],
+        )
+        s.add(p)
+        await s.commit()
+        await s.refresh(p)
+        return p.id
+
+
+async def test_handle_regen_always_calls_rebuild(session_maker):
+    pid = await _make_post(session_maker)
+
+    # Stub out regen_post_text to return an "updated" post (same DB row).
+    async def fake_regen_post_text(post_id, api_key, model, language, session_maker, *, footer):
+        async with session_maker() as s:
+            r = await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))
+            post = r.scalar_one_or_none()
+            if post:
+                post.image_urls = ["https://x/a.jpg", "https://x/new.jpg"]
+                await s.commit()
+                await s.refresh(post)
+            return "Post regenerated.", post
+
+    with (
+        patch("app.channel.review.telegram_io.regen_post_text", side_effect=fake_regen_post_text),
+        patch("app.channel.review.telegram_io._rebuild_review_message", new=AsyncMock()) as rebuild,
+    ):
+        bot = SimpleNamespace()
+        status = await handle_regen(
+            bot,
+            post_id=pid,
+            api_key="k",
+            model="m",
+            language="Russian",
+            review_chat_id=-100,
+            session_maker=session_maker,
+            footer="— Konnekt",
+        )
+        assert "regenerated" in status.lower()
+        rebuild.assert_awaited_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run -m pytest tests/unit/test_handle_regen_rebuild.py -v`
+Expected: FAIL — `handle_regen` currently calls `_edit_review_message`, not `_rebuild_review_message`.
+
+- [ ] **Step 3: Rewrite `handle_regen`**
+
+In `app/channel/review/telegram_io.py`, replace the body of `handle_regen` (currently lines ~411-456) with:
+
+```python
+async def handle_regen(
+    bot: Bot,
+    post_id: int,
+    api_key: str,
+    model: str,
+    language: str,
+    review_chat_id: int | str,
+    session_maker: async_sessionmaker[AsyncSession],
+    *,
+    footer: str = "",
+    channel_name: str = "",
+    channel_username: str | None = None,
+) -> str:
+    """Regenerate a post from its original sources. Always rebuilds the review message."""
+    status_msg, updated_post = await regen_post_text(
+        post_id=post_id,
+        api_key=api_key,
+        model=model,
+        language=language,
+        session_maker=session_maker,
+        footer=footer,
+    )
+
+    if updated_post and updated_post.review_message_id:
+        source_btn_data = extract_source_btn_data(updated_post)
+        keyboard = build_review_keyboard(
+            post_id,
+            source_items=source_btn_data,
+            channel_name=channel_name,
+            channel_username=channel_username,
+        )
+        try:
+            await _rebuild_review_message(bot, review_chat_id, post_id, session_maker, keyboard)
+        except Exception:
+            logger.exception("review_regen_rebuild_error")
+
+    return status_msg
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_handle_regen_rebuild.py tests/e2e/test_channel_review.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/review/telegram_io.py tests/unit/test_handle_regen_rebuild.py
+git commit -m "feat(review): handle_regen triggers full rebuild (text + images)"
+```
+
+---
+
+## Task 8: `handle_delete` cleans album messages
+
+**Files:**
+- Modify: `app/channel/review/telegram_io.py:339-356` (`handle_delete`)
+- Test: `tests/unit/test_handle_delete_album.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_handle_delete_album.py`:
+
+```python
+"""handle_delete deletes pult AND album photos when present."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from app.channel.review.telegram_io import handle_delete
+from app.core.enums import PostStatus
+from app.db.models import ChannelPost
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_post(session_maker, *, review_mid: int, album_ids: list[int] | None) -> int:
+    async with session_maker() as s:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="x",
+            title="t",
+            post_text="b",
+            status=PostStatus.DRAFT,
+            review_message_id=review_mid,
+            review_album_message_ids=album_ids,
+        )
+        s.add(p)
+        await s.commit()
+        await s.refresh(p)
+        return p.id
+
+
+async def test_delete_removes_album_plus_pult(session_maker):
+    pid = await _make_post(session_maker, review_mid=100, album_ids=[101, 102, 103])
+    deleted: list[int] = []
+
+    bot = SimpleNamespace()
+
+    async def fake_delete_messages(**kwargs):
+        deleted.extend(kwargs["message_ids"])
+
+    async def fake_delete_message(**kwargs):
+        deleted.append(kwargs["message_id"])
+
+    bot.delete_messages = fake_delete_messages
+    bot.delete_message = fake_delete_message
+
+    await handle_delete(bot, pid, -100, 100, session_maker)
+    assert set(deleted) == {100, 101, 102, 103}
+
+
+async def test_delete_with_no_album_still_deletes_pult(session_maker):
+    pid = await _make_post(session_maker, review_mid=200, album_ids=None)
+    deleted: list[int] = []
+
+    bot = SimpleNamespace()
+
+    async def fake_delete_message(**kwargs):
+        deleted.append(kwargs["message_id"])
+
+    async def fake_delete_messages(**kwargs):
+        deleted.extend(kwargs["message_ids"])
+
+    bot.delete_message = fake_delete_message
+    bot.delete_messages = fake_delete_messages
+
+    await handle_delete(bot, pid, -100, 200, session_maker)
+    assert deleted == [200]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_handle_delete_album.py -v`
+Expected: FAIL — first test fails because only pult is deleted today.
+
+- [ ] **Step 3: Update `handle_delete`**
+
+In `app/channel/review/telegram_io.py`, replace `handle_delete` (currently lines ~339-356) with:
+
+```python
+async def handle_delete(
+    bot: Bot,
+    post_id: int,
+    review_chat_id: int | str,
+    review_message_id: int | None,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> str:
+    """Skip a post (soft-delete) and remove the review messages from chat."""
+    from sqlalchemy import select
+
+    from app.db.models import ChannelPost
+
+    album_ids: list[int] = []
+    async with session_maker() as session:
+        r = await session.execute(select(ChannelPost).where(ChannelPost.id == post_id))
+        post = r.scalar_one_or_none()
+        if post and post.review_album_message_ids:
+            album_ids = list(post.review_album_message_ids)
+
+    status_msg, skipped_post = await delete_post(post_id, session_maker)
+
+    if skipped_post:
+        # Delete album photos in bulk (best-effort).
+        if album_ids:
+            try:
+                await bot.delete_messages(chat_id=review_chat_id, message_ids=album_ids)
+            except Exception:
+                logger.warning("review_album_delete_failed", post_id=post_id, exc_info=True)
+        # Delete pult.
+        if review_message_id:
+            try:
+                await bot.delete_message(chat_id=review_chat_id, message_id=review_message_id)
+            except Exception:
+                logger.warning("review_message_delete_failed", post_id=post_id, exc_info=True)
+
+    return status_msg
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_handle_delete_album.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/review/telegram_io.py tests/unit/test_handle_delete_album.py
+git commit -m "feat(review): handle_delete removes album photos too"
+```
+
+---
+
+## Task 9: End-to-end smoke test — full album review flow
+
+**Files:**
+- Create: `tests/e2e/test_review_album_e2e.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/e2e/test_review_album_e2e.py`:
+
+```python
+"""Full review-flow smoke test: album send → approve chain via FakeTelegramServer."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from aiogram import Bot
+from aiogram.client.session.aiohttp import AiohttpSession
+from aiogram.client.telegram import TelegramAPIServer
+from app.channel.generator import GeneratedPost
+from app.channel.review.telegram_io import send_for_review, handle_delete
+from app.db.models import ChannelPost
+from sqlalchemy import select
+
+from tests.fake_telegram import FakeTelegramServer
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Item:
+    def __init__(self, title: str, url: str) -> None:
+        self.title = title
+        self.url = url
+        self.body = "b"
+        self.source_url = url
+        self.external_id = url
+        self.summary = "s"
+
+
+async def _make_bot(server: FakeTelegramServer) -> Bot:
+    return Bot(
+        token="123:fake",
+        session=AiohttpSession(api=TelegramAPIServer.from_base(server.base_url)),
+    )
+
+
+async def test_send_album_for_review_produces_media_group_plus_pult(session_maker, fake_tg):
+    bot = await _make_bot(fake_tg)
+    try:
+        post = GeneratedPost(
+            text="Body text\n\n——\n🔗 **Konnekt**",
+            image_url="https://x/a.jpg",
+            image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+        )
+        post_id = await send_for_review(
+            bot,
+            review_chat_id=-100,
+            channel_id=-100,
+            post=post,
+            source_items=[_Item("News", "https://src/1")],
+            session_maker=session_maker,
+        )
+        assert post_id is not None
+    finally:
+        await bot.session.close()
+
+    mg_calls = fake_tg.get_calls("sendMediaGroup")
+    msg_calls = fake_tg.get_calls("sendMessage")
+    assert len(mg_calls) == 1
+    assert len(msg_calls) == 1
+
+    mg_params = mg_calls[0].params
+    media_raw = mg_params.get("media", "[]")
+    media = json.loads(media_raw) if isinstance(media_raw, str) else media_raw
+    assert len(media) == 2
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one()
+        assert row.review_album_message_ids and len(row.review_album_message_ids) == 2
+        assert row.review_message_id
+
+
+async def test_delete_album_post_issues_bulk_delete(session_maker, fake_tg):
+    bot = await _make_bot(fake_tg)
+    try:
+        post = GeneratedPost(
+            text="Body\n\n——\n🔗 **Konnekt**",
+            image_url="https://x/a.jpg",
+            image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+        )
+        post_id = await send_for_review(
+            bot,
+            review_chat_id=-100,
+            channel_id=-100,
+            post=post,
+            source_items=[_Item("News", "https://src/1")],
+            session_maker=session_maker,
+        )
+        assert post_id is not None
+
+        async with session_maker() as s:
+            row = (await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one()
+            pult = row.review_message_id
+
+        fake_tg.reset()  # only observe the delete-path calls below
+
+        await handle_delete(bot, post_id, -100, pult, session_maker)
+    finally:
+        await bot.session.close()
+
+    # One bulk delete for the 2 album photos, plus one single delete for the pult.
+    assert len(fake_tg.get_calls("deleteMessages")) == 1
+    assert len(fake_tg.get_calls("deleteMessage")) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/e2e/test_review_album_e2e.py -v`
+Expected: PASS (2 tests). All wiring from Tasks 1–8 is in place.
+
+- [ ] **Step 3: Run the full test suite as a regression check**
+
+Run: `uv run -m pytest -q`
+Expected: all previously-passing tests still pass; new tests added by this plan pass.
+
+- [ ] **Step 4: Lint + typecheck**
+
+```bash
+uv run ruff check app tests && uv run ruff format --check app tests && uv run ty check app tests
+```
+Expected: no violations.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/test_review_album_e2e.py
+git commit -m "test(e2e): album review flow via FakeTelegramServer"
+```
+
+---
+
+## Final Step: Open the PR
+
+- [ ] **Push the branch and open a PR**
+
+```bash
+git push -u origin feat/review-album-ui
+gh pr create --title "feat(review): show full album during review (Sprint 1.5)" --body "$(cat <<'EOF'
+## Summary
+- Review flow now sends `send_media_group` + a separate pult text message for posts with 2+ images, so reviewers see every image the agent composed.
+- Image tool edits (`use_candidate`, `remove_image`, `reorder_images`, etc.) and `/regen` rebuild the review using new-first-then-delete to avoid dead-callback windows.
+- New nullable `ChannelPost.review_album_message_ids` JSON column tracks the album photo ids alongside the existing `review_message_id` (the pult).
+
+## Test plan
+- [ ] `uv run -m pytest tests/unit/test_channel_post_album_ids.py tests/unit/test_review_render_modes.py tests/unit/test_review_rebuild.py tests/unit/test_send_for_review_album.py tests/unit/test_handle_regen_rebuild.py tests/unit/test_handle_delete_album.py -v`
+- [ ] `uv run -m pytest tests/e2e/test_review_album_e2e.py tests/e2e/test_fake_tg_album_endpoints.py -v`
+- [ ] `uv run -m pytest -q` — full regression
+- [ ] Manual: publish a multi-image draft in the Konnekt Review group, verify both the album and the button pult render; use `use_candidate` / `remove_image` / `regen` and watch the review rebuild itself cleanly.
+
+Design spec: `docs/superpowers/specs/2026-04-17-review-album-ui-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-17-review-album-ui-design.md
+++ b/docs/superpowers/specs/2026-04-17-review-album-ui-design.md
@@ -1,0 +1,215 @@
+# Review Album UI Design
+
+**Date:** 2026-04-17
+**Status:** Draft
+**Sprint:** 1.5 (Sprint 1 follow-up)
+
+## Problem
+
+After Sprint 1 landed the multi-image pipeline, posts routinely carry 2–4 images in `ChannelPost.image_urls`. The channel **publisher** already sends these as a Telegram media group, but the **review flow** still only shows the **first** image (see `app/channel/review/telegram_io.py:187`). Reviewers cannot see what the agent actually composed until the post is published.
+
+This design replaces the review-message rendering with an "album + pult" presentation when a post has 2+ images, keeping the existing single-photo and text-only paths for smaller posts.
+
+## Goals
+
+- Reviewer sees **every** image a post carries, in the exact order the publisher will use.
+- Review buttons (Approve / Reject / Delete / Regen / etc.) stay fully functional regardless of image count.
+- Reviewer's granular image tools (`use_candidate`, `add_image_url`, `remove_image`, `reorder_images`, `find_and_add_image`, `clear_images`) refresh the visible album after mutation.
+
+## Non-goals
+
+- Longer-than-900-char posts. Generator cap remains 900; Telegram caption cap is 1024; the "caption too long → image lost" edge case does not trigger under existing rules.
+- In-place per-slot editing of media groups. We use a uniform **delete-and-resend** strategy when the album changes.
+- Carousel UI (◀ 1/3 ▶) — explicitly rejected in brainstorming.
+- A style-RAG or critic agent. Those are separate Sprint 2 tracks.
+
+## Architecture overview
+
+```
+┌────────────────────────────── Review chat ──────────────────────────────┐
+│                                                                          │
+│  [📷] [📷] [📷]        ← send_media_group (N photos, no captions)        │
+│  ────────────────                                                        │
+│  Post text...          ← send_message (text + entities + reply_markup)   │
+│  [✅ Approve] [⏰ Schedule] [❌ Reject] [🗑 Delete]                        │
+│  [✂️ Shorter] [📝 Longer] [🔄 Regen]                                      │
+│                                                                          │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+Rendering modes (decided by `len(image_urls)`):
+
+| Mode | Condition | Messages sent | Callback target |
+|---|---|---|---|
+| `text` | 0 images | 1 text msg (text + buttons) | The text msg |
+| `single` | 1 image | 1 photo msg (caption + buttons) | The photo msg |
+| `album` | ≥2 images | N photo msgs (no caption) + 1 **pult** text msg (reply to first photo, text + buttons) | The pult |
+
+`text` and `single` are existing behaviour and do not change. `album` is new.
+
+### Invariants
+
+- `ChannelPost.review_message_id` always points to the message that carries inline buttons (pult in `album` mode, the single msg in `text`/`single`).
+- `ChannelPost.review_album_message_ids` is **not null** iff mode is `album`. In that case it holds the photo message ids (in display order), **not** including the pult.
+- Callbacks are routed by `post_id` embedded in `callback_data` — the pult message id is only used for edits.
+
+## Data model
+
+### ORM
+
+`app/db/models.py` gains one column on `ChannelPost`:
+
+```python
+review_album_message_ids: Mapped[list[int] | None] = mapped_column(
+    JSON, nullable=True, default=None
+)
+```
+
+Precedent: `reply_chain_message_ids` (same line) is already `Mapped[list[int] | None]` over JSON. The same conventions apply:
+
+- Add `review_album_message_ids: list[int] | None = None` as an `__init__` kwarg with default `None`, and assign `self.review_album_message_ids = review_album_message_ids` inside `__init__`. Sprint 1 code review flagged missed `__init__` kwargs for new columns — this is now a permanent checklist item.
+
+### Migration
+
+New Alembic revision with `down_revision = <latest>`. Up adds the column; down drops it. No backfill: posts already in a terminal status are unaffected, and `DRAFT` posts without the column behave as non-album (falls back to existing `review_message_id` path).
+
+## Message lifecycle
+
+All send/edit/rebuild logic lives in `app/channel/review/telegram_io.py` behind two new private helpers:
+
+```python
+async def _render_review_message(
+    bot, chat_id, post_text, image_urls, keyboard
+) -> tuple[int, list[int] | None]:
+    """Send the review message in the right mode. Returns (pult_id, album_ids | None)."""
+
+async def _rebuild_review_message(
+    bot, chat_id, post, session_maker, keyboard
+) -> tuple[int, list[int] | None]:
+    """New-first-then-delete rebuild. Commits new ids before best-effort deleting old."""
+```
+
+### Send (primary)
+
+`send_for_review` calls `_render_review_message` once and persists the returned ids:
+
+- `album` mode: `bot.send_media_group(N InputMediaPhoto, no caption)` → `bot.send_message(text + entities + reply_markup, reply_to=media[0].message_id, parse_mode=None)`. Returns `(pult.id, [photo.id ...])`.
+- `single` mode: existing `send_photo(caption+buttons)` path. Returns `(photo.id, None)`.
+- `text` mode: existing `send_message(text+buttons)` path. Returns `(msg.id, None)`.
+
+### Text-only edit (`update_post`, shorter, longer)
+
+No change in behaviour. `_edit_review_message(pult_id, ...)` works identically whether pult is a photo-with-caption (single mode) or a plain text message (album mode). Album photos are never touched.
+
+### Image edit (`use_candidate`, `add_image_url`, `remove_image`, `reorder_images`, `find_and_add_image`, `clear_images`)
+
+After a successful mutation, the @agent.tool wrapper in `app/channel/review/agent.py` calls `_rebuild_review_message`:
+
+1. Call `_render_review_message` with the post's new state — this sends *new* messages first.
+2. Commit new `(pult_id, album_ids)` to DB (so callbacks on new pult work immediately).
+3. Best-effort `bot.delete_messages(chat_id, [old_pult_id, *old_album_ids])`. Log but ignore failures (messages >48h old, already deleted, etc.).
+
+This "new-first-then-delete" order means the worst visible failure is a few seconds of duplicate messages, never a dead-callback state.
+
+### Regen
+
+`regen_post_text` already recomputes text **and** re-runs the image pipeline. After a successful regen we **always** rebuild — simpler than diffing new vs old image sets, and regen is the heaviest operation anyway.
+
+### Approve / Reject / Delete
+
+- **Approve:** `publisher.publish_post` already handles `image_urls` as a media group. No changes.
+- **Delete:** `handle_delete` currently calls `bot.delete_message(review_message_id)`. Extend to `bot.delete_messages(chat_id, [pult_id, *album_ids])` when album_ids is non-null. Best-effort.
+- **Reject:** The review message stays in chat (status changes, button set rebuilt elsewhere). No album-specific work.
+
+## Code surface
+
+| File | Change | Est. LOC |
+|---|---|---|
+| `app/db/models.py` | +1 field `review_album_message_ids` (JSON nullable) | +3 |
+| `alembic/versions/<new>.py` | new migration | ~25 |
+| `app/channel/review/telegram_io.py` | new `_render_review_message`, `_rebuild_review_message`, `_delete_album` helpers; refactor `_send_review_message` into `_render`; `handle_delete` cleans album ids | +120 new, ~30 changed |
+| `app/channel/review/image_tools.py` | each `*_op` returns `(status: str, mutated: bool)` | +30 |
+| `app/channel/review/agent.py` | each @agent.tool wrapper calls `_rebuild_review_message` when `mutated` | +15 |
+| `app/channel/review/service.py` | `create_review_post` initialises `review_album_message_ids=None`; `regen_post_text` triggers rebuild via caller | +10 |
+
+### Design decision: where does the Telegram side-effect live?
+
+image_tools `*_op` functions are currently pure DB operations, testable without Telegram mocks. Adding a Telegram side-effect has two viable shapes:
+
+- **X (chosen):** `*_op` returns `(status, mutated)`. The agent @tool wrapper (which already has `bot` in deps) decides when to call `_rebuild_review_message`. Keeps image_tools Telegram-agnostic. Small duplication in 7 wrappers.
+- **Y (rejected):** inject a `rebuild_fn` callable into `ImageToolsDeps`. DRY-er but forces image_tools unit tests to mock the callback; blurs the layering.
+
+We take **X**. Duplication is minimal (one line per wrapper) and the layering is cleaner.
+
+## Testing
+
+### Unit
+
+- `tests/unit/test_channel_post_album_ids.py` — ORM round-trips `list[int]` and `None`.
+- `tests/unit/test_review_render_modes.py` — `_render_review_message` with mocked `Bot`:
+  - 0 images → `send_message` once.
+  - 1 image → `send_photo(caption+buttons)` once.
+  - 2 images → `send_media_group` once + `send_message` once, reply-to set correctly.
+- `tests/unit/test_review_rebuild.py` — `_rebuild_review_message`:
+  - Order: new send → DB commit → old delete.
+  - `delete_messages` raising does **not** roll back DB or bubble.
+- `tests/unit/test_image_tools_mutated_flag.py` — each of the 7 `*_op` returns `mutated=True` on success, `False` on invalid-input / wrong-status.
+
+### Integration (PG)
+
+- `tests/integration/test_review_album_migration_pg.py` — alembic `upgrade head` then `downgrade -1` on a clean DB.
+- `tests/integration/test_review_album_persistence_pg.py` — after rebuild, DB has new ids; old ids are gone from column.
+
+### E2E (`FakeTelegramServer`)
+
+**Pre-req:** the fake server at `tests/fake_telegram.py` does **not** currently route `sendMediaGroup` or `deleteMessages`. Add handlers that:
+
+- `POST /bot{token}/sendMediaGroup` — accepts `media` (JSON-encoded list of `InputMediaPhoto`), returns a list of minimal `Message` objects with distinct `message_id`s, records the call for assertions.
+- `POST /bot{token}/deleteMessages` — accepts `message_ids` (list of ints), records the call, returns `{ok: true, result: true}`.
+
+
+- `tests/e2e/test_review_album_send.py` — generate post with 2 images → `send_for_review` → fake server sees exactly one `sendMediaGroup` (2 photos, no captions) + one `sendMessage` (reply_to=first photo, has `reply_markup`).
+- `tests/e2e/test_review_album_image_tool_rebuild.py` — reviewer calls `remove_image` → fake server sees: 1× `sendMediaGroup` (1 photo now) OR `sendPhoto` (if mode flips to single), 1× `sendMessage` (new pult), 1× `deleteMessages` with old ids.
+- `tests/e2e/test_review_album_regen.py` — regen always triggers rebuild.
+- `tests/e2e/test_review_album_approve.py` — approve still publishes the full album via `publisher.publish_post`.
+
+### Out of scope for tests
+
+- Real Telegram API (only via `FakeTelegramServer`).
+- Image rendering / bytes — handled by Sprint 1 pipeline.
+
+## Error handling
+
+| Failure | Strategy |
+|---|---|
+| `send_media_group` raises (bad URL, rate limit) | Rebuild fails — don't update DB, return error status from tool. Existing review message remains valid. **No** fallback to single-photo mode (would desynchronise vs what publisher will do). Log and surface to reviewer. |
+| `send_message` (pult) fails after `send_media_group` succeeded | Rare (API hiccup). Log error. DB still has old pult; album photos are "orphaned" in chat. Reviewer sees duplicate photos plus old pult. Acceptable — rebuild can be retried via another tool call. |
+| `delete_messages` raises (too-old / already-deleted) | Best-effort. Log warning, swallow exception. New messages already committed. |
+| Migration `downgrade` on a DB with non-null `review_album_message_ids` | Column drop is destructive. That is fine — ids are ephemeral (review chat only). |
+
+## Rollout
+
+- Single PR off `feat/review-album-ui` branch → squash to `main`.
+- Order of changes inside the PR (for reviewer sanity):
+  1. Migration + model field
+  2. `_render_review_message` / `_rebuild_review_message` + renaming
+  3. `send_for_review` persists album ids
+  4. image_tools return `(status, mutated)`
+  5. agent wrappers call rebuild
+  6. `handle_delete` extends cleanup
+  7. Tests: unit → integration → e2e
+- No feature flag. Backwards-compat holds because the new column is nullable and mode is decided at render time from `len(image_urls)`.
+- Rollback: `alembic downgrade -1`. No data loss (column is ephemeral review-chat state).
+
+## Risk register
+
+- **`delete_messages` batch partial failure** — Telegram occasionally accepts a batch and leaves some messages undeleted. We treat the whole batch as best-effort. Acceptable.
+- **Media-group order drift** — if `send_media_group` returns messages in a different order than we sent, callbacks still work (they target pult), but our stored `album_message_ids` should match the returned order. Sort by `message_id` is **not** safe — Telegram guarantees the returned list matches request order, so we store `[m.message_id for m in messages]`.
+- **Pult reply-to becomes orphan on delete** — when we delete the first album photo, the pult's `reply_to_message_id` points to a dead id. Telegram shows "deleted message" hint. Cosmetic only; rebuild replaces pult anyway. Not worth fixing.
+- **Race: reviewer clicks a callback mid-rebuild** — the callback hits the old pult which is about to be deleted. The handler looks up the post by `post_id` (from `callback_data`), so it still resolves. Between new-send and delete-old, the old pult keyboard is still live. Acceptable.
+
+## Future work (explicitly deferred)
+
+- In-place `edit_message_media` when album size is unchanged (less chat noise).
+- Long-text posts with a separate pult even in single-image mode (requires generator changes).
+- Sprint 2: critic agent, style-RAG.

--- a/docs/superpowers/specs/2026-04-17-review-album-ui-design.md
+++ b/docs/superpowers/specs/2026-04-17-review-album-ui-design.md
@@ -101,15 +101,20 @@ async def _rebuild_review_message(
 
 No change in behaviour. `_edit_review_message(pult_id, ...)` works identically whether pult is a photo-with-caption (single mode) or a plain text message (album mode). Album photos are never touched.
 
-### Image edit (`use_candidate`, `add_image_url`, `remove_image`, `reorder_images`, `find_and_add_image`, `clear_images`)
+### Image edit (`use_candidate`, `add_image_url`, `remove_image`, `reorder_images`, `clear_images`)
 
-After a successful mutation, the @agent.tool wrapper in `app/channel/review/agent.py` calls `_rebuild_review_message`:
+The existing `_refresh_after_change` in `app/channel/review/agent.py` already calls `_refresh_review_message` after each image op. We upgrade `_refresh_review_message` (in `agent.py`) to use the new render helper and handle the album case:
 
-1. Call `_render_review_message` with the post's new state — this sends *new* messages first.
-2. Commit new `(pult_id, album_ids)` to DB (so callbacks on new pult work immediately).
-3. Best-effort `bot.delete_messages(chat_id, [old_pult_id, *old_album_ids])`. Log but ignore failures (messages >48h old, already deleted, etc.).
+1. Re-fetch the post from DB to get fresh `image_urls` and existing `review_message_id` / `review_album_message_ids`.
+2. Call `_render_review_message` with the new state — sends fresh messages first.
+3. Commit new `(pult_id, album_ids)` to DB (so callbacks on new pult work immediately).
+4. Best-effort `bot.delete_messages(chat_id, [old_pult_id, *old_album_ids])`. Log but ignore failures (messages >48h old, already deleted, etc.).
 
 This "new-first-then-delete" order means the worst visible failure is a few seconds of duplicate messages, never a dead-callback state.
+
+Note: `find_and_add_image` does **not** trigger a refresh — it adds to the candidate pool, not to the selected images. Existing behaviour preserved.
+
+`*_op` functions in `image_tools.py` keep their current `-> str` signature. The refresh call stays unconditional at the @tool-wrapper level: if the op returned an error ("invalid index"), refresh rebuilds the same visual state — cheap and idempotent. Not worth the signature-change scope.
 
 ### Regen
 
@@ -127,19 +132,14 @@ This "new-first-then-delete" order means the worst visible failure is a few seco
 |---|---|---|
 | `app/db/models.py` | +1 field `review_album_message_ids` (JSON nullable) | +3 |
 | `alembic/versions/<new>.py` | new migration | ~25 |
-| `app/channel/review/telegram_io.py` | new `_render_review_message`, `_rebuild_review_message`, `_delete_album` helpers; refactor `_send_review_message` into `_render`; `handle_delete` cleans album ids | +120 new, ~30 changed |
-| `app/channel/review/image_tools.py` | each `*_op` returns `(status: str, mutated: bool)` | +30 |
-| `app/channel/review/agent.py` | each @agent.tool wrapper calls `_rebuild_review_message` when `mutated` | +15 |
-| `app/channel/review/service.py` | `create_review_post` initialises `review_album_message_ids=None`; `regen_post_text` triggers rebuild via caller | +10 |
+| `app/channel/review/telegram_io.py` | new `_render_review_message`; `send_for_review` persists album ids; `handle_delete` cleans album ids; `handle_regen` always rebuilds | +90 new, ~40 changed |
+| `app/channel/review/agent.py` | `_refresh_review_message` upgraded: fetches album ids from DB, new-first-then-delete, calls `_render_review_message` | ~50 changed |
+| `app/channel/review/service.py` | `regen_post_text` returns the updated post with image_urls so the caller can rebuild | ~5 changed |
+| `tests/fake_telegram.py` | new `/sendMediaGroup` and `/deleteMessages` endpoints | +60 |
 
-### Design decision: where does the Telegram side-effect live?
+### Design decision: minimise blast radius
 
-image_tools `*_op` functions are currently pure DB operations, testable without Telegram mocks. Adding a Telegram side-effect has two viable shapes:
-
-- **X (chosen):** `*_op` returns `(status, mutated)`. The agent @tool wrapper (which already has `bot` in deps) decides when to call `_rebuild_review_message`. Keeps image_tools Telegram-agnostic. Small duplication in 7 wrappers.
-- **Y (rejected):** inject a `rebuild_fn` callable into `ImageToolsDeps`. DRY-er but forces image_tools unit tests to mock the callback; blurs the layering.
-
-We take **X**. Duplication is minimal (one line per wrapper) and the layering is cleaner.
+`agent.py` already owns the "refresh review message after an image op" call (`_refresh_after_change` → `_refresh_review_message`). We keep that seam. `image_tools.py` stays pure; its unit tests don't need to know about Telegram. The work of the rebuild moves *inside* `_refresh_review_message`, not up into the tool wrappers.
 
 ## Testing
 
@@ -153,7 +153,7 @@ We take **X**. Duplication is minimal (one line per wrapper) and the layering is
 - `tests/unit/test_review_rebuild.py` — `_rebuild_review_message`:
   - Order: new send → DB commit → old delete.
   - `delete_messages` raising does **not** roll back DB or bubble.
-- `tests/unit/test_image_tools_mutated_flag.py` — each of the 7 `*_op` returns `mutated=True` on success, `False` on invalid-input / wrong-status.
+- `tests/unit/test_review_refresh_album.py` — `_refresh_review_message` when post has album ids: fetches post, calls render helper, commits new ids, then best-effort deletes old.
 
 ### Integration (PG)
 

--- a/tests/e2e/test_fake_tg_album_endpoints.py
+++ b/tests/e2e/test_fake_tg_album_endpoints.py
@@ -1,0 +1,60 @@
+"""Smoke test: FakeTelegramServer handles sendMediaGroup and deleteMessages."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from aiogram import Bot
+from aiogram.client.session.aiohttp import AiohttpSession
+from aiogram.client.telegram import TelegramAPIServer
+from aiogram.types import InputMediaPhoto
+
+from tests.fake_telegram import FakeTelegramServer
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_send_media_group_returns_distinct_message_ids():
+    async with FakeTelegramServer() as server:
+        bot = Bot(
+            token="123:fake",
+            session=AiohttpSession(api=TelegramAPIServer.from_base(server.base_url)),
+        )
+        try:
+            media = [
+                InputMediaPhoto(media="https://example.com/a.jpg"),
+                InputMediaPhoto(media="https://example.com/b.jpg"),
+            ]
+            messages = await bot.send_media_group(chat_id=-100, media=media)
+        finally:
+            await bot.session.close()
+
+        assert len(messages) == 2
+        assert messages[0].message_id != messages[1].message_id
+
+        calls = server.get_calls("sendMediaGroup")
+        assert len(calls) == 1
+        media_param = calls[0].params.get("media")
+        # aiogram serialises media as JSON string in multipart form
+        parsed = json.loads(media_param) if isinstance(media_param, str) else media_param
+        assert len(parsed) == 2
+
+
+async def test_delete_messages_records_ids():
+    async with FakeTelegramServer() as server:
+        bot = Bot(
+            token="123:fake",
+            session=AiohttpSession(api=TelegramAPIServer.from_base(server.base_url)),
+        )
+        try:
+            ok = await bot.delete_messages(chat_id=-100, message_ids=[1001, 1002, 1003])
+        finally:
+            await bot.session.close()
+
+        assert ok is True
+        calls = server.get_calls("deleteMessages")
+        assert len(calls) == 1
+        ids_param = calls[0].params.get("message_ids")
+        parsed = json.loads(ids_param) if isinstance(ids_param, str) else ids_param
+        assert list(parsed) == [1001, 1002, 1003]

--- a/tests/e2e/test_review_album_e2e.py
+++ b/tests/e2e/test_review_album_e2e.py
@@ -1,0 +1,122 @@
+"""Full review-flow smoke test: album send → approve chain via FakeTelegramServer."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from aiogram import Bot
+from aiogram.client.session.aiohttp import AiohttpSession
+from aiogram.client.telegram import TelegramAPIServer
+from aiogram.types import URLInputFile
+from app.channel.generator import GeneratedPost
+from app.channel.review.telegram_io import handle_delete, send_for_review
+from app.db.models import ChannelPost
+from sqlalchemy import select
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from tests.fake_telegram import FakeTelegramServer
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _stub_urlinputfile_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """URLInputFile normally streams bytes from the URL; in tests the URLs are
+    unreachable (https://x/...), so we stub the read iterator with fake bytes so
+    aiogram can build the multipart body and reach FakeTelegramServer."""
+
+    async def _fake_read(self: URLInputFile, bot: Bot) -> AsyncGenerator[bytes, None]:
+        yield b"fake-image-bytes"
+
+    monkeypatch.setattr(URLInputFile, "read", _fake_read)
+
+
+class _Item:
+    def __init__(self, title: str, url: str) -> None:
+        self.title = title
+        self.url = url
+        self.body = "b"
+        self.source_url = url
+        self.external_id = url
+        self.summary = "s"
+
+
+async def _make_bot(server: FakeTelegramServer) -> Bot:
+    return Bot(
+        token="123:fake",
+        session=AiohttpSession(api=TelegramAPIServer.from_base(server.base_url)),
+    )
+
+
+async def test_send_album_for_review_produces_media_group_plus_pult(session_maker, fake_tg):
+    bot = await _make_bot(fake_tg)
+    try:
+        post = GeneratedPost(
+            text="Body text\n\n——\n🔗 **Konnekt**",
+            image_url="https://x/a.jpg",
+            image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+        )
+        post_id = await send_for_review(
+            bot,
+            review_chat_id=-100,
+            channel_id=-100,
+            post=post,
+            source_items=[_Item("News", "https://src/1")],  # ty: ignore[invalid-argument-type]
+            session_maker=session_maker,
+        )
+        assert post_id is not None
+    finally:
+        await bot.session.close()
+
+    mg_calls = fake_tg.get_calls("sendMediaGroup")
+    msg_calls = fake_tg.get_calls("sendMessage")
+    assert len(mg_calls) == 1
+    assert len(msg_calls) == 1
+
+    mg_params = mg_calls[0].params
+    media_raw = mg_params.get("media", "[]")
+    media = json.loads(media_raw) if isinstance(media_raw, str) else media_raw
+    assert len(media) == 2
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one()
+        assert row.review_album_message_ids is not None
+        assert len(row.review_album_message_ids) == 2
+        assert row.review_message_id
+
+
+async def test_delete_album_post_issues_bulk_delete(session_maker, fake_tg):
+    bot = await _make_bot(fake_tg)
+    try:
+        post = GeneratedPost(
+            text="Body\n\n——\n🔗 **Konnekt**",
+            image_url="https://x/a.jpg",
+            image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+        )
+        post_id = await send_for_review(
+            bot,
+            review_chat_id=-100,
+            channel_id=-100,
+            post=post,
+            source_items=[_Item("News", "https://src/1")],  # ty: ignore[invalid-argument-type]
+            session_maker=session_maker,
+        )
+        assert post_id is not None
+
+        async with session_maker() as s:
+            row = (await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one()
+            pult = row.review_message_id
+
+        fake_tg.reset()  # only observe the delete-path calls below
+
+        await handle_delete(bot, post_id, -100, pult, session_maker)
+    finally:
+        await bot.session.close()
+
+    # One bulk delete for the 2 album photos, plus one single delete for the pult.
+    assert len(fake_tg.get_calls("deleteMessages")) == 1
+    assert len(fake_tg.get_calls("deleteMessage")) == 1

--- a/tests/fake_telegram.py
+++ b/tests/fake_telegram.py
@@ -151,6 +151,42 @@ class FakeTelegramServer:
     def _handle_deleteMessage(self, params: dict[str, Any]) -> web.Response:
         return web.json_response({"ok": True, "result": True})
 
+    def _handle_sendMediaGroup(self, params: dict[str, Any]) -> web.Response:
+        """Return one minimal Message per item in the media list, with distinct ids."""
+        import json as _json
+
+        media_raw = params.get("media", "[]")
+        try:
+            media = _json.loads(media_raw) if isinstance(media_raw, str) else list(media_raw)
+        except Exception:
+            media = []
+        chat_id = int(params.get("chat_id", 0))
+        messages: list[dict[str, Any]] = []
+        for _ in media:
+            self._message_id_counter += 1
+            messages.append(
+                {
+                    "message_id": self._message_id_counter,
+                    "from": {"id": 5145935834, "is_bot": True, "first_name": "Test Bot"},
+                    "chat": {"id": chat_id, "type": "supergroup", "title": "Test Chat"},
+                    "date": 1700000000,
+                    "photo": [
+                        {
+                            "file_id": f"photo-{self._message_id_counter}",
+                            "file_unique_id": f"u-{self._message_id_counter}",
+                            "width": 800,
+                            "height": 600,
+                            "file_size": 1024,
+                        }
+                    ],
+                }
+            )
+        return web.json_response({"ok": True, "result": messages})
+
+    def _handle_deleteMessages(self, params: dict[str, Any]) -> web.Response:
+        """Bulk delete. Accept and record the list; return success."""
+        return web.json_response({"ok": True, "result": True})
+
     def _handle_restrictChatMember(self, params: dict[str, Any]) -> web.Response:
         return web.json_response({"ok": True, "result": True})
 

--- a/tests/fake_telegram.py
+++ b/tests/fake_telegram.py
@@ -11,6 +11,7 @@ Usage:
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any
 
@@ -153,12 +154,10 @@ class FakeTelegramServer:
 
     def _handle_sendMediaGroup(self, params: dict[str, Any]) -> web.Response:
         """Return one minimal Message per item in the media list, with distinct ids."""
-        import json as _json
-
         media_raw = params.get("media", "[]")
         try:
-            media = _json.loads(media_raw) if isinstance(media_raw, str) else list(media_raw)
-        except Exception:
+            media = json.loads(media_raw) if isinstance(media_raw, str) else list(media_raw)
+        except (TypeError, ValueError):
             media = []
         chat_id = int(params.get("chat_id", 0))
         messages: list[dict[str, Any]] = []

--- a/tests/unit/test_channel_agent.py
+++ b/tests/unit/test_channel_agent.py
@@ -1035,7 +1035,7 @@ class TestReviewFlow:
         mock_bot: AsyncMock,
         session_maker: async_sessionmaker[AsyncSession],
     ) -> None:
-        """When review_message_id is set, regen should update the review message."""
+        """When review_message_id is set, regen should rebuild the review message."""
         from app.channel.review import handle_regen
 
         async with session_maker() as session:
@@ -1052,16 +1052,20 @@ class TestReviewFlow:
             await session.commit()
             post_id = post.id
 
-        with patch("app.channel.generator.generate_post", new_callable=AsyncMock) as mock_gen:
+        with (
+            patch("app.channel.generator.generate_post", new_callable=AsyncMock) as mock_gen,
+            patch("app.channel.review.telegram_io._rebuild_review_message", new_callable=AsyncMock) as mock_rebuild,
+        ):
             mock_gen.return_value = GeneratedPost(text="<b>Regenerated</b>", is_sensitive=False)
             result = await handle_regen(mock_bot, post_id, "key", "model", "Russian", -100, session_maker)
 
         assert result == "Post regenerated."
-        # Review message should be updated
-        mock_bot.edit_message_text.assert_called_once()
-        edit_kwargs = mock_bot.edit_message_text.call_args[1]
-        assert edit_kwargs["message_id"] == 50
-        assert edit_kwargs.get("parse_mode") is None
+        # Review message should be rebuilt (new-first-then-delete), not edited in place
+        mock_rebuild.assert_awaited_once()
+        rebuild_args = mock_rebuild.call_args
+        # Positional args: (bot, chat_id, post_id, session_maker, keyboard)
+        assert rebuild_args.args[1] == -100
+        assert rebuild_args.args[2] == post_id
 
 
 # ── ChannelSource enable/disable tests ───────────────────────────────

--- a/tests/unit/test_channel_post_album_ids.py
+++ b/tests/unit/test_channel_post_album_ids.py
@@ -1,0 +1,45 @@
+"""ORM round-trip for ChannelPost.review_album_message_ids."""
+
+from __future__ import annotations
+
+import pytest
+from app.core.enums import PostStatus
+from app.db.models import ChannelPost
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_review_album_message_ids_roundtrips_list_of_ints(session_maker):
+    async with session_maker() as s:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="x",
+            title="t",
+            post_text="b",
+            status=PostStatus.DRAFT,
+            review_album_message_ids=[1001, 1002, 1003],
+        )
+        s.add(p)
+        await s.commit()
+        await s.refresh(p)
+        pid = p.id
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+        assert row.review_album_message_ids == [1001, 1002, 1003]
+
+
+async def test_review_album_message_ids_defaults_to_none(session_maker):
+    async with session_maker() as s:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="y",
+            title="t",
+            post_text="b",
+            status=PostStatus.DRAFT,
+        )
+        s.add(p)
+        await s.commit()
+        await s.refresh(p)
+        assert p.review_album_message_ids is None

--- a/tests/unit/test_handle_delete_album.py
+++ b/tests/unit/test_handle_delete_album.py
@@ -1,0 +1,67 @@
+"""handle_delete deletes pult AND album photos when present."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from app.channel.review.telegram_io import handle_delete
+from app.core.enums import PostStatus
+from app.db.models import ChannelPost
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_post(session_maker, *, review_mid: int, album_ids: list[int] | None) -> int:
+    async with session_maker() as s:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="x",
+            title="t",
+            post_text="b",
+            status=PostStatus.DRAFT,
+            review_message_id=review_mid,
+            review_album_message_ids=album_ids,
+        )
+        s.add(p)
+        await s.commit()
+        await s.refresh(p)
+        return p.id
+
+
+async def test_delete_removes_album_plus_pult(session_maker):
+    pid = await _make_post(session_maker, review_mid=100, album_ids=[101, 102, 103])
+    deleted: list[int] = []
+
+    bot = SimpleNamespace()
+
+    async def fake_delete_messages(**kwargs):
+        deleted.extend(kwargs["message_ids"])
+
+    async def fake_delete_message(**kwargs):
+        deleted.append(kwargs["message_id"])
+
+    bot.delete_messages = fake_delete_messages
+    bot.delete_message = fake_delete_message
+
+    await handle_delete(bot, pid, -100, 100, session_maker)
+    assert set(deleted) == {100, 101, 102, 103}
+
+
+async def test_delete_with_no_album_still_deletes_pult(session_maker):
+    pid = await _make_post(session_maker, review_mid=200, album_ids=None)
+    deleted: list[int] = []
+
+    bot = SimpleNamespace()
+
+    async def fake_delete_message(**kwargs):
+        deleted.append(kwargs["message_id"])
+
+    async def fake_delete_messages(**kwargs):
+        deleted.extend(kwargs["message_ids"])
+
+    bot.delete_message = fake_delete_message
+    bot.delete_messages = fake_delete_messages
+
+    await handle_delete(bot, pid, -100, 200, session_maker)
+    assert deleted == [200]

--- a/tests/unit/test_handle_regen_rebuild.py
+++ b/tests/unit/test_handle_regen_rebuild.py
@@ -1,0 +1,66 @@
+"""handle_regen rebuilds the review message when images changed."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from app.channel.review.telegram_io import handle_regen
+from app.core.enums import PostStatus
+from app.db.models import ChannelPost
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_post(session_maker) -> int:
+    async with session_maker() as s:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="x",
+            title="t",
+            post_text="Body",
+            status=PostStatus.DRAFT,
+            image_urls=["https://x/a.jpg"],
+            review_message_id=1000,
+            review_album_message_ids=None,
+            source_items=[{"title": "t", "url": "https://src", "source_url": "https://src", "external_id": "x"}],
+        )
+        s.add(p)
+        await s.commit()
+        await s.refresh(p)
+        return p.id
+
+
+async def test_handle_regen_always_calls_rebuild(session_maker):
+    pid = await _make_post(session_maker)
+
+    # Stub out regen_post_text to return an "updated" post (same DB row, but with more images).
+    async def fake_regen_post_text(post_id, api_key, model, language, session_maker, *, footer):
+        async with session_maker() as s:
+            r = await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))
+            post = r.scalar_one_or_none()
+            if post:
+                post.image_urls = ["https://x/a.jpg", "https://x/new.jpg"]
+                await s.commit()
+                await s.refresh(post)
+            return "Post regenerated.", post
+
+    with (
+        patch("app.channel.review.telegram_io.regen_post_text", side_effect=fake_regen_post_text),
+        patch("app.channel.review.telegram_io._rebuild_review_message", new=AsyncMock()) as rebuild,
+    ):
+        bot = SimpleNamespace()
+        status = await handle_regen(
+            bot,
+            post_id=pid,
+            api_key="k",
+            model="m",
+            language="Russian",
+            review_chat_id=-100,
+            session_maker=session_maker,
+            footer="— Konnekt",
+        )
+        assert "regenerated" in status.lower()
+        rebuild.assert_awaited_once()

--- a/tests/unit/test_image_tool_rebuild_wiring.py
+++ b/tests/unit/test_image_tool_rebuild_wiring.py
@@ -1,0 +1,25 @@
+"""The agent's _refresh_review_message helper delegates to telegram_io._rebuild_review_message.
+
+We don't test via the PydanticAI toolset registry (internals change too often);
+we test the seam by lexical inspection of agent.py's source, plus the
+Task 9 e2e covers the full runtime behaviour end-to-end.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_agent_module_uses_telegram_io_rebuild():
+    """Lexical check: agent.py imports and references _rebuild_review_message."""
+    import app.channel.review.agent as agent_mod
+
+    src = inspect.getsource(agent_mod)
+    assert "_rebuild_review_message" in src, (
+        "agent.py should route image-tool refresh through telegram_io._rebuild_review_message"
+    )
+    # The old per-message delete-and-single-send path must be gone.
+    assert "bot.delete_message(chat_id=review_chat_id, message_id=post.review_message_id)" not in src, (
+        "agent.py should no longer open-code single-message delete-and-resend; "
+        "that logic lives in telegram_io._rebuild_review_message now."
+    )

--- a/tests/unit/test_review_rebuild.py
+++ b/tests/unit/test_review_rebuild.py
@@ -1,0 +1,145 @@
+"""Unit tests for _rebuild_review_message: new-first-then-delete semantics."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from app.channel.review.telegram_io import _rebuild_review_message
+from app.core.enums import PostStatus
+from app.db.models import ChannelPost
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+def _kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[[InlineKeyboardButton(text="ok", callback_data="x")]])
+
+
+async def _make_post(
+    session_maker,
+    *,
+    review_message_id: int | None,
+    album_ids: list[int] | None,
+    image_urls: list[str] | None,
+) -> int:
+    async with session_maker() as s:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="x",
+            title="t",
+            post_text="Body",
+            status=PostStatus.DRAFT,
+            review_message_id=review_message_id,
+            review_album_message_ids=album_ids,
+            image_urls=image_urls,
+        )
+        s.add(p)
+        await s.commit()
+        await s.refresh(p)
+        return p.id
+
+
+async def test_rebuild_album_to_album_commits_new_then_deletes_old(session_maker):
+    """Happy path: post has 2 images, rebuild sends new album+pult, commits, then deletes old."""
+    pid = await _make_post(
+        session_maker,
+        review_message_id=100,
+        album_ids=[200, 201],
+        image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+    )
+
+    call_order: list[str] = []
+    deleted_ids_capture: list[int] = []
+
+    bot = SimpleNamespace()
+
+    async def fake_send_media_group(**kwargs):
+        call_order.append("send_media_group")
+        return [SimpleNamespace(message_id=300), SimpleNamespace(message_id=301)]
+
+    async def fake_send_message(**kwargs):
+        call_order.append("send_message")
+        return SimpleNamespace(message_id=302)
+
+    async def fake_delete_messages(**kwargs):
+        call_order.append("delete_messages")
+        deleted_ids_capture.extend(kwargs["message_ids"])
+
+    bot.send_media_group = fake_send_media_group
+    bot.send_message = fake_send_message
+    bot.send_photo = AsyncMock()
+    bot.delete_messages = fake_delete_messages
+
+    await _rebuild_review_message(bot, -100, pid, session_maker, _kb())
+
+    # New messages went out before the old ones were deleted.
+    assert call_order == ["send_media_group", "send_message", "delete_messages"]
+    # Original pult + album — order may vary, compare as a set.
+    assert set(deleted_ids_capture) == {100, 200, 201}
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+        assert row.review_message_id == 302
+        assert row.review_album_message_ids == [300, 301]
+
+
+async def test_rebuild_single_to_album_deletes_old_single(session_maker):
+    """Post had 1 image, reviewer added another → rebuild flips to album, deletes old single."""
+    pid = await _make_post(
+        session_maker,
+        review_message_id=500,
+        album_ids=None,
+        image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+    )
+
+    deleted_ids: list[int] = []
+    bot = SimpleNamespace()
+    bot.send_media_group = AsyncMock(return_value=[SimpleNamespace(message_id=600), SimpleNamespace(message_id=601)])
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=602))
+    bot.send_photo = AsyncMock()
+
+    async def fake_delete_messages(**kwargs):
+        deleted_ids.extend(kwargs["message_ids"])
+
+    bot.delete_messages = fake_delete_messages
+
+    await _rebuild_review_message(bot, -100, pid, session_maker, _kb())
+
+    assert deleted_ids == [500]  # only the old single pult
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+        assert row.review_message_id == 602
+        assert row.review_album_message_ids == [600, 601]
+
+
+async def test_rebuild_swallows_delete_errors(session_maker):
+    """If delete_messages raises, DB was already committed — rebuild must not bubble the error."""
+    pid = await _make_post(
+        session_maker,
+        review_message_id=700,
+        album_ids=[701, 702],
+        image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+    )
+
+    bot = SimpleNamespace()
+    bot.send_media_group = AsyncMock(return_value=[SimpleNamespace(message_id=800), SimpleNamespace(message_id=801)])
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=802))
+    bot.send_photo = AsyncMock()
+
+    async def failing_delete(**kwargs):
+        raise RuntimeError("too old")
+
+    bot.delete_messages = failing_delete
+
+    # Must not raise
+    await _rebuild_review_message(bot, -100, pid, session_maker, _kb())
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+        assert row.review_message_id == 802
+        assert row.review_album_message_ids == [800, 801]

--- a/tests/unit/test_review_render_modes.py
+++ b/tests/unit/test_review_render_modes.py
@@ -1,0 +1,96 @@
+"""Unit tests for _render_review_message: chooses the right mode based on image count."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from app.channel.review.telegram_io import _render_review_message
+
+pytestmark = pytest.mark.asyncio
+
+
+def _kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[[InlineKeyboardButton(text="ok", callback_data="x")]])
+
+
+async def test_render_text_mode_no_images():
+    bot = SimpleNamespace()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=2001))
+    bot.send_photo = AsyncMock()
+    bot.send_media_group = AsyncMock()
+
+    pult_id, album_ids = await _render_review_message(
+        bot, chat_id=-100, post_text="hello", image_urls=[], keyboard=_kb()
+    )
+
+    assert pult_id == 2001
+    assert album_ids is None
+    bot.send_message.assert_awaited_once()
+    bot.send_photo.assert_not_awaited()
+    bot.send_media_group.assert_not_awaited()
+
+
+async def test_render_single_mode_one_image():
+    bot = SimpleNamespace()
+    bot.send_message = AsyncMock()
+    bot.send_photo = AsyncMock(return_value=SimpleNamespace(message_id=2002))
+    bot.send_media_group = AsyncMock()
+
+    pult_id, album_ids = await _render_review_message(
+        bot, chat_id=-100, post_text="hello", image_urls=["https://x/a.jpg"], keyboard=_kb()
+    )
+
+    assert pult_id == 2002
+    assert album_ids is None
+    bot.send_photo.assert_awaited_once()
+    # parse_mode must be None to preserve entities past the bot's default HTML mode
+    kwargs = bot.send_photo.await_args.kwargs
+    assert kwargs.get("parse_mode") is None
+    bot.send_message.assert_not_awaited()
+    bot.send_media_group.assert_not_awaited()
+
+
+async def test_render_album_mode_two_or_more_images():
+    bot = SimpleNamespace()
+    album_msgs = [SimpleNamespace(message_id=3001), SimpleNamespace(message_id=3002)]
+    bot.send_media_group = AsyncMock(return_value=album_msgs)
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=3003))
+    bot.send_photo = AsyncMock()
+
+    pult_id, album_ids = await _render_review_message(
+        bot,
+        chat_id=-100,
+        post_text="hello",
+        image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+        keyboard=_kb(),
+    )
+
+    assert pult_id == 3003
+    assert album_ids == [3001, 3002]
+    bot.send_media_group.assert_awaited_once()
+    # pult must reply to the first album photo so Telegram visually groups them
+    pult_kwargs = bot.send_message.await_args.kwargs
+    assert pult_kwargs.get("reply_to_message_id") == 3001
+    assert pult_kwargs.get("parse_mode") is None
+    bot.send_photo.assert_not_awaited()
+
+
+async def test_render_single_mode_long_text_falls_back_to_text_message():
+    """Existing behaviour: if caption > 1024 chars, image is dropped (text-only msg)."""
+    bot = SimpleNamespace()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=4001))
+    bot.send_photo = AsyncMock()
+    bot.send_media_group = AsyncMock()
+
+    long_text = "x" * 1100
+    pult_id, album_ids = await _render_review_message(
+        bot, chat_id=-100, post_text=long_text, image_urls=["https://x/a.jpg"], keyboard=_kb()
+    )
+
+    assert pult_id == 4001
+    assert album_ids is None
+    bot.send_message.assert_awaited_once()
+    bot.send_photo.assert_not_awaited()

--- a/tests/unit/test_send_for_review_album.py
+++ b/tests/unit/test_send_for_review_album.py
@@ -1,0 +1,84 @@
+"""send_for_review persists review_album_message_ids for 2+ image posts."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from app.channel.generator import GeneratedPost
+from app.channel.review.telegram_io import send_for_review
+from app.db.models import ChannelPost
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Item:
+    def __init__(self, title: str, url: str) -> None:
+        self.title = title
+        self.url = url
+        self.body = "b"
+        self.source_url = url
+        self.external_id = url
+        self.summary = "s"
+
+
+async def _bot_with_album(album_ids: list[int], pult_id: int):
+    bot = SimpleNamespace()
+    bot.send_media_group = AsyncMock(return_value=[SimpleNamespace(message_id=mid) for mid in album_ids])
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=pult_id))
+    bot.send_photo = AsyncMock()
+    return bot
+
+
+async def test_album_message_ids_persisted_when_two_images(session_maker):
+    bot = await _bot_with_album(album_ids=[5001, 5002], pult_id=5003)
+    post = GeneratedPost(
+        text="Body\n\n——\n🔗 **Konnekt**",
+        image_url="https://x/a.jpg",
+        image_urls=["https://x/a.jpg", "https://x/b.jpg"],
+    )
+    items = [_Item("News", "https://src/1")]
+
+    post_id = await send_for_review(
+        bot,
+        review_chat_id=-100,
+        channel_id=-100,
+        post=post,
+        source_items=items,
+        session_maker=session_maker,
+    )
+    assert post_id is not None
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one()
+        assert row.review_message_id == 5003
+        assert row.review_album_message_ids == [5001, 5002]
+
+
+async def test_album_message_ids_is_none_when_single_image(session_maker):
+    bot = SimpleNamespace()
+    bot.send_photo = AsyncMock(return_value=SimpleNamespace(message_id=6001))
+    bot.send_message = AsyncMock()
+    bot.send_media_group = AsyncMock()
+    post = GeneratedPost(
+        text="Body\n\n——\n🔗 **Konnekt**",
+        image_url="https://x/a.jpg",
+        image_urls=["https://x/a.jpg"],
+    )
+    items = [_Item("News", "https://src/1")]
+
+    post_id = await send_for_review(
+        bot,
+        review_chat_id=-100,
+        channel_id=-100,
+        post=post,
+        source_items=items,
+        session_maker=session_maker,
+    )
+
+    async with session_maker() as s:
+        row = (await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one()
+        assert row.review_message_id == 6001
+        assert row.review_album_message_ids is None


### PR DESCRIPTION
## Summary
- Review flow now sends `send_media_group` + a separate pult text message for posts with 2+ images, so reviewers see every image the agent composed (was: just the first one).
- Image tool edits (`use_candidate`, `remove_image`, `reorder_images`, etc.) and `/regen` rebuild the review via new-first-then-delete to avoid dead-callback windows when mode flips (single ↔ album).
- New nullable `ChannelPost.review_album_message_ids` JSON column tracks album photo ids alongside the existing `review_message_id` (the pult).
- `handle_delete` now also bulk-deletes the album photos, not just the pult.

## Scope

- 1 spec: \`docs/superpowers/specs/2026-04-17-review-album-ui-design.md\`
- 1 plan, 9 implementation tasks
- Text-only posts and single-image posts: **unchanged behaviour**. Only 2+ image posts hit the new album path.

## Implementation

Built via Subagent-Driven Development: fresh subagent per task, two-stage review (spec compliance + code quality) after each, autonomous end-to-end.

| # | Commit | What |
|---|---|---|
| 1 | \`e515d9c\` | DB column \`review_album_message_ids\` + migration |
| 2 | \`7445368\` | FakeTelegramServer: \`sendMediaGroup\` + \`deleteMessages\` endpoints |
| 3 | \`f96d17c\` | \`_render_review_message\` with text / single / album modes |
| 4 | \`f430fac\` | \`send_for_review\` persists album ids |
| 5 | \`9fad5a0\` | \`_rebuild_review_message\` new-first-then-delete |
| 6 | \`9d8ea52\` | Agent image tools route through new rebuild helper |
| 7 | \`97128e3\` | \`handle_regen\` triggers rebuild (text + images) |
| 8 | \`8b19063\` | \`handle_delete\` removes album photos too |
| 9 | \`aa9d47f\` | e2e smoke test against FakeTelegramServer |

## Test plan

- [x] \`uv run -m pytest -q\` — **732 passed, 2 skipped** (pre-existing), up from 640 baseline
- [x] \`uv run ruff check app tests && uv run ruff format --check app tests\` — clean
- [x] \`uv run ty check app tests\` — 85 diagnostics (same as baseline, 0 new regressions)
- [ ] Manual smoke in the Konnekt Review group: publish a multi-image draft, verify both the album and the button pult render; use \`use_candidate\` / \`remove_image\` / \`/regen\` and watch the review rebuild cleanly

Design spec: \`docs/superpowers/specs/2026-04-17-review-album-ui-design.md\`
Implementation plan: \`docs/superpowers/plans/2026-04-17-review-album-ui.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)