### PR TITLE
feat(critic): post-generation polish pass (Sprint 2 / Track 2)

### DIFF
--- a/alembic/versions/c663f6310e6f_add_critic_enabled_and_pre_critic_text.py
+++ b/alembic/versions/c663f6310e6f_add_critic_enabled_and_pre_critic_text.py
@@ -1,0 +1,27 @@
+"""add critic_enabled and pre_critic_text
+
+Revision ID: c663f6310e6f
+Revises: 21c84750b5db
+Create Date: 2026-04-17 21:17:44.955966
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'c663f6310e6f'
+down_revision: Union[str, None] = '21c84750b5db'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("channels", sa.Column("critic_enabled", sa.Boolean(), nullable=True))
+    op.add_column("channel_posts", sa.Column("pre_critic_text", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("channel_posts", "pre_critic_text")
+    op.drop_column("channels", "critic_enabled")

--- a/app/assistant/tools/channel/channels.py
+++ b/app/assistant/tools/channel/channels.py
@@ -155,3 +155,34 @@ def register_channels_tools(agent: Agent[AssistantDeps, str]) -> None:
         if not ok:
             return f"Канал {telegram_id} не найден."
         return f"Канал {telegram_id} удалён. Оркестратор остановит его в течение 5 минут."
+
+    @agent.tool
+    async def set_channel_critic(
+        ctx: RunContext[AssistantDeps],
+        telegram_id: int,
+        enabled: bool | None,
+    ) -> str:
+        """Set per-channel critic override. enabled=True forces the critic on for
+        this channel, False forces it off, None resets the override so the channel
+        follows the global CHANNEL_CRITIC_ENABLED setting."""
+        from sqlalchemy import select
+
+        from app.core.config import settings
+        from app.db.models import Channel
+
+        async with ctx.deps.session_maker() as session:
+            row = (
+                await session.execute(select(Channel).where(Channel.telegram_id == telegram_id))
+            ).scalar_one_or_none()
+            if row is None:
+                return f"Канал {telegram_id} не найден."
+            row.critic_enabled = enabled
+            await session.commit()
+
+        global_val = settings.channel.critic_enabled
+        effective = enabled if enabled is not None else global_val
+        if enabled is None:
+            return (
+                f"Канал {telegram_id}: override сброшен, теперь следует глобальной настройке (effective={effective})."
+            )
+        return f"Канал {telegram_id}: critic_enabled={enabled} (global={global_val}, effective={effective})."

--- a/app/channel/config.py
+++ b/app/channel/config.py
@@ -58,6 +58,14 @@ class ChannelAgentSettings(BaseSettings):
     http_timeout: int = Field(default=30, description="HTTP client timeout in seconds")
     screening_threshold: int = Field(default=5, description="Minimum relevance score (0-10) to pass screening")
     temperature: float = Field(default=0.3, description="LLM temperature for content generation")
+    critic_enabled: bool = Field(
+        default=False,
+        description="Master kill-switch for the post critic polish pass",
+    )
+    critic_model: str = Field(
+        default="anthropic/claude-sonnet-4-6",
+        description="Model used by the critic agent",
+    )
 
     # Brave Search — complementary to Perplexity for URL-based factual search
     brave_discovery_enabled: bool = Field(

--- a/app/channel/critic.py
+++ b/app/channel/critic.py
@@ -1,0 +1,113 @@
+"""Post critic: polish pass that removes clichés while preserving facts/links/structure.
+
+Invoked from `generate_post` after length-enforcement, before the image pipeline.
+On any failure the pipeline keeps the original text (silent fallback).
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from app.core.exceptions import DomainError
+from app.core.logging import get_logger
+
+logger = get_logger("channel.critic")
+
+
+class CriticError(DomainError):
+    """Raised when the critic pass fails after retry (invariants still violated)."""
+
+
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+# Whitelist of headline emojis used by the generation prompt. Any of these
+# at the first non-whitespace codepoint is considered a valid headline emoji.
+_HEADLINE_EMOJIS = frozenset({"📰", "🎓", "💼", "🎉", "🏠", "💰", "⚡", "✨", "🔥", "⭐"})
+
+_MIN_LENGTH = 100
+_MAX_LENGTH = 900
+
+
+def _extract_md_links(text: str) -> list[tuple[str, str]]:
+    """Return list of (label, url) pairs from Markdown links `[label](url)`."""
+    return [(m.group(1), m.group(2)) for m in _LINK_RE.finditer(text)]
+
+
+def _strip_agent_artifacts(output: str) -> str:
+    """Strip common LLM artifacts: code fences, prefix phrases, surrounding quotes.
+
+    Applied before invariant validation so benign formatting cruft doesn't
+    trigger failures.
+    """
+    text = output.strip()
+
+    # 1. Code fence (```lang ... ```), optionally with language tag.
+    fence = re.match(
+        r"^```[a-zA-Z0-9_-]*\s*\n?(.*?)\n?```$",
+        text,
+        flags=re.DOTALL,
+    )
+    if fence:
+        text = fence.group(1).strip()
+
+    # 2. Common prefix phrases like "Here's the polished version:"
+    prefix_patterns = [
+        r"^here'?s?\s+(?:the|your|a)?\s*polished\s+(?:version|post)?:?\s*\n+",
+        r"^polished\s+(?:version|post):?\s*\n+",
+        r"^here\s+is\s+(?:the|your)?\s*polished\s+(?:version|post)?:?\s*\n+",
+    ]
+    for pat in prefix_patterns:
+        text = re.sub(pat, "", text, count=1, flags=re.IGNORECASE).strip()
+
+    # 3. Surrounding quotes.
+    if len(text) >= 2 and text[0] in {'"', "'", "«", "\u201c"} and text[-1] in {'"', "'", "»", "\u201d"}:
+        text = text[1:-1].strip()
+
+    return text
+
+
+def _first_visible_char(text: str) -> str:
+    """Return the first non-whitespace character of `text`, or empty string."""
+    for ch in text:
+        if not ch.isspace():
+            return ch
+    return ""
+
+
+def _validate_invariants(original: str, polished: str, footer: str) -> list[str]:
+    """Return a list of human-readable violation strings. Empty list = all pass."""
+    violations: list[str] = []
+
+    orig_links = _extract_md_links(original)
+    new_links = _extract_md_links(polished)
+
+    orig_urls = {url for _, url in orig_links}
+    new_urls = {url for _, url in new_links}
+
+    missing = orig_urls - new_urls
+    for url in missing:
+        violations.append(f"lost URL: {url}")
+
+    if len(new_links) < len(orig_links):
+        violations.append(f"link count dropped: {len(orig_links)} → {len(new_links)}")
+
+    if footer and footer not in polished:
+        violations.append("footer missing")
+
+    if len(polished) > _MAX_LENGTH:
+        violations.append(f"length over 900: {len(polished)}")
+
+    if len(polished) < _MIN_LENGTH:
+        violations.append(f"output too short: {len(polished)} (min {_MIN_LENGTH})")
+
+    first = _first_visible_char(polished)
+    if first and first not in _HEADLINE_EMOJIS:
+        # Fallback: check the whole first codepoint is in the Symbol,Other
+        # Unicode category (emoji-ish). `first` is a single character from the
+        # Python string; compare its category via `unicodedata`.
+        cat = unicodedata.category(first)
+        if not cat.startswith("So"):
+            violations.append(f"headline emoji missing (first char: {first!r})")
+
+    return violations

--- a/app/channel/critic.py
+++ b/app/channel/critic.py
@@ -11,7 +11,7 @@ import unicodedata
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from app.core.config import Settings
+    from app.core.config import AppSettings
     from app.db.models import Channel
 
 from pydantic_ai import Agent
@@ -227,7 +227,7 @@ async def polish_post(
     raise CriticError(f"invariants violated after retry: {violations}")
 
 
-def resolve_critic_enabled(channel: Channel, settings_obj: Settings) -> bool:
+def resolve_critic_enabled(channel: Channel, settings_obj: AppSettings) -> bool:
     """Resolve the effective critic-enabled flag.
 
     Per-channel value wins when set (True/False). None falls back to

--- a/app/channel/critic.py
+++ b/app/channel/critic.py
@@ -9,6 +9,12 @@ from __future__ import annotations
 import re
 import unicodedata
 
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from app.channel.cost_tracker import extract_usage_from_pydanticai_result, log_usage
+from app.core.config import settings
 from app.core.exceptions import DomainError
 from app.core.logging import get_logger
 
@@ -111,3 +117,106 @@ def _validate_invariants(original: str, polished: str, footer: str) -> list[str]
             violations.append(f"headline emoji missing (first char: {first!r})")
 
     return violations
+
+
+# ── LLM critic pass ──────────────────────────────────────────────────
+
+CRITIC_PROMPT = """\
+You are a ruthless style editor for the Telegram channel "Konnekt"
+(news for CIS students in the Czech Republic). Your ONLY job: polish a
+post by removing clichés, banal openers, dead verbs, and pompous or
+corporate phrasing.
+
+HARD RULES — violation = task failed:
+1. PRESERVE every Markdown link [text](url) — same URLs, same count.
+2. PRESERVE the exact footer at the end: {footer}
+3. PRESERVE facts: numbers, dates, names, institutions, prices, addresses.
+4. PRESERVE structure: same paragraph breaks, same order, same headline
+   emoji at the very start.
+5. Output MUST be <= 900 characters total.
+6. Do NOT add new information. Do NOT invent details, numbers, or names.
+
+WHAT TO FIX:
+- Banned phrases: "это отличная/уникальная возможность",
+  "не упустите шанс", "лично расспросить", "рады сообщить",
+  "с гордостью представляем", "Ознакомиться можно...",
+  "Подробнее здесь...", "Узнать больше..."
+- Banal openers: "У нас отличная новость", "Есть хорошая новость для
+  вас", "Хотим поделиться..."
+- Dead verbs: "предоставляем", "сообщаем", "уведомляем" — replace with
+  the concrete action.
+- Pompous / corporate tone → friendly, peer-to-peer student tone.
+- Filler adjectives: "уникальный", "незабываемый", "эксклюзивный".
+
+TONE: simple, slightly witty, like telling a friend about news. At
+most one exclamation mark per post.
+
+OUTPUT: return ONLY the polished post text. No explanations, no
+"Here's your polished version:", no markdown code fences. Plain
+polished post.
+"""
+
+_RETRY_HINT = (
+    "Your previous rewrite violated hard rules. Fix the violations and "
+    "return ONLY the polished post text.\n"
+    "You MUST preserve every link [text](url), the exact footer, the "
+    "headline emoji, and keep the total length <= 900 characters.\n"
+)
+
+
+def _create_critic_agent(api_key: str, model: str, *, footer: str) -> Agent[None, str]:
+    """Build the PydanticAI agent for the critic pass."""
+    provider = OpenAIProvider(base_url=settings.openrouter.base_url, api_key=api_key)
+    llm = OpenAIChatModel(model_name=model, provider=provider)
+    prompt = CRITIC_PROMPT.format(footer=footer)
+    return Agent(llm, system_prompt=prompt, output_type=str, model_settings={"temperature": 0.4})
+
+
+async def polish_post(
+    *,
+    text: str,
+    footer: str,
+    api_key: str,
+    model: str,
+) -> str:
+    """Run the critic pass on `text`. Returns polished text or raises CriticError.
+
+    Makes at most two LLM calls: the main polish, plus one retry if the
+    first result violates invariants. On any exception (LLM error, retry
+    still violates), raises CriticError so the caller can fall back.
+    """
+    agent = _create_critic_agent(api_key, model, footer=footer)
+
+    try:
+        result = await agent.run(text)
+    except Exception as exc:
+        raise CriticError(f"first call failed: {exc}") from exc
+
+    usage = extract_usage_from_pydanticai_result(result, model, "critic")
+    if usage:
+        await log_usage(usage)
+
+    polished = _strip_agent_artifacts(result.output)
+    violations = _validate_invariants(text, polished, footer)
+    if not violations:
+        return polished
+
+    logger.info("critic_retry", violations=violations)
+
+    retry_prompt = f"{_RETRY_HINT}Previous violations: {', '.join(violations)}\n\nOriginal post (rewrite this):\n{text}"
+
+    try:
+        result = await agent.run(retry_prompt)
+    except Exception as exc:
+        raise CriticError(f"retry call failed: {exc}") from exc
+
+    usage = extract_usage_from_pydanticai_result(result, model, "critic_retry")
+    if usage:
+        await log_usage(usage)
+
+    polished = _strip_agent_artifacts(result.output)
+    violations = _validate_invariants(text, polished, footer)
+    if not violations:
+        return polished
+
+    raise CriticError(f"invariants violated after retry: {violations}")

--- a/app/channel/critic.py
+++ b/app/channel/critic.py
@@ -8,6 +8,11 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.core.config import Settings
+    from app.db.models import Channel
 
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIChatModel
@@ -220,3 +225,14 @@ async def polish_post(
         return polished
 
     raise CriticError(f"invariants violated after retry: {violations}")
+
+
+def resolve_critic_enabled(channel: Channel, settings_obj: Settings) -> bool:
+    """Resolve the effective critic-enabled flag.
+
+    Per-channel value wins when set (True/False). None falls back to
+    `settings.channel.critic_enabled`.
+    """
+    if channel.critic_enabled is not None:
+        return channel.critic_enabled
+    return settings_obj.channel.critic_enabled

--- a/app/channel/generator.py
+++ b/app/channel/generator.py
@@ -339,6 +339,8 @@ async def generate_post(
     vision_model: str = "",
     phash_threshold: int = 10,
     phash_lookback: int = 30,
+    critic_enabled: bool = False,
+    critic_model: str = "",
 ) -> GeneratedPost | None:
     """Generate a post from one or more content items."""
     if not items:
@@ -400,6 +402,30 @@ async def generate_post(
             if len(post.text) > 900:
                 logger.warning("post_still_too_long", length=len(post.text), action="truncate")
                 post.text = enforce_footer_and_length(post.text, footer, max_length=900)
+
+        # Critic polish pass — best-effort. Silent fallback on failure.
+        if critic_enabled and critic_model:
+            try:
+                from app.channel.critic import CriticError, polish_post
+
+                original_text = post.text
+                polished = await polish_post(
+                    text=original_text,
+                    footer=footer,
+                    api_key=api_key,
+                    model=critic_model,
+                )
+                post.pre_critic_text = original_text
+                post.text = polished
+                logger.info(
+                    "critic_applied",
+                    orig_len=len(original_text),
+                    new_len=len(polished),
+                )
+            except CriticError as exc:
+                logger.warning("critic_failed_fallback", reason=str(exc))
+            except Exception:
+                logger.exception("critic_unexpected_error")
 
         # Resolve images: new pipeline — filter, score, dedup, compose.
         # Best-effort: failure leaves post.image_urls = [].

--- a/app/channel/generator.py
+++ b/app/channel/generator.py
@@ -74,6 +74,10 @@ class GeneratedPost(BaseModel):
     image_phashes: list[str] = Field(
         default_factory=list, description="pHashes of selected images (for future cross-post dedup)"
     )
+    pre_critic_text: str | None = Field(
+        default=None,
+        description="Post text before the critic polish pass; None when critic did not run or failed",
+    )
 
 
 SCREENING_PROMPT_TEMPLATE = """\

--- a/app/channel/review/service.py
+++ b/app/channel/review/service.py
@@ -478,7 +478,20 @@ async def regen_post_text(
         if not items:
             return "No source data to regenerate from.", None
 
+        from app.channel.critic import resolve_critic_enabled
         from app.core.config import settings
+        from app.db.models import Channel
+
+        # Resolve per-channel override for the critic flag. post.channel_id is
+        # the Telegram id; load the Channel row. If not found, fall back to global.
+        ch_row = (
+            await session.execute(select(Channel).where(Channel.telegram_id == post.channel_id))
+        ).scalar_one_or_none()
+        if ch_row is not None:
+            critic_enabled = resolve_critic_enabled(ch_row, settings)
+        else:
+            critic_enabled = settings.channel.critic_enabled
+        critic_model = settings.channel.critic_model
 
         new_post = await generate_post(
             items,
@@ -491,11 +504,14 @@ async def regen_post_text(
             vision_model=settings.channel.vision_model,
             phash_threshold=settings.channel.image_phash_threshold,
             phash_lookback=settings.channel.image_phash_lookback_posts,
+            critic_enabled=critic_enabled,
+            critic_model=critic_model,
         )
         if not new_post:
             return "Regeneration failed.", None
 
         post.update_text(new_post.text)
+        post.pre_critic_text = new_post.pre_critic_text
         # Also refresh image fields from the new pipeline run — otherwise the
         # post's text and image pool diverge (old images stay attached to new text).
         post.image_url = new_post.image_url

--- a/app/channel/review/service.py
+++ b/app/channel/review/service.py
@@ -143,6 +143,7 @@ async def create_review_post(
         image_phashes=post.image_phashes or None,
         source_items=source_data,
         review_chat_id=int(review_chat_id) if review_chat_id else 0,
+        pre_critic_text=post.pre_critic_text,
     )
     session.add(db_post)
     try:

--- a/app/channel/workflow.py
+++ b/app/channel/workflow.py
@@ -344,6 +344,17 @@ async def generate_post(state: State) -> State:
     if channel.discovery_query:
         channel_context = f"Channel focus: {channel.discovery_query}"
 
+    from app.channel.critic import resolve_critic_enabled
+
+    # Wrap `config` (ChannelAgentSettings) in a shim so resolve_critic_enabled
+    # can access settings_obj.channel.critic_enabled using the state config,
+    # not the global singleton (which may differ in tests and staging).
+    class _SettingsShim:
+        channel = config
+
+    critic_enabled = resolve_critic_enabled(channel, _SettingsShim())  # type: ignore[arg-type]
+    critic_model = config.critic_model
+
     try:
         post = await _generate(
             relevant[:1],  # 1 news = 1 post
@@ -359,6 +370,8 @@ async def generate_post(state: State) -> State:
             vision_model=config.vision_model,
             phash_threshold=config.image_phash_threshold,
             phash_lookback=config.image_phash_lookback_posts,
+            critic_enabled=critic_enabled,
+            critic_model=critic_model,
         )
         if post is None:
             return state.update(generated_post=None, error="generation_failed")

--- a/app/channel/workflow.py
+++ b/app/channel/workflow.py
@@ -475,6 +475,7 @@ async def send_for_review(state: State) -> State:
                             image_phashes=post.image_phashes or None,
                             status=PostStatus.APPROVED,
                             telegram_message_id=msg_id,
+                            pre_critic_text=post.pre_critic_text,
                         )
                         session.add(db_post)
                         await session.commit()

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -271,6 +271,7 @@ class Channel(Base):
     last_source_discovery_at: Mapped[datetime.datetime | None] = mapped_column(DateTime, nullable=True)
     footer_template: Mapped[str | None] = mapped_column(String, nullable=True)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    critic_enabled: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(DateTime, default=utc_now)
     modified_at: Mapped[datetime.datetime] = mapped_column(DateTime, default=utc_now, onupdate=utc_now)
 
@@ -290,6 +291,7 @@ class Channel(Base):
         username: str | None = None,
         footer_template: str | None = None,
         enabled: bool = True,
+        critic_enabled: bool | None = None,
     ) -> None:
         self.telegram_id = telegram_id
         self.name = name
@@ -303,6 +305,7 @@ class Channel(Base):
         self.username = username
         self.footer_template = footer_template
         self.enabled = enabled
+        self.critic_enabled = critic_enabled
 
     @property
     def footer(self) -> str:
@@ -413,6 +416,7 @@ class ChannelPost(Base):
     image_phashes: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
     status: Mapped[str] = mapped_column(String(16), default=PostStatus.DRAFT, index=True)
     admin_feedback: Mapped[str | None] = mapped_column(String, nullable=True)
+    pre_critic_text: Mapped[str | None] = mapped_column(String, nullable=True)
     scheduled_at: Mapped[datetime.datetime | None] = mapped_column(DateTime, nullable=True)
     scheduled_telegram_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     published_at: Mapped[datetime.datetime | None] = mapped_column(DateTime, nullable=True)
@@ -441,6 +445,7 @@ class ChannelPost(Base):
         status: str = PostStatus.DRAFT,
         embedding: Any | None = None,
         embedding_model: str | None = None,
+        pre_critic_text: str | None = None,
     ) -> None:
         self.channel_id = channel_id
         self.external_id = external_id
@@ -460,6 +465,7 @@ class ChannelPost(Base):
         self.review_album_message_ids = review_album_message_ids
         self.embedding = embedding
         self.embedding_model = embedding_model
+        self.pre_critic_text = pre_critic_text
 
     def approve(self, message_id: int) -> None:
         self.status = PostStatus.APPROVED

--- a/docs/superpowers/plans/2026-04-17-critic-agent.md
+++ b/docs/superpowers/plans/2026-04-17-critic-agent.md
@@ -1,0 +1,1967 @@
+# Critic Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a post-generation polish pass (Claude Sonnet 4.6) that removes clichés, banal openers, dead verbs, and pompous phrasing while preserving facts, links, footer, structure, and length, behind a global + per-channel kill switch.
+
+**Architecture:** New `app/channel/critic.py` module with a `polish_post()` entrypoint invoked from `generate_post()` after length-enforcement and before the image pipeline. Silent fallback on any failure (retry once, then return original text). Per-channel override `channels.critic_enabled` resolves against global `settings.channel.critic_enabled`. Original text preserved in `channel_posts.pre_critic_text` for audit/diff.
+
+**Tech Stack:** PydanticAI Agent + OpenAIChatModel via OpenRouter, SQLAlchemy 2.x async, Alembic, pytest, pytest-asyncio.
+
+---
+
+## File map
+
+**New:**
+- `app/channel/critic.py` — polish pass, invariants, agent builder, `resolve_critic_enabled`
+- `alembic/versions/<hash>_add_critic_columns.py` — two-column migration
+- `tests/unit/test_critic_config.py`
+- `tests/unit/test_critic_columns.py`
+- `tests/unit/test_critic_invariants.py`
+- `tests/unit/test_critic_polish.py`
+- `tests/unit/test_critic_resolve.py`
+- `tests/integration/test_generator_with_critic.py`
+- `tests/unit/test_assistant_set_channel_critic.py`
+
+**Modified:**
+- `app/channel/config.py` — `critic_enabled`, `critic_model` fields
+- `app/db/models.py` — `Channel.critic_enabled`, `ChannelPost.pre_critic_text`, `__init__` kwargs, `GeneratedPost` is in `generator.py`
+- `app/channel/generator.py` — `GeneratedPost.pre_critic_text`, new kwargs on `generate_post`, critic invocation
+- `app/channel/workflow.py` — resolve critic flags, pass to generator
+- `app/channel/review/service.py` — persist `pre_critic_text` in `create_review_post`; regen path mirrors workflow
+- `app/assistant/tools/channel/channels.py` — `set_channel_critic` tool
+
+---
+
+## Task 1: Add config fields
+
+Adds the global master switch and model selection to `ChannelAgentSettings`.
+
+**Files:**
+- Modify: `app/channel/config.py`
+- Create: `tests/unit/test_critic_config.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_critic_config.py`:
+
+```python
+"""Tests for critic-related settings on ChannelAgentSettings."""
+
+from __future__ import annotations
+
+from app.channel.config import ChannelAgentSettings
+
+
+def test_critic_enabled_default_false():
+    s = ChannelAgentSettings()
+    assert s.critic_enabled is False
+
+
+def test_critic_model_default_sonnet():
+    s = ChannelAgentSettings()
+    assert s.critic_model == "anthropic/claude-sonnet-4-6"
+
+
+def test_critic_env_override(monkeypatch):
+    monkeypatch.setenv("CHANNEL_CRITIC_ENABLED", "true")
+    monkeypatch.setenv("CHANNEL_CRITIC_MODEL", "openai/gpt-5.1")
+    s = ChannelAgentSettings()
+    assert s.critic_enabled is True
+    assert s.critic_model == "openai/gpt-5.1"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_critic_config.py -v`
+Expected: FAIL with `AttributeError` / `no attribute 'critic_enabled'`.
+
+- [ ] **Step 3: Add the fields**
+
+In `app/channel/config.py`, inside `class ChannelAgentSettings(BaseSettings)`, add after the `temperature` field (around line 60):
+
+```python
+    critic_enabled: bool = Field(
+        default=False,
+        description="Master kill-switch for the post critic polish pass",
+    )
+    critic_model: str = Field(
+        default="anthropic/claude-sonnet-4-6",
+        description="Model used by the critic agent",
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_critic_config.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/config.py tests/unit/test_critic_config.py
+git commit -m "feat(critic): add critic_enabled and critic_model config fields"
+```
+
+---
+
+## Task 2: DB migration + ORM columns
+
+Adds `channels.critic_enabled` (nullable bool) and `channel_posts.pre_critic_text` (nullable text), updates ORM models and their `__init__` methods.
+
+**Files:**
+- Create: `alembic/versions/<hash>_add_critic_columns.py`
+- Modify: `app/db/models.py`
+- Create: `tests/unit/test_critic_columns.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_critic_columns.py`:
+
+```python
+"""Tests for critic DB columns on Channel and ChannelPost."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from app.core.enums import PostStatus
+from app.db.models import Channel, ChannelPost
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_channel_critic_enabled_default_none(session_maker):
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-1001, name="X")
+        session.add(ch)
+        await session.commit()
+        await session.refresh(ch)
+        assert ch.critic_enabled is None
+
+
+async def test_channel_critic_enabled_roundtrip(session_maker):
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-1002, name="X", critic_enabled=True)
+        session.add(ch)
+        await session.commit()
+        cid = ch.id
+
+    async with session_maker() as session:
+        row = (await session.execute(select(Channel).where(Channel.id == cid))).scalar_one()
+    assert row.critic_enabled is True
+
+
+async def test_channel_critic_enabled_explicit_false(session_maker):
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-1003, name="X", critic_enabled=False)
+        session.add(ch)
+        await session.commit()
+        cid = ch.id
+
+    async with session_maker() as session:
+        row = (await session.execute(select(Channel).where(Channel.id == cid))).scalar_one()
+    assert row.critic_enabled is False
+
+
+async def test_channel_post_pre_critic_text_default_none(session_maker):
+    async with session_maker() as session:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="x",
+            title="t",
+            post_text="b",
+            status=PostStatus.DRAFT,
+        )
+        session.add(p)
+        await session.commit()
+        await session.refresh(p)
+        assert p.pre_critic_text is None
+
+
+async def test_channel_post_pre_critic_text_roundtrip(session_maker):
+    async with session_maker() as session:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="y",
+            title="t",
+            post_text="new",
+            status=PostStatus.DRAFT,
+            pre_critic_text="original pre-critic text with **bold**",
+        )
+        session.add(p)
+        await session.commit()
+        pid = p.id
+
+    async with session_maker() as session:
+        row = (await session.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+    assert row.pre_critic_text == "original pre-critic text with **bold**"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_critic_columns.py -v`
+Expected: FAIL — `critic_enabled` / `pre_critic_text` unknown kwarg / attribute.
+
+- [ ] **Step 3: Add `critic_enabled` to `Channel`**
+
+In `app/db/models.py`, inside `class Channel`, add the column declaration next to `enabled` (around line 273):
+
+```python
+    critic_enabled: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+```
+
+Update `Channel.__init__` signature (around line 279-306) to accept and assign it:
+
+```python
+    def __init__(
+        self,
+        telegram_id: int,
+        name: str,
+        description: str = "",
+        language: str = "ru",
+        review_chat_id: int | None = None,
+        max_posts_per_day: int = 3,
+        posting_schedule: list[str] | None = None,
+        discovery_query: str = "",
+        source_discovery_query: str = "",
+        username: str | None = None,
+        footer_template: str | None = None,
+        enabled: bool = True,
+        critic_enabled: bool | None = None,
+    ) -> None:
+        self.telegram_id = telegram_id
+        self.name = name
+        self.description = description
+        self.language = language
+        self.review_chat_id = review_chat_id
+        self.max_posts_per_day = max_posts_per_day
+        self.posting_schedule = posting_schedule
+        self.discovery_query = discovery_query
+        self.source_discovery_query = source_discovery_query
+        self.username = username
+        self.footer_template = footer_template
+        self.enabled = enabled
+        self.critic_enabled = critic_enabled
+```
+
+- [ ] **Step 4: Add `pre_critic_text` to `ChannelPost`**
+
+In `app/db/models.py`, inside `class ChannelPost`, add the column declaration near `admin_feedback` (around line 415):
+
+```python
+    pre_critic_text: Mapped[str | None] = mapped_column(String, nullable=True)
+```
+
+Update `ChannelPost.__init__` signature (around line 425-462) to accept `pre_critic_text`:
+
+```python
+    def __init__(
+        self,
+        channel_id: int,
+        external_id: str,
+        title: str,
+        post_text: str,
+        source_url: str | None = None,
+        source_items: list[dict[str, Any]] | None = None,
+        telegram_message_id: int | None = None,
+        review_message_id: int | None = None,
+        review_chat_id: int | None = None,
+        review_album_message_ids: list[int] | None = None,
+        image_url: str | None = None,
+        image_urls: list[str] | None = None,
+        image_candidates: list[dict[str, Any]] | None = None,
+        image_phashes: list[str] | None = None,
+        status: str = PostStatus.DRAFT,
+        embedding: Any | None = None,
+        embedding_model: str | None = None,
+        pre_critic_text: str | None = None,
+    ) -> None:
+        self.channel_id = channel_id
+        self.external_id = external_id
+        self.title = title
+        self.post_text = post_text
+        self.source_url = source_url
+        self.source_items = source_items
+        self.telegram_message_id = telegram_message_id
+        self.review_message_id = review_message_id
+        self.review_chat_id = review_chat_id
+        self.image_url = image_url
+        self.image_urls = image_urls
+        self.image_candidates = image_candidates
+        self.image_phashes = image_phashes
+        self.status = status
+        self.reply_chain_message_ids: list[int] | None = None
+        self.review_album_message_ids = review_album_message_ids
+        self.embedding = embedding
+        self.embedding_model = embedding_model
+        self.pre_critic_text = pre_critic_text
+```
+
+- [ ] **Step 5: Generate the Alembic migration**
+
+Run: `uv run alembic revision --autogenerate -m "add critic_enabled and pre_critic_text"`
+
+This writes a file like `alembic/versions/<hash>_add_critic_enabled_and_pre_critic_text.py`. Open that file and verify its `upgrade()` contains exactly these two operations and nothing else (if autogenerate pulls in unrelated drift — which has happened before on this repo — edit the file to keep only the two operations):
+
+```python
+def upgrade() -> None:
+    op.add_column("channels", sa.Column("critic_enabled", sa.Boolean(), nullable=True))
+    op.add_column("channel_posts", sa.Column("pre_critic_text", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("channel_posts", "pre_critic_text")
+    op.drop_column("channels", "critic_enabled")
+```
+
+Ensure `down_revision` points to the current head `"21c84750b5db"`. Autogenerate fills this in automatically.
+
+- [ ] **Step 6: Run the test suite to verify the migration and columns**
+
+Run: `uv run -m pytest tests/unit/test_critic_columns.py -v`
+Expected: 5 passed.
+
+Additionally sanity-check by running the broader ORM test file so we catch regressions in the model `__init__` signatures:
+
+Run: `uv run -m pytest tests/unit -k "channel" -v`
+Expected: all existing channel-related tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/db/models.py alembic/versions tests/unit/test_critic_columns.py
+git commit -m "feat(critic): add critic_enabled + pre_critic_text columns"
+```
+
+---
+
+## Task 3: Add `pre_critic_text` to `GeneratedPost`
+
+The pydantic model used by the generator needs a field to carry the original text through the pipeline.
+
+**Files:**
+- Modify: `app/channel/generator.py` (lines 64-77 — `class GeneratedPost`)
+- Test: `tests/unit/test_critic_columns.py` (adding a small assertion; no new file)
+
+- [ ] **Step 1: Write a failing test**
+
+Append to `tests/unit/test_critic_columns.py`:
+
+```python
+def test_generated_post_pre_critic_text_default_none():
+    from app.channel.generator import GeneratedPost
+
+    p = GeneratedPost(text="hello")
+    assert p.pre_critic_text is None
+
+
+def test_generated_post_pre_critic_text_roundtrip():
+    from app.channel.generator import GeneratedPost
+
+    p = GeneratedPost(text="new text", pre_critic_text="original text")
+    assert p.pre_critic_text == "original text"
+
+    dumped = p.model_dump()
+    restored = GeneratedPost.model_validate(dumped)
+    assert restored.pre_critic_text == "original text"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_critic_columns.py::test_generated_post_pre_critic_text_default_none tests/unit/test_critic_columns.py::test_generated_post_pre_critic_text_roundtrip -v`
+Expected: FAIL — `pre_critic_text` not a valid field.
+
+- [ ] **Step 3: Add the field**
+
+In `app/channel/generator.py`, modify `class GeneratedPost` (around line 64) to add the field after `image_phashes`:
+
+```python
+class GeneratedPost(BaseModel):
+    """Output from the post generation agent."""
+
+    text: str = Field(description="The post text in Markdown format")
+    is_sensitive: bool = Field(default=False, description="Whether the post needs admin review")
+    image_url: str | None = Field(default=None, description="Primary image URL (backward compat)")
+    image_urls: list[str] = Field(default_factory=list, description="All image URLs for the post")
+    image_candidates: list[dict[str, Any]] | None = Field(
+        default=None, description="Full candidate pool with scores and metadata (for review agent)"
+    )
+    image_phashes: list[str] = Field(
+        default_factory=list, description="pHashes of selected images (for future cross-post dedup)"
+    )
+    pre_critic_text: str | None = Field(
+        default=None,
+        description="Post text before the critic polish pass; None when critic did not run or failed",
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_critic_columns.py -v`
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/generator.py tests/unit/test_critic_columns.py
+git commit -m "feat(critic): add pre_critic_text to GeneratedPost"
+```
+
+---
+
+## Task 4: Critic module — helpers and invariant validation
+
+Adds the structural pieces of `app/channel/critic.py`: exception, link extraction, artifact stripping, invariant validation. The actual `polish_post` lands in Task 5.
+
+**Files:**
+- Create: `app/channel/critic.py`
+- Create: `tests/unit/test_critic_invariants.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_critic_invariants.py`:
+
+```python
+"""Tests for critic helpers: link extraction, artifact stripping, invariant validation."""
+
+from __future__ import annotations
+
+from app.channel.critic import (
+    CriticError,
+    _extract_md_links,
+    _strip_agent_artifacts,
+    _validate_invariants,
+)
+
+FOOTER = "——\n🔗 **Konnekt** | @konnekt_channel"
+
+
+def test_extract_md_links_empty():
+    assert _extract_md_links("") == []
+
+
+def test_extract_md_links_none():
+    assert _extract_md_links("plain text no links") == []
+
+
+def test_extract_md_links_single():
+    out = _extract_md_links("Check [platform](https://example.com/x) today")
+    assert out == [("platform", "https://example.com/x")]
+
+
+def test_extract_md_links_multiple():
+    out = _extract_md_links("See [a](http://x/1) and [b](http://y/2)")
+    assert out == [("a", "http://x/1"), ("b", "http://y/2")]
+
+
+def test_extract_md_links_ignores_malformed():
+    assert _extract_md_links("broken [text(no close http://x)") == []
+
+
+def test_strip_agent_artifacts_clean_passthrough():
+    text = "🎓 **Headline**\n\nBody.\n\n" + FOOTER
+    assert _strip_agent_artifacts(text) == text
+
+
+def test_strip_agent_artifacts_code_fence():
+    text = "```\n🎓 **H**\n\nBody.\n```"
+    assert _strip_agent_artifacts(text) == "🎓 **H**\n\nBody."
+
+
+def test_strip_agent_artifacts_markdown_fence():
+    text = "```markdown\n🎓 **H**\n```"
+    assert _strip_agent_artifacts(text) == "🎓 **H**"
+
+
+def test_strip_agent_artifacts_prefix():
+    text = "Here's your polished version:\n\n🎓 **H**\n\nBody."
+    out = _strip_agent_artifacts(text)
+    assert out.startswith("🎓"), out
+
+
+def test_strip_agent_artifacts_surrounding_quotes():
+    text = '"🎓 **H** Body."'
+    assert _strip_agent_artifacts(text) == "🎓 **H** Body."
+
+
+def _make_polished(body: str = "Body text with [link](https://x/1).") -> str:
+    return f"🎓 **Headline**\n\n{body}\n\n{FOOTER}"
+
+
+def test_validate_invariants_all_valid():
+    original = _make_polished()
+    polished = _make_polished()
+    assert _validate_invariants(original, polished, FOOTER) == []
+
+
+def test_validate_invariants_lost_url():
+    original = _make_polished("Body with [link](https://x/1) here.")
+    polished = _make_polished("Body without the link here.")
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("lost URL" in v for v in violations), violations
+
+
+def test_validate_invariants_link_count_dropped():
+    original = f"🎓 **H**\n\n[a](http://x/1) and [b](http://y/2)\n\n{FOOTER}"
+    polished = f"🎓 **H**\n\nBoth links removed\n\n{FOOTER}"
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("link count" in v or "lost URL" in v for v in violations), violations
+
+
+def test_validate_invariants_missing_footer():
+    original = _make_polished()
+    polished = "🎓 **Headline**\n\nBody text with [link](https://x/1)."
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("footer" in v.lower() for v in violations), violations
+
+
+def test_validate_invariants_length_over_900():
+    original = _make_polished()
+    polished = "🎓 **H**\n\n" + "word " * 300 + f"\n\n{FOOTER}"
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("over 900" in v or "length" in v.lower() for v in violations), violations
+
+
+def test_validate_invariants_output_too_short():
+    original = _make_polished()
+    polished = "🎓 X"
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("too short" in v or "100" in v for v in violations), violations
+
+
+def test_validate_invariants_missing_headline_emoji():
+    original = _make_polished()
+    polished = f"**Headline**\n\nBody text with [link](https://x/1).\n\n{FOOTER}"
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("emoji" in v.lower() for v in violations), violations
+
+
+def test_validate_invariants_whitelisted_emojis_pass():
+    for emoji in ["📰", "🎓", "💼", "🎉", "🏠", "💰", "⚡"]:
+        body = f"Body text with [link](https://x/1)."
+        polished = f"{emoji} **Headline**\n\n{body}\n\n{FOOTER}"
+        assert _validate_invariants(polished, polished, FOOTER) == []
+
+
+def test_critic_error_subclass_of_domain():
+    from app.core.exceptions import DomainError
+
+    assert issubclass(CriticError, DomainError)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_critic_invariants.py -v`
+Expected: FAIL — `app.channel.critic` does not exist.
+
+- [ ] **Step 3: Create `app/channel/critic.py` with helpers**
+
+Create `app/channel/critic.py`:
+
+```python
+"""Post critic: polish pass that removes clichés while preserving facts/links/structure.
+
+Invoked from `generate_post` after length-enforcement, before the image pipeline.
+On any failure the pipeline keeps the original text (silent fallback).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from app.core.exceptions import DomainError
+from app.core.logging import get_logger
+
+if TYPE_CHECKING:
+    from app.core.config import Settings
+    from app.db.models import Channel
+
+logger = get_logger("channel.critic")
+
+
+class CriticError(DomainError):
+    """Raised when the critic pass fails after retry (invariants still violated)."""
+
+
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+# Whitelist of headline emojis used by the generation prompt. Any of these
+# at the first non-whitespace codepoint is considered a valid headline emoji.
+_HEADLINE_EMOJIS = frozenset({"📰", "🎓", "💼", "🎉", "🏠", "💰", "⚡", "✨", "🔥", "⭐"})
+
+_MIN_LENGTH = 100
+_MAX_LENGTH = 900
+
+
+def _extract_md_links(text: str) -> list[tuple[str, str]]:
+    """Return list of (label, url) pairs from Markdown links `[label](url)`."""
+    return [(m.group(1), m.group(2)) for m in _LINK_RE.finditer(text)]
+
+
+def _strip_agent_artifacts(output: str) -> str:
+    """Strip common LLM artifacts: code fences, prefix phrases, surrounding quotes.
+
+    Applied before invariant validation so benign formatting cruft doesn't
+    trigger failures.
+    """
+    text = output.strip()
+
+    # 1. Code fence (```lang ... ```), optionally with language tag.
+    fence = re.match(
+        r"^```[a-zA-Z0-9_-]*\s*\n?(.*?)\n?```$",
+        text,
+        flags=re.DOTALL,
+    )
+    if fence:
+        text = fence.group(1).strip()
+
+    # 2. Common prefix phrases like "Here's the polished version:"
+    prefix_patterns = [
+        r"^here'?s?\s+(?:the|your|a)?\s*polished\s+(?:version|post)?:?\s*\n+",
+        r"^polished\s+(?:version|post):?\s*\n+",
+        r"^here\s+is\s+(?:the|your)?\s*polished\s+(?:version|post)?:?\s*\n+",
+    ]
+    for pat in prefix_patterns:
+        text = re.sub(pat, "", text, count=1, flags=re.IGNORECASE).strip()
+
+    # 3. Surrounding quotes.
+    if len(text) >= 2 and text[0] in {'"', "'", "«", "“"} and text[-1] in {'"', "'", "»", "”"}:
+        text = text[1:-1].strip()
+
+    return text
+
+
+def _first_visible_char(text: str) -> str:
+    """Return the first non-whitespace character of `text`, or empty string."""
+    for ch in text:
+        if not ch.isspace():
+            return ch
+    return ""
+
+
+def _validate_invariants(original: str, polished: str, footer: str) -> list[str]:
+    """Return a list of human-readable violation strings. Empty list = all pass."""
+    violations: list[str] = []
+
+    orig_links = _extract_md_links(original)
+    new_links = _extract_md_links(polished)
+
+    orig_urls = {url for _, url in orig_links}
+    new_urls = {url for _, url in new_links}
+
+    missing = orig_urls - new_urls
+    for url in missing:
+        violations.append(f"lost URL: {url}")
+
+    if len(new_links) < len(orig_links):
+        violations.append(f"link count dropped: {len(orig_links)} → {len(new_links)}")
+
+    if footer and footer not in polished:
+        violations.append("footer missing")
+
+    if len(polished) > _MAX_LENGTH:
+        violations.append(f"length over 900: {len(polished)}")
+
+    if len(polished) < _MIN_LENGTH:
+        violations.append(f"output too short: {len(polished)} (min {_MIN_LENGTH})")
+
+    first = _first_visible_char(polished)
+    if first and first not in _HEADLINE_EMOJIS:
+        # Fallback: check the whole first codepoint is in the Symbol,Other
+        # Unicode category (emoji-ish). `first` is a single character from the
+        # Python string; compare its category via `unicodedata`.
+        import unicodedata
+
+        cat = unicodedata.category(first)
+        if not cat.startswith("So"):
+            violations.append(f"headline emoji missing (first char: {first!r})")
+
+    return violations
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_critic_invariants.py -v`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/critic.py tests/unit/test_critic_invariants.py
+git commit -m "feat(critic): invariant validation + link/artifact helpers"
+```
+
+---
+
+## Task 5: Critic module — `polish_post` with retry
+
+Adds the LLM call, the system prompt, and the retry-then-fail-loud-with-CriticError path.
+
+**Files:**
+- Modify: `app/channel/critic.py`
+- Create: `tests/unit/test_critic_polish.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_critic_polish.py`:
+
+```python
+"""Tests for polish_post — happy path, retry, and CriticError on persistent failure."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.channel.critic import CriticError, polish_post
+
+pytestmark = pytest.mark.asyncio
+
+FOOTER = "——\n🔗 **Konnekt** | @konnekt_channel"
+
+ORIGINAL = (
+    "🎓 **Продлили дедлайн стипендии**\n\n"
+    "ČVUT продлил приём заявок на [стипендию](https://cvut.cz/s) "
+    "до 15 мая. Подать документы можно в деканате.\n\n" + FOOTER
+)
+
+POLISHED_OK = (
+    "🎓 **Дедлайн стипендии ČVUT перенесли**\n\n"
+    "ČVUT принимает заявки на [стипендию](https://cvut.cz/s) до 15 мая. "
+    "Документы — в деканате.\n\n" + FOOTER
+)
+
+POLISHED_MISSING_FOOTER = (
+    "🎓 **Дедлайн стипендии ČVUT перенесли**\n\n"
+    "ČVUT принимает заявки на [стипендию](https://cvut.cz/s) до 15 мая."
+)
+
+
+def _fake_run_result(output: str):
+    """Build an object shaped like a PydanticAI RunResult for our purposes."""
+    return SimpleNamespace(output=output)
+
+
+async def test_polish_post_success():
+    fake_agent = SimpleNamespace(run=AsyncMock(return_value=_fake_run_result(POLISHED_OK)))
+    with (
+        patch("app.channel.critic._create_critic_agent", return_value=fake_agent),
+        patch("app.channel.critic.extract_usage_from_pydanticai_result", return_value=None),
+    ):
+        out = await polish_post(
+            text=ORIGINAL, footer=FOOTER, api_key="k", model="anthropic/claude-sonnet-4-6"
+        )
+    assert out == POLISHED_OK
+    assert fake_agent.run.await_count == 1
+
+
+async def test_polish_post_retry_then_success():
+    fake_agent = SimpleNamespace(
+        run=AsyncMock(
+            side_effect=[
+                _fake_run_result(POLISHED_MISSING_FOOTER),  # first call — violates footer
+                _fake_run_result(POLISHED_OK),  # retry — ok
+            ]
+        )
+    )
+    with (
+        patch("app.channel.critic._create_critic_agent", return_value=fake_agent),
+        patch("app.channel.critic.extract_usage_from_pydanticai_result", return_value=None),
+    ):
+        out = await polish_post(
+            text=ORIGINAL, footer=FOOTER, api_key="k", model="anthropic/claude-sonnet-4-6"
+        )
+    assert out == POLISHED_OK
+    assert fake_agent.run.await_count == 2
+
+
+async def test_polish_post_fails_after_retry():
+    fake_agent = SimpleNamespace(
+        run=AsyncMock(
+            side_effect=[
+                _fake_run_result(POLISHED_MISSING_FOOTER),
+                _fake_run_result(POLISHED_MISSING_FOOTER),
+            ]
+        )
+    )
+    with (
+        patch("app.channel.critic._create_critic_agent", return_value=fake_agent),
+        patch("app.channel.critic.extract_usage_from_pydanticai_result", return_value=None),
+    ):
+        with pytest.raises(CriticError) as exc_info:
+            await polish_post(
+                text=ORIGINAL, footer=FOOTER, api_key="k", model="anthropic/claude-sonnet-4-6"
+            )
+    assert "footer" in str(exc_info.value).lower()
+    assert fake_agent.run.await_count == 2
+
+
+async def test_polish_post_raises_on_llm_exception():
+    fake_agent = SimpleNamespace(run=AsyncMock(side_effect=RuntimeError("openrouter 500")))
+    with (
+        patch("app.channel.critic._create_critic_agent", return_value=fake_agent),
+        patch("app.channel.critic.extract_usage_from_pydanticai_result", return_value=None),
+    ):
+        with pytest.raises(CriticError):
+            await polish_post(
+                text=ORIGINAL, footer=FOOTER, api_key="k", model="anthropic/claude-sonnet-4-6"
+            )
+
+
+async def test_polish_post_logs_usage_per_call():
+    fake_agent = SimpleNamespace(
+        run=AsyncMock(
+            side_effect=[
+                _fake_run_result(POLISHED_MISSING_FOOTER),
+                _fake_run_result(POLISHED_OK),
+            ]
+        )
+    )
+    extract_mock = AsyncMock(return_value=None)
+    log_mock = AsyncMock()
+    with (
+        patch("app.channel.critic._create_critic_agent", return_value=fake_agent),
+        patch("app.channel.critic.extract_usage_from_pydanticai_result", side_effect=extract_mock),
+        patch("app.channel.critic.log_usage", log_mock),
+    ):
+        await polish_post(
+            text=ORIGINAL, footer=FOOTER, api_key="k", model="anthropic/claude-sonnet-4-6"
+        )
+
+    # Two calls → two extract attempts, one per operation value.
+    operations = [call.args[2] for call in extract_mock.await_args_list]
+    assert operations == ["critic", "critic_retry"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_critic_polish.py -v`
+Expected: FAIL — `polish_post`/`_create_critic_agent` missing.
+
+- [ ] **Step 3: Extend `app/channel/critic.py` with prompt, agent, polish_post**
+
+Append to `app/channel/critic.py`:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from app.channel.cost_tracker import extract_usage_from_pydanticai_result, log_usage
+from app.core.config import settings
+
+
+CRITIC_PROMPT = """\
+You are a ruthless style editor for the Telegram channel "Konnekt"
+(news for CIS students in the Czech Republic). Your ONLY job: polish a
+post by removing clichés, banal openers, dead verbs, and pompous or
+corporate phrasing.
+
+HARD RULES — violation = task failed:
+1. PRESERVE every Markdown link [text](url) — same URLs, same count.
+2. PRESERVE the exact footer at the end: {footer}
+3. PRESERVE facts: numbers, dates, names, institutions, prices, addresses.
+4. PRESERVE structure: same paragraph breaks, same order, same headline
+   emoji at the very start.
+5. Output MUST be <= 900 characters total.
+6. Do NOT add new information. Do NOT invent details, numbers, or names.
+
+WHAT TO FIX:
+- Banned phrases: "это отличная/уникальная возможность",
+  "не упустите шанс", "лично расспросить", "рады сообщить",
+  "с гордостью представляем", "Ознакомиться можно...",
+  "Подробнее здесь...", "Узнать больше..."
+- Banal openers: "У нас отличная новость", "Есть хорошая новость для
+  вас", "Хотим поделиться..."
+- Dead verbs: "предоставляем", "сообщаем", "уведомляем" — replace with
+  the concrete action.
+- Pompous / corporate tone → friendly, peer-to-peer student tone.
+- Filler adjectives: "уникальный", "незабываемый", "эксклюзивный".
+
+TONE: simple, slightly witty, like telling a friend about news. At
+most one exclamation mark per post.
+
+OUTPUT: return ONLY the polished post text. No explanations, no
+"Here's your polished version:", no markdown code fences. Plain
+polished post.
+"""
+
+_RETRY_HINT = (
+    "Your previous rewrite violated hard rules. Fix the violations and "
+    "return ONLY the polished post text.\n"
+    "You MUST preserve every link [text](url), the exact footer, the "
+    "headline emoji, and keep the total length <= 900 characters.\n"
+)
+
+
+def _create_critic_agent(api_key: str, model: str, *, footer: str) -> Agent[None, str]:
+    """Build the PydanticAI agent for the critic pass."""
+    provider = OpenAIProvider(base_url=settings.openrouter.base_url, api_key=api_key)
+    llm = OpenAIChatModel(model_name=model, provider=provider)
+    prompt = CRITIC_PROMPT.format(footer=footer)
+    return Agent(llm, system_prompt=prompt, output_type=str, model_settings={"temperature": 0.4})
+
+
+async def polish_post(
+    *,
+    text: str,
+    footer: str,
+    api_key: str,
+    model: str,
+) -> str:
+    """Run the critic pass on `text`. Returns polished text or raises CriticError.
+
+    Makes at most two LLM calls: the main polish, plus one retry if the
+    first result violates invariants. On any exception (LLM error, retry
+    still violates), raises CriticError so the caller can fall back.
+    """
+    agent = _create_critic_agent(api_key, model, footer=footer)
+
+    try:
+        result = await agent.run(text)
+    except Exception as exc:
+        raise CriticError(f"first call failed: {exc}") from exc
+
+    usage = extract_usage_from_pydanticai_result(result, model, "critic")
+    if usage:
+        await log_usage(usage)
+
+    polished = _strip_agent_artifacts(result.output)
+    violations = _validate_invariants(text, polished, footer)
+    if not violations:
+        return polished
+
+    logger.info("critic_retry", violations=violations)
+
+    retry_prompt = (
+        f"{_RETRY_HINT}"
+        f"Previous violations: {', '.join(violations)}\n\n"
+        f"Original post (rewrite this):\n{text}"
+    )
+
+    try:
+        result = await agent.run(retry_prompt)
+    except Exception as exc:
+        raise CriticError(f"retry call failed: {exc}") from exc
+
+    usage = extract_usage_from_pydanticai_result(result, model, "critic_retry")
+    if usage:
+        await log_usage(usage)
+
+    polished = _strip_agent_artifacts(result.output)
+    violations = _validate_invariants(text, polished, footer)
+    if not violations:
+        return polished
+
+    raise CriticError(f"invariants violated after retry: {violations}")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_critic_polish.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/critic.py tests/unit/test_critic_polish.py
+git commit -m "feat(critic): polish_post with retry and usage tracking"
+```
+
+---
+
+## Task 6: `resolve_critic_enabled` helper
+
+Adds the per-channel-override-then-global resolver.
+
+**Files:**
+- Modify: `app/channel/critic.py`
+- Create: `tests/unit/test_critic_resolve.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_critic_resolve.py`:
+
+```python
+"""Tests for resolve_critic_enabled — per-channel-override-then-global."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.channel.critic import resolve_critic_enabled
+
+
+def _mk_channel(critic_enabled):
+    return SimpleNamespace(critic_enabled=critic_enabled)
+
+
+def _mk_settings(global_enabled: bool):
+    return SimpleNamespace(channel=SimpleNamespace(critic_enabled=global_enabled))
+
+
+@pytest.mark.parametrize(
+    "channel_val,global_val,expected",
+    [
+        (None, False, False),
+        (None, True, True),
+        (True, False, True),
+        (True, True, True),
+        (False, False, False),
+        (False, True, False),
+    ],
+)
+def test_resolve_critic_enabled_matrix(channel_val, global_val, expected):
+    assert (
+        resolve_critic_enabled(_mk_channel(channel_val), _mk_settings(global_val))
+        is expected
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_critic_resolve.py -v`
+Expected: FAIL — `resolve_critic_enabled` missing.
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `app/channel/critic.py`:
+
+```python
+def resolve_critic_enabled(channel: "Channel", settings_obj: "Settings") -> bool:
+    """Resolve the effective critic-enabled flag.
+
+    Per-channel value wins when set (True/False). None falls back to
+    `settings.channel.critic_enabled`.
+    """
+    if channel.critic_enabled is not None:
+        return channel.critic_enabled
+    return settings_obj.channel.critic_enabled
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_critic_resolve.py -v`
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/critic.py tests/unit/test_critic_resolve.py
+git commit -m "feat(critic): resolve_critic_enabled helper"
+```
+
+---
+
+## Task 7: Integrate critic into `generate_post`
+
+New kwargs on `generate_post()` and the actual call site between length-enforcement and the image pipeline.
+
+**Files:**
+- Modify: `app/channel/generator.py`
+- Create: `tests/integration/test_generator_with_critic.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/integration/test_generator_with_critic.py`:
+
+```python
+"""Tests for critic integration inside generate_post."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.channel.generator import generate_post
+from app.channel.sources import ContentItem
+
+pytestmark = pytest.mark.asyncio
+
+
+FOOTER = "——\n🔗 **Konnekt** | @konnekt_channel"
+RAW_TEXT = f"🎓 **Headline**\n\nBody with [link](https://x/1) text.\n\n{FOOTER}"
+POLISHED_TEXT = f"🎓 **Tighter Headline**\n\nBody with [link](https://x/1) text.\n\n{FOOTER}"
+
+
+def _fake_generation_result(text: str):
+    from types import SimpleNamespace
+
+    from app.channel.generator import GeneratedPost
+
+    return SimpleNamespace(output=GeneratedPost(text=text))
+
+
+@pytest.fixture
+def _item() -> list[ContentItem]:
+    return [
+        ContentItem(
+            source_url="https://rss/x",
+            external_id="abc",
+            title="Headline",
+            body="Body",
+            url="https://x/1",
+        )
+    ]
+
+
+async def test_generate_post_applies_critic_when_enabled(_item):
+    with (
+        patch(
+            "app.channel.generator._create_generation_agent",
+            return_value=__import__("types").SimpleNamespace(
+                run=AsyncMock(return_value=_fake_generation_result(RAW_TEXT))
+            ),
+        ),
+        patch(
+            "app.channel.generator.extract_usage_from_pydanticai_result",
+            return_value=None,
+        ),
+        patch(
+            "app.channel.critic.polish_post",
+            new=AsyncMock(return_value=POLISHED_TEXT),
+        ),
+    ):
+        out = await generate_post(
+            _item,
+            api_key="k",
+            model="m",
+            footer=FOOTER,
+            critic_enabled=True,
+            critic_model="anthropic/claude-sonnet-4-6",
+        )
+    assert out is not None
+    assert out.text == POLISHED_TEXT
+    assert out.pre_critic_text == RAW_TEXT
+
+
+async def test_generate_post_no_critic_when_disabled(_item):
+    with (
+        patch(
+            "app.channel.generator._create_generation_agent",
+            return_value=__import__("types").SimpleNamespace(
+                run=AsyncMock(return_value=_fake_generation_result(RAW_TEXT))
+            ),
+        ),
+        patch(
+            "app.channel.generator.extract_usage_from_pydanticai_result",
+            return_value=None,
+        ),
+        patch("app.channel.critic.polish_post", new=AsyncMock()) as polish_mock,
+    ):
+        out = await generate_post(
+            _item,
+            api_key="k",
+            model="m",
+            footer=FOOTER,
+            critic_enabled=False,
+            critic_model="anthropic/claude-sonnet-4-6",
+        )
+    assert out is not None
+    assert out.text == RAW_TEXT
+    assert out.pre_critic_text is None
+    polish_mock.assert_not_awaited()
+
+
+async def test_generate_post_no_critic_when_model_empty(_item):
+    with (
+        patch(
+            "app.channel.generator._create_generation_agent",
+            return_value=__import__("types").SimpleNamespace(
+                run=AsyncMock(return_value=_fake_generation_result(RAW_TEXT))
+            ),
+        ),
+        patch(
+            "app.channel.generator.extract_usage_from_pydanticai_result",
+            return_value=None,
+        ),
+        patch("app.channel.critic.polish_post", new=AsyncMock()) as polish_mock,
+    ):
+        out = await generate_post(
+            _item,
+            api_key="k",
+            model="m",
+            footer=FOOTER,
+            critic_enabled=True,
+            critic_model="",
+        )
+    assert out is not None
+    assert out.text == RAW_TEXT
+    assert out.pre_critic_text is None
+    polish_mock.assert_not_awaited()
+
+
+async def test_generate_post_silent_fallback_on_critic_error(_item):
+    from app.channel.critic import CriticError
+
+    with (
+        patch(
+            "app.channel.generator._create_generation_agent",
+            return_value=__import__("types").SimpleNamespace(
+                run=AsyncMock(return_value=_fake_generation_result(RAW_TEXT))
+            ),
+        ),
+        patch(
+            "app.channel.generator.extract_usage_from_pydanticai_result",
+            return_value=None,
+        ),
+        patch(
+            "app.channel.critic.polish_post",
+            new=AsyncMock(side_effect=CriticError("nope")),
+        ),
+    ):
+        out = await generate_post(
+            _item,
+            api_key="k",
+            model="m",
+            footer=FOOTER,
+            critic_enabled=True,
+            critic_model="anthropic/claude-sonnet-4-6",
+        )
+    assert out is not None
+    assert out.text == RAW_TEXT
+    assert out.pre_critic_text is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/integration/test_generator_with_critic.py -v`
+Expected: FAIL — `critic_enabled` unknown kwarg.
+
+- [ ] **Step 3: Add kwargs and call site**
+
+In `app/channel/generator.py`, update `generate_post` signature (around line 323-338) to add two kwargs at the end:
+
+```python
+async def generate_post(
+    items: list[ContentItem],
+    api_key: str,
+    model: str,
+    language: str = "Russian",
+    feedback_context: str | None = None,
+    footer: str = "",
+    *,
+    channel_name: str = "",
+    channel_context: str = "",
+    channel_id: int | None = None,
+    session_maker: async_sessionmaker[AsyncSession] | None = None,
+    vision_model: str = "",
+    phash_threshold: int = 10,
+    phash_lookback: int = 30,
+    critic_enabled: bool = False,
+    critic_model: str = "",
+) -> GeneratedPost | None:
+```
+
+Insert the critic block **after** `enforce_footer_and_length` and the shorten-retry block (which ends around line 398), **before** the image pipeline. The exact insertion point is right after the final `post.text = enforce_footer_and_length(post.text, footer, max_length=900)` inside the `if len(post.text) > 900` block. To keep the critic unconditional of the length retry, place it after the whole `if len(post.text) > 900:` block closes and before `# Resolve images: ...`. Concretely:
+
+```python
+        # Critic polish pass — best-effort. Silent fallback on failure.
+        if critic_enabled and critic_model:
+            try:
+                from app.channel.critic import CriticError, polish_post
+
+                original_text = post.text
+                polished = await polish_post(
+                    text=original_text,
+                    footer=footer,
+                    api_key=api_key,
+                    model=critic_model,
+                )
+                post.pre_critic_text = original_text
+                post.text = polished
+                logger.info(
+                    "critic_applied",
+                    orig_len=len(original_text),
+                    new_len=len(polished),
+                )
+            except CriticError as exc:
+                logger.warning("critic_failed_fallback", reason=str(exc))
+            except Exception:
+                logger.exception("critic_unexpected_error")
+
+        # Resolve images: new pipeline — filter, score, dedup, compose.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/integration/test_generator_with_critic.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/generator.py tests/integration/test_generator_with_critic.py
+git commit -m "feat(critic): wire polish_post into generate_post"
+```
+
+---
+
+## Task 8: Workflow wiring + persist `pre_critic_text`
+
+Resolves flags inside the Burr `generate_post` action and passes them to the generator. Also updates `create_review_post` to persist `pre_critic_text` on the `ChannelPost` row.
+
+**Files:**
+- Modify: `app/channel/workflow.py`
+- Modify: `app/channel/review/service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_workflow_critic_wiring.py`:
+
+```python
+"""Tests that workflow.generate_post resolves and passes critic flags."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.channel.workflow import generate_post as wf_generate
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Channel(SimpleNamespace):
+    pass
+
+
+async def _make_state():
+    channel = _Channel(
+        id=1,
+        telegram_id=-100,
+        name="X",
+        language="ru",
+        footer="——\n🔗 **Konnekt** | @konnekt_channel",
+        footer_template=None,
+        username="konnekt_channel",
+        discovery_query="",
+        critic_enabled=True,  # per-channel override
+    )
+    config = SimpleNamespace(
+        generation_model="gen-model",
+        vision_model="vis-model",
+        image_phash_threshold=10,
+        image_phash_lookback_posts=30,
+        screening_model="sc",
+        http_timeout=30,
+        temperature=0.3,
+        embedding_model="emb",
+        semantic_dedup_threshold=0.9,
+        dedup_lookback_days=30,
+        dedup_query_snippet_chars=200,
+        critic_enabled=False,  # global — ignored because channel is True
+        critic_model="anthropic/claude-sonnet-4-6",
+    )
+
+    return {
+        "relevant_items": [
+            SimpleNamespace(title="T", body="B", url="https://x/1", source_url="https://rss", external_id="e")
+        ],
+        "api_key": "k",
+        "config": config,
+        "channel": channel,
+        "channel_id": 1,
+        "session_maker": AsyncMock(),
+    }
+
+
+async def test_workflow_generate_passes_critic_flags():
+    state = await _make_state()
+
+    from types import SimpleNamespace as SN
+
+    fake_state = SN(
+        __getitem__=lambda self, k: state[k],
+        update=lambda **kw: SN(__getitem__=lambda self, k: {**state, **kw}.get(k)),
+    )
+    # Use a simple dict-based stub instead of the Burr State object.
+    class _State(dict):
+        def update(self, **kw):
+            new = _State(self)
+            new.update_raw(kw)
+            return new
+
+        def update_raw(self, kw):
+            for k, v in kw.items():
+                dict.__setitem__(self, k, v)
+
+    s = _State(state)
+
+    captured: dict = {}
+
+    async def fake_generate(items, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            text="🎓 **H**\n\nB [l](https://x/1)\n\n" + state["channel"].footer,
+            pre_critic_text=None,
+            image_urls=[],
+            image_url=None,
+            image_candidates=None,
+            image_phashes=[],
+            model_dump=lambda: {"text": "x"},
+        )
+
+    async def fake_find_nearest_posts(*args, **kwargs):
+        return []
+
+    async def fake_feedback(**kwargs):
+        return None
+
+    with (
+        patch("app.channel.generator.generate_post", new=fake_generate),
+        patch("app.channel.semantic_dedup.find_nearest_posts", new=fake_find_nearest_posts),
+        patch("app.channel.feedback.get_feedback_summary", new=fake_feedback),
+    ):
+        await wf_generate(s)
+
+    assert captured["critic_enabled"] is True
+    assert captured["critic_model"] == "anthropic/claude-sonnet-4-6"
+
+
+async def test_workflow_generate_channel_none_uses_global():
+    state = await _make_state()
+    state["channel"].critic_enabled = None  # fall back to global
+    state["config"].critic_enabled = True
+
+    class _State(dict):
+        def update(self, **kw):
+            new = _State(self)
+            for k, v in kw.items():
+                dict.__setitem__(new, k, v)
+            return new
+
+    s = _State(state)
+
+    captured: dict = {}
+
+    async def fake_generate(items, **kwargs):
+        captured.update(kwargs)
+        from types import SimpleNamespace as SN
+
+        return SN(
+            text="🎓 **H**\n\n\n\n" + state["channel"].footer,
+            pre_critic_text=None,
+            image_urls=[],
+            image_url=None,
+            image_candidates=None,
+            image_phashes=[],
+            model_dump=lambda: {"text": "x"},
+        )
+
+    async def fake_find(*args, **kwargs):
+        return []
+
+    async def fake_feedback(**kwargs):
+        return None
+
+    with (
+        patch("app.channel.generator.generate_post", new=fake_generate),
+        patch("app.channel.semantic_dedup.find_nearest_posts", new=fake_find),
+        patch("app.channel.feedback.get_feedback_summary", new=fake_feedback),
+    ):
+        await wf_generate(s)
+
+    assert captured["critic_enabled"] is True
+```
+
+For `create_review_post` persistence, add a test in the same file:
+
+```python
+async def test_create_review_post_persists_pre_critic_text(session_maker):
+    from sqlalchemy import select
+
+    from app.channel.generator import GeneratedPost
+    from app.channel.review.service import create_review_post
+    from app.channel.sources import ContentItem
+    from app.db.models import ChannelPost
+
+    post = GeneratedPost(
+        text="🎓 **H**\n\nB [l](https://x/1)\n\n——\n🔗 **K** | @c",
+        pre_critic_text="🎓 **Original**\n\nOrig body\n\n——\n🔗 **K** | @c",
+    )
+    item = ContentItem(
+        source_url="https://rss",
+        external_id="e1",
+        title="T",
+        body="B",
+        url="https://x/1",
+    )
+    async with session_maker() as session:
+        cp = await create_review_post(
+            channel_id=-100,
+            post=post,
+            source_items=[item],
+            review_chat_id=-200,
+            session=session,
+        )
+        await session.commit()
+    assert cp is not None
+    async with session_maker() as session:
+        row = (await session.execute(select(ChannelPost).where(ChannelPost.id == cp.id))).scalar_one()
+    assert row.pre_critic_text.startswith("🎓 **Original**")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_workflow_critic_wiring.py -v`
+Expected: FAIL — `create_review_post` ignores `pre_critic_text`; workflow doesn't pass kwargs.
+
+- [ ] **Step 3: Patch `app/channel/workflow.py::generate_post`**
+
+In `app/channel/workflow.py`, modify the `_generate(...)` call (around line 348) to resolve and pass the critic flags. Add the resolution just above the `_generate` call:
+
+```python
+    from app.channel.critic import resolve_critic_enabled
+    from app.core.config import settings as _settings
+
+    critic_enabled = resolve_critic_enabled(channel, _settings)
+    critic_model = config.critic_model
+
+    try:
+        post = await _generate(
+            relevant[:1],
+            api_key=api_key,
+            model=config.generation_model,
+            language=language,
+            feedback_context=feedback_context,
+            footer=footer,
+            channel_name=channel.name,
+            channel_context=channel_context,
+            channel_id=channel_id,
+            session_maker=session_maker,
+            vision_model=config.vision_model,
+            phash_threshold=config.image_phash_threshold,
+            phash_lookback=config.image_phash_lookback_posts,
+            critic_enabled=critic_enabled,
+            critic_model=critic_model,
+        )
+```
+
+- [ ] **Step 4: Patch `create_review_post` to persist `pre_critic_text`**
+
+In `app/channel/review/service.py`, update the `ChannelPost(...)` constructor call inside `create_review_post` (around line 135-146) to include `pre_critic_text`:
+
+```python
+    db_post = ChannelPost(
+        channel_id=channel_id,
+        external_id=ext_id,
+        title=source_items[0].title[:REVIEW_TITLE_MAX_CHARS] if source_items else "Generated post",
+        post_text=post.text,
+        image_url=post.image_url,
+        image_urls=post.image_urls or None,
+        image_candidates=post.image_candidates,
+        image_phashes=post.image_phashes or None,
+        source_items=source_data,
+        review_chat_id=int(review_chat_id) if review_chat_id else 0,
+        pre_critic_text=post.pre_critic_text,
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_workflow_critic_wiring.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/channel/workflow.py app/channel/review/service.py tests/unit/test_workflow_critic_wiring.py
+git commit -m "feat(critic): resolve flags in workflow + persist pre_critic_text"
+```
+
+---
+
+## Task 9: Review regen path wiring
+
+The review service `regen_post_text` path calls `generate_post` again to produce a new draft. Thread critic flags through and copy `pre_critic_text` onto the persisted row.
+
+**Files:**
+- Modify: `app/channel/review/service.py` (regen path around line 482-506)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/unit/test_workflow_critic_wiring.py`:
+
+```python
+async def test_regen_post_text_threads_critic_and_persists(session_maker, monkeypatch):
+    """regen_post_text must pass critic flags to generate_post and save pre_critic_text."""
+    from app.channel.review.service import regen_post_text
+    from app.core.enums import PostStatus
+    from app.db.models import Channel, ChannelPost
+
+    async with session_maker() as session:
+        ch = Channel(
+            telegram_id=-100,
+            name="X",
+            username="konnekt_channel",
+            footer_template="——\n🔗 **K** | @c",
+            critic_enabled=True,
+        )
+        session.add(ch)
+        await session.flush()
+        p = ChannelPost(
+            channel_id=ch.telegram_id,
+            external_id="e",
+            title="t",
+            post_text="old",
+            status=PostStatus.DRAFT,
+            source_items=[
+                {"title": "T", "url": "https://x/1", "source_url": "https://rss", "external_id": "e"}
+            ],
+        )
+        session.add(p)
+        await session.commit()
+        pid = p.id
+
+    captured_kwargs: dict = {}
+
+    async def fake_generate(items, **kwargs):
+        from types import SimpleNamespace as SN
+
+        captured_kwargs.update(kwargs)
+        return SN(
+            text="🎓 **New**\n\nBody [l](https://x/1)\n\n——\n🔗 **K** | @c",
+            pre_critic_text="🎓 **Original**\n\nBody [l](https://x/1)\n\n——\n🔗 **K** | @c",
+            image_urls=[],
+            image_url=None,
+            image_candidates=None,
+            image_phashes=[],
+        )
+
+    # The regen path uses `from app.channel.generator import generate_post`
+    # (local import inside regen_post_text). Patch at the module source so the
+    # subsequent local import binds to the fake.
+    monkeypatch.setattr("app.channel.generator.generate_post", fake_generate)
+
+    msg, post = await regen_post_text(
+        session_maker=session_maker,
+        post_id=pid,
+        api_key="k",
+        model="gen-m",
+        language="Russian",
+        footer="——\n🔗 **K** | @c",
+    )
+    assert post is not None
+    assert captured_kwargs.get("critic_enabled") is True
+    assert captured_kwargs.get("critic_model") == "anthropic/claude-sonnet-4-6"
+
+    from sqlalchemy import select
+
+    async with session_maker() as session:
+        row = (await session.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+    assert row.pre_critic_text.startswith("🎓 **Original**")
+```
+
+Note: the test assumes `regen_post_text` exposes a signature compatible with these kwargs. Before running, inspect the existing signature and adjust test kwargs to match it exactly. The test is a **spec** — implementation follows.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_workflow_critic_wiring.py::test_regen_post_text_threads_critic_and_persists -v`
+Expected: FAIL — either wrong signature or `pre_critic_text` not persisted.
+
+- [ ] **Step 3: Patch the regen path**
+
+In `app/channel/review/service.py` (around line 480-506), change the regen call site to resolve + pass critic flags and persist `pre_critic_text`:
+
+```python
+        from app.channel.critic import resolve_critic_enabled
+        from app.core.config import settings
+
+        # `post.channel_id` is the telegram id of the channel. Load the Channel row
+        # to resolve the per-channel override. If not found, fall back to global.
+        from sqlalchemy import select
+
+        from app.db.models import Channel
+
+        ch_row = (
+            await session.execute(select(Channel).where(Channel.telegram_id == post.channel_id))
+        ).scalar_one_or_none()
+        if ch_row is not None:
+            critic_enabled = resolve_critic_enabled(ch_row, settings)
+        else:
+            critic_enabled = settings.channel.critic_enabled
+        critic_model = settings.channel.critic_model
+
+        new_post = await generate_post(
+            items,
+            api_key=api_key,
+            model=model,
+            language=language,
+            footer=footer,
+            channel_id=post.channel_id,
+            session_maker=session_maker,
+            vision_model=settings.channel.vision_model,
+            phash_threshold=settings.channel.image_phash_threshold,
+            phash_lookback=settings.channel.image_phash_lookback_posts,
+            critic_enabled=critic_enabled,
+            critic_model=critic_model,
+        )
+        if not new_post:
+            return "Regeneration failed.", None
+
+        post.update_text(new_post.text)
+        post.pre_critic_text = new_post.pre_critic_text
+        # Also refresh image fields from the new pipeline run — otherwise the
+        # post's text and image pool diverge (old images stay attached to new text).
+        post.image_url = new_post.image_url
+        post.image_urls = new_post.image_urls or None
+        post.image_candidates = new_post.image_candidates
+        post.image_phashes = new_post.image_phashes or None
+        await session.commit()
+```
+
+(If the existing code already imports `settings` once above, reuse that import rather than re-importing; otherwise this snippet works standalone.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_workflow_critic_wiring.py -v`
+Expected: all prior tests + new regen test pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/channel/review/service.py tests/unit/test_workflow_critic_wiring.py
+git commit -m "feat(critic): thread flags + persist pre_critic_text on regen path"
+```
+
+---
+
+## Task 10: Assistant bot `set_channel_critic` tool
+
+User-facing control: flip per-channel critic override without touching SQL. Mirrors `edit_channel` but narrower (one field, accepts None).
+
+**Files:**
+- Modify: `app/assistant/tools/channel/channels.py`
+- Create: `tests/unit/test_assistant_set_channel_critic.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_assistant_set_channel_critic.py`:
+
+```python
+"""Tests for the set_channel_critic assistant tool."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from app.db.models import Channel
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Recorder:
+    """Capture PydanticAI `@agent.tool` registrations so tests can call them."""
+
+    def __init__(self):
+        self.tools: dict = {}
+
+    def tool(self, fn):
+        self.tools[fn.__name__] = fn
+        return fn
+
+
+async def test_set_channel_critic_enables(session_maker):
+    from app.assistant.tools.channel.channels import register_channels_tools
+
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-123, name="X")
+        session.add(ch)
+        await session.commit()
+
+    recorder = _Recorder()
+    register_channels_tools(recorder)  # type: ignore[arg-type]
+    tool = recorder.tools["set_channel_critic"]
+
+    ctx = SimpleNamespace(deps=SimpleNamespace(session_maker=session_maker))
+    msg = await tool(ctx, telegram_id=-123, enabled=True)
+    assert "True" in msg or "включ" in msg.lower()
+
+    async with session_maker() as session:
+        row = (await session.execute(select(Channel).where(Channel.telegram_id == -123))).scalar_one()
+    assert row.critic_enabled is True
+
+
+async def test_set_channel_critic_disables(session_maker):
+    from app.assistant.tools.channel.channels import register_channels_tools
+
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-124, name="X", critic_enabled=True)
+        session.add(ch)
+        await session.commit()
+
+    recorder = _Recorder()
+    register_channels_tools(recorder)  # type: ignore[arg-type]
+    tool = recorder.tools["set_channel_critic"]
+
+    ctx = SimpleNamespace(deps=SimpleNamespace(session_maker=session_maker))
+    await tool(ctx, telegram_id=-124, enabled=False)
+
+    async with session_maker() as session:
+        row = (await session.execute(select(Channel).where(Channel.telegram_id == -124))).scalar_one()
+    assert row.critic_enabled is False
+
+
+async def test_set_channel_critic_resets_to_global(session_maker):
+    from app.assistant.tools.channel.channels import register_channels_tools
+
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-125, name="X", critic_enabled=True)
+        session.add(ch)
+        await session.commit()
+
+    recorder = _Recorder()
+    register_channels_tools(recorder)  # type: ignore[arg-type]
+    tool = recorder.tools["set_channel_critic"]
+
+    ctx = SimpleNamespace(deps=SimpleNamespace(session_maker=session_maker))
+    msg = await tool(ctx, telegram_id=-125, enabled=None)
+    assert "global" in msg.lower() or "глобал" in msg.lower()
+
+    async with session_maker() as session:
+        row = (await session.execute(select(Channel).where(Channel.telegram_id == -125))).scalar_one()
+    assert row.critic_enabled is None
+
+
+async def test_set_channel_critic_unknown_channel(session_maker):
+    from app.assistant.tools.channel.channels import register_channels_tools
+
+    recorder = _Recorder()
+    register_channels_tools(recorder)  # type: ignore[arg-type]
+    tool = recorder.tools["set_channel_critic"]
+
+    ctx = SimpleNamespace(deps=SimpleNamespace(session_maker=session_maker))
+    msg = await tool(ctx, telegram_id=-9999, enabled=True)
+    assert "не найден" in msg.lower() or "not found" in msg.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run -m pytest tests/unit/test_assistant_set_channel_critic.py -v`
+Expected: FAIL — `set_channel_critic` does not exist.
+
+- [ ] **Step 3: Add the tool**
+
+In `app/assistant/tools/channel/channels.py`, append a new `@agent.tool` inside `register_channels_tools`, right after `remove_channel`:
+
+```python
+    @agent.tool
+    async def set_channel_critic(
+        ctx: RunContext[AssistantDeps],
+        telegram_id: int,
+        enabled: bool | None,
+    ) -> str:
+        """Set per-channel critic override. enabled=True forces the critic on for
+        this channel, False forces it off, None resets the override so the channel
+        follows the global CHANNEL_CRITIC_ENABLED setting."""
+        from sqlalchemy import select
+
+        from app.core.config import settings
+        from app.db.models import Channel
+
+        async with ctx.deps.session_maker() as session:
+            row = (
+                await session.execute(select(Channel).where(Channel.telegram_id == telegram_id))
+            ).scalar_one_or_none()
+            if row is None:
+                return f"Канал {telegram_id} не найден."
+            row.critic_enabled = enabled
+            await session.commit()
+
+        global_val = settings.channel.critic_enabled
+        effective = enabled if enabled is not None else global_val
+        if enabled is None:
+            return (
+                f"Канал {telegram_id}: override сброшен, теперь следует глобальной "
+                f"настройке (effective={effective})."
+            )
+        return (
+            f"Канал {telegram_id}: critic_enabled={enabled} "
+            f"(global={global_val}, effective={effective})."
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run -m pytest tests/unit/test_assistant_set_channel_critic.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/assistant/tools/channel/channels.py tests/unit/test_assistant_set_channel_critic.py
+git commit -m "feat(assistant): add set_channel_critic tool"
+```
+
+---
+
+## Task 11: Full-suite verification
+
+Run the whole test suite, linter, and type checker to catch regressions.
+
+**Files:** none new; verification only.
+
+- [ ] **Step 1: Run the full pytest suite**
+
+Run: `uv run -m pytest -x`
+Expected: all tests pass.
+
+- [ ] **Step 2: Run ruff**
+
+Run: `uv run -m ruff check app tests && uv run -m ruff format --check app tests`
+Expected: no issues. If formatting failures, run `uv run -m ruff format app tests` and amend the most recent commit (or add a small follow-up commit if the history has already been pushed).
+
+- [ ] **Step 3: Run the type checker**
+
+Run: `uv run -m ty check app tests`
+Expected: no new errors attributable to this work. Pre-existing errors outside this plan's files are out of scope.
+
+- [ ] **Step 4: Smoke-check migrations**
+
+Run: `uv run alembic upgrade head`
+Expected: clean apply (no drift).
+
+- [ ] **Step 5: Final commit (if any fixes were applied)**
+
+```bash
+git add -A
+git commit -m "chore(critic): final lint + format fixes"
+```
+
+Only create this commit if steps 2 or 3 applied fixes.
+
+---
+
+## Verification summary
+
+After Task 11:
+
+- New module `app/channel/critic.py` with public surface `CriticError`, `polish_post`, `resolve_critic_enabled`, and private helpers covered by unit tests.
+- `generate_post` accepts `critic_enabled` + `critic_model` kwargs, invokes the critic after length-enforcement, stores the original text in `pre_critic_text` on success, and silently falls back on `CriticError`.
+- `channels.critic_enabled` (nullable bool) + `channel_posts.pre_critic_text` (nullable text) migrated and persisted end-to-end (workflow creation path and review regen path).
+- Global env switches: `CHANNEL_CRITIC_ENABLED` (default False), `CHANNEL_CRITIC_MODEL` (default `anthropic/claude-sonnet-4-6`).
+- Assistant bot tool `set_channel_critic(telegram_id, enabled)` for per-channel overrides.
+- Default state after merge: global off, no channel overrides set → nothing runs until explicitly enabled.
+
+## Rollout (post-merge, manual)
+
+1. Deploy. Critic disabled globally — no behavior change.
+2. Via assistant bot: `set_channel_critic(telegram_id=<dev>, enabled=True)` for `@test908070`.
+3. Observe 20–30 posts; sanity-check tone, fact preservation, fallback rate via `critic_failed_fallback` log volume.
+4. If clean, flip env `CHANNEL_CRITIC_ENABLED=true`; all channels inherit.
+5. If a specific channel misbehaves later: `set_channel_critic(telegram_id=X, enabled=False)` — no redeploy.

--- a/docs/superpowers/specs/2026-04-17-critic-agent-design.md
+++ b/docs/superpowers/specs/2026-04-17-critic-agent-design.md
@@ -1,0 +1,439 @@
+# Critic Agent (Sprint 2 / Track 2) — Design Spec
+
+**Date:** 2026-04-17
+**Status:** Draft
+**Branch:** `feat/critic-agent`
+
+## Goal & Non-goals
+
+**Goal.** Add a post-generation polish pass that removes clichés, banal
+openers, dead verbs, and pompous/corporate phrasing from generated posts
+while preserving facts, links, structure, and length.
+
+**Non-goals.**
+
+- No RAG or few-shot style learning (Track 1, deferred).
+- No structural rewrites (paragraph order, headline emoji swaps).
+- No fact injection or concreteness augmentation (risk of invented details).
+- No multi-model pipeline or routing (single model per call).
+
+## Motivation
+
+Current posts are produced by a single `generate_post` call against
+`google/gemini-3.1-flash-lite-preview`. The style guide in the system
+prompt lists banned phrases and tone rules, but Flash Lite is the
+weakest model in the stack at tool-calling and taste; banned phrases
+still leak through ("рады сообщить", "лично расспросить",
+"Ознакомиться можно..."), and openers cluster around a handful of
+templates. The generation prompt cannot be made stricter without
+producing stiff text.
+
+Instead of swapping the generation model (which affects structure,
+cost, and latency across the pipeline), we add a cheap, stateless
+polish pass behind a kill switch. Claude Sonnet 4.6 leads the EQ-Bench
+Creative Writing leaderboard (1936 Elo) and is the judge model for
+longform-writing benchmarks — industry-validated for the polish role.
+
+## Architecture
+
+### Flow
+
+```
+generate_post(items, ..., critic_enabled, critic_model)
+  ├─ agent.run() → raw GeneratedPost
+  ├─ enforce_footer_and_length()              ← already exists
+  ├─ if critic_enabled and critic_model:      ← NEW
+  │     try:
+  │         original = post.text
+  │         polished = await polish_post(
+  │             text=post.text,
+  │             footer=footer,
+  │             api_key=api_key,
+  │             model=critic_model,
+  │         )
+  │         post.text = polished
+  │         post.pre_critic_text = original
+  │     except CriticError:
+  │         logger.warning("critic_failed_fallback", ...)
+  │         # post.text unchanged, pre_critic_text stays None
+  └─ image pipeline (unchanged)
+```
+
+The polish pass is **best-effort**: on failure the original text is
+kept and the pipeline proceeds. The caller (workflow / review service)
+does not need to know whether the critic ran.
+
+### Module layout
+
+New module `app/channel/critic.py`.
+
+**Public surface:**
+
+```python
+class CriticError(DomainError): ...
+
+def resolve_critic_enabled(channel: Channel, settings: Settings) -> bool:
+    """Per-channel override falls back to global default."""
+    if channel.critic_enabled is not None:
+        return channel.critic_enabled
+    return settings.channel.critic_enabled
+
+async def polish_post(
+    *,
+    text: str,
+    footer: str,
+    api_key: str,
+    model: str,
+) -> str:
+    """Run critic pass. Returns polished text or raises CriticError."""
+```
+
+**Private:**
+
+- `_create_critic_agent(api_key, model) -> Agent[None, str]` — PydanticAI
+  agent with `temperature=0.4`, `output_type=str`.
+- `CRITIC_PROMPT: str` — system prompt (see below).
+- `_validate_invariants(original, polished, footer) -> list[str]` —
+  returns a list of violation strings; empty = pass.
+- `_strip_agent_artifacts(output: str) -> str` — strips code fences,
+  `"Here's your polished version:"` prefixes, surrounding quotes.
+- `_extract_md_links(text: str) -> list[tuple[str, str]]` — extracts
+  `(label, url)` pairs from `[text](url)` markdown.
+- `_RETRY_HINT: str` — preamble used when the first attempt violates an
+  invariant.
+
+### Data model
+
+Two nullable columns added via a single Alembic migration.
+
+**`channels` table:**
+
+```python
+critic_enabled: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+```
+
+`None` means "follow global default". `True` / `False` override.
+
+**`channel_posts` table:**
+
+```python
+pre_critic_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+```
+
+Set to the generator's output when the critic successfully rewrites
+the post; `None` otherwise (critic disabled, critic failed, or post
+was not run through the critic).
+
+**`GeneratedPost` pydantic model** gains:
+
+```python
+pre_critic_text: str | None = Field(default=None)
+```
+
+Orchestrators that persist `GeneratedPost` to `ChannelPost` copy this
+field across.
+
+### Configuration
+
+New fields in `ChannelAgentSettings` (`app/channel/config.py`):
+
+```python
+critic_enabled: bool = Field(
+    default=False,
+    description="Master kill-switch for the post critic polish pass",
+)
+critic_model: str = Field(
+    default="anthropic/claude-sonnet-4-6",
+    description="Model used by the critic agent",
+)
+```
+
+Env-overrides: `CHANNEL_CRITIC_ENABLED`, `CHANNEL_CRITIC_MODEL`.
+
+**Default `critic_enabled=False`** — safe rollout. Flip on per-channel
+via assistant tool to test on `@test908070`, then flip global to True
+after verification.
+
+**Resolution matrix:**
+
+| channel.critic_enabled | settings.channel.critic_enabled | effective |
+| --- | --- | --- |
+| `None` | `False` | `False` |
+| `None` | `True` | `True` |
+| `True` | `False` | `True` |
+| `True` | `True` | `True` |
+| `False` | `False` | `False` |
+| `False` | `True` | `False` |
+
+### System prompt
+
+```
+You are a ruthless style editor for the Telegram channel "{channel_name}"
+(news for CIS students in the Czech Republic). Your ONLY job: polish a
+post by removing clichés, banal openers, dead verbs, and pompous or
+corporate phrasing.
+
+HARD RULES — violation = task failed:
+1. PRESERVE every Markdown link [text](url) — same URLs, same count.
+2. PRESERVE the exact footer at the end: {footer}
+3. PRESERVE facts: numbers, dates, names, institutions, prices, addresses.
+4. PRESERVE structure: same paragraph breaks, same order, same headline
+   emoji at the very start.
+5. Output MUST be <= 900 characters total.
+6. Do NOT add new information. Do NOT invent details, numbers, or names.
+
+WHAT TO FIX:
+- Banned phrases: "это отличная/уникальная возможность",
+  "не упустите шанс", "лично расспросить", "рады сообщить",
+  "с гордостью представляем", "Ознакомиться можно...",
+  "Подробнее здесь...", "Узнать больше..."
+- Banal openers: "У нас отличная новость", "Есть хорошая новость для
+  вас", "Хотим поделиться..."
+- Dead verbs: "предоставляем", "сообщаем", "уведомляем" — replace with
+  the concrete action.
+- Pompous / corporate tone → friendly, peer-to-peer student tone.
+- Filler adjectives: "уникальный", "незабываемый", "эксклюзивный".
+
+TONE: simple, slightly witty, like telling a friend about news. At
+most one exclamation mark per post.
+
+OUTPUT: return ONLY the polished post text. No explanations, no
+"Here's your polished version:", no markdown code fences. Plain
+polished post.
+```
+
+The prompt is filled with `{channel_name}` and `{footer}` at agent
+construction time.
+
+### Invariant checks
+
+Post-call validation; violations are collected then either fixed in a
+retry or raised as `CriticError`.
+
+| # | Check | Failure string |
+| --- | --- | --- |
+| 1 | `set(original_urls) <= set(polished_urls)` | `"lost URL: <url>"` |
+| 2 | `len(polished_links) >= len(original_links)` | `"link count dropped: N → M"` |
+| 3 | `footer in polished` | `"footer missing"` |
+| 4 | `len(polished) <= 900` | `"length over 900: N"` |
+| 5 | `len(polished) >= 100` | `"output too short: N"` |
+| 6 | First non-whitespace codepoint is emoji | `"headline emoji missing"` |
+
+URL regex: `re.findall(r"\[([^\]]+)\]\(([^)]+)\)", text)`.
+
+Emoji check: first codepoint is in Unicode category `So` (Symbol,
+Other) or in the approved whitelist `{📰 🎓 💼 🎉 🏠 💰 ⚡}`. We use a
+whitelist rather than `\p{Emoji}` to stay dependency-free.
+
+### Failure handling (`polish_post` implementation sketch)
+
+```python
+async def polish_post(*, text, footer, api_key, model):
+    agent = _create_critic_agent(api_key, model, footer=footer)
+
+    result = await agent.run(text)
+    usage = extract_usage_from_pydanticai_result(result, model, "critic")
+    if usage:
+        await log_usage(usage)
+
+    polished = _strip_agent_artifacts(result.output)
+    violations = _validate_invariants(text, polished, footer)
+    if not violations:
+        return polished
+
+    # Retry once with explicit correction hint.
+    retry_prompt = (
+        f"{_RETRY_HINT}\n"
+        f"Previous violations: {', '.join(violations)}\n\n"
+        f"Original post:\n{text}"
+    )
+    result = await agent.run(retry_prompt)
+    usage = extract_usage_from_pydanticai_result(result, model, "critic_retry")
+    if usage:
+        await log_usage(usage)
+
+    polished = _strip_agent_artifacts(result.output)
+    violations = _validate_invariants(text, polished, footer)
+    if not violations:
+        return polished
+
+    raise CriticError(f"invariant violations after retry: {violations}")
+```
+
+Cost tracking logs each attempt separately (`critic` vs
+`critic_retry`) so retry rate is observable.
+
+### Integration points
+
+**`app/channel/generator.py::generate_post` — new kwargs:**
+
+```python
+async def generate_post(
+    ...,
+    critic_enabled: bool = False,
+    critic_model: str = "",
+) -> GeneratedPost | None:
+```
+
+Call site sits between `enforce_footer_and_length` (line ~375) and the
+image pipeline (line ~400).
+
+**`app/channel/workflow.py::generate_post` (Burr action) — resolves
+flags and passes them through:**
+
+```python
+critic_enabled = resolve_critic_enabled(channel, settings)
+critic_model = settings.channel.critic_model
+
+post = await _generate(
+    ...,
+    critic_enabled=critic_enabled,
+    critic_model=critic_model,
+)
+```
+
+And when persisting `ChannelPost`:
+```python
+ChannelPost(
+    ...,
+    pre_critic_text=post.pre_critic_text,
+)
+```
+
+**`app/channel/review/service.py` (regeneration path)** — same
+plumbing: resolve flags from channel + settings, pass through, copy
+`pre_critic_text` into the persisted row.
+
+### Assistant bot tool
+
+New tool (co-located with existing channel-management tools):
+
+```python
+async def set_channel_critic(channel_id: int, enabled: bool | None) -> str:
+    """
+    Override critic enablement for a specific channel.
+    - True  → force-on for this channel
+    - False → force-off for this channel
+    - None  → follow global default (CHANNEL_CRITIC_ENABLED)
+    Returns a one-line status including the effective value after update.
+    """
+```
+
+Semantics mirror the resolution matrix above. The implementation
+reads global default from `settings.channel.critic_enabled` so the
+response message shows both the override and the effective result.
+
+## Testing strategy
+
+### Unit — `tests/unit/test_critic.py`
+
+1. `_extract_md_links` — empty text, 0/1/many links, malformed
+   markdown.
+2. `_validate_invariants` — one test per rule:
+   - lost URL
+   - dropped link count
+   - missing footer
+   - length > 900
+   - length < 100
+   - missing headline emoji
+   - all-valid → empty list
+3. `_strip_agent_artifacts` — strips ```markdown fences, `"Here's..."`
+   prefixes, surrounding quotes; idempotent on clean output.
+4. `polish_post` success — mock agent returns valid polished text →
+   returned as-is, `log_usage` called once with `operation="critic"`.
+5. `polish_post` retry-then-success — first call returns text missing
+   footer, second call fixes it → returned, `log_usage` called twice
+   (`critic` + `critic_retry`).
+6. `polish_post` fail after retry → `CriticError` with violation list
+   in message.
+7. `resolve_critic_enabled` — 6 rows from the resolution matrix.
+
+### DB — `tests/unit/test_critic_columns.py`
+
+1. `Channel.critic_enabled` round-trips `None`, `True`, `False`.
+2. `ChannelPost.pre_critic_text` round-trips `None` and a long string.
+3. Default on new `Channel(...)` is `None`.
+4. Default on new `ChannelPost(...)` is `None`.
+
+### Integration — `tests/integration/test_generator_with_critic.py`
+
+1. `generate_post(critic_enabled=True, critic_model="m")` with mocked
+   critic → `post.text` equals polished, `post.pre_critic_text` equals
+   the pre-critic text.
+2. `generate_post(critic_enabled=False)` → `post.text` unchanged,
+   `post.pre_critic_text is None`.
+3. `generate_post(critic_enabled=True)` with critic raising
+   `CriticError` → `post.text` unchanged, `post.pre_critic_text is
+   None`, warning logged. Post is still returned (not None).
+4. With critic enabled and `critic_model=""` → critic NOT invoked
+   (guarded by `and critic_model`).
+
+### Assistant tool — `tests/unit/test_assistant_set_channel_critic.py`
+
+1. Set `True` on channel → DB column is `True`, response includes
+   "enabled: True".
+2. Set `False` → DB column is `False`.
+3. Set `None` → DB column is `None`, response says "follow global".
+4. Unknown `channel_id` → error string, no DB mutation.
+
+### E2E
+
+Skipped. Existing E2E (`tests/e2e/test_review_*.py`) cover the flow;
+critic is a narrow polish pass whose integration is covered by the
+integration test above.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Sonnet drops a fact ("300 заявок" → "много заявок") | Prompt hard-rule. Invariant checker is URL-only today; facts are out of scope for automated validation. If admin catches a dropped fact, flip channel critic off and file a prompt-improvement ticket. |
+| Critic invents new information | Prompt hard-rule; fact-checking is out of scope for v1. Admin review is the authoritative gate. |
+| Cost drift if the feature is silently enabled on many channels | Global kill-switch, plus `log_usage(operation="critic")` is visible in the existing cost-tracking query. Watch for anomalies after rollout. |
+| Critic removes legitimate stylistic word ("отличный" in "отличное исследование") | Prompt targets clichéd openers and pompous fillers, not all adjectives. First-week test on `@test908070`; adjust prompt if it over-edits. |
+| Invariant checker too strict → high retry + fallback rate | Add a counter log `critic_fallback_rate` via existing cost/usage logging; if >10% of generations fall back, soften invariants or the retry hint. |
+| LLM returns code fences or a prefix like "Here's your polished version:" | `_strip_agent_artifacts` handles the common patterns before invariant checks. Prompt explicitly forbids them. |
+| First codepoint-is-emoji check breaks on legitimate non-emoji openers (e.g. numbers) | Generation prompt already requires a headline emoji, so every input to the critic has one. The check is protecting against the critic stripping it. |
+
+## Rollout plan
+
+1. Merge feature branch with `critic_enabled=False` default. No
+   production behavior change on deploy.
+2. Via assistant bot on `@test908070` (Konnekt Dev):
+   `set_channel_critic(channel_id=<dev>, enabled=True)`.
+3. Observe 20–30 posts on the dev channel (one-to-two-day window).
+   Check: fallback rate, admin satisfaction with tone, any fact drift.
+4. If clean, flip global env `CHANNEL_CRITIC_ENABLED=true`. All
+   channels inherit unless overridden.
+5. If issues on a specific channel later,
+   `set_channel_critic(channel_id=X, enabled=False)` kills it without
+   redeploy.
+
+## Open questions
+
+None. All clarifying questions resolved in brainstorming.
+
+## File map
+
+**New:**
+
+- `app/channel/critic.py`
+- `tests/unit/test_critic.py`
+- `tests/unit/test_critic_columns.py`
+- `tests/unit/test_assistant_set_channel_critic.py`
+- `tests/integration/test_generator_with_critic.py`
+- `alembic/versions/<hash>_add_critic_columns.py`
+
+**Modified:**
+
+- `app/channel/config.py` — `critic_enabled`, `critic_model` fields.
+- `app/channel/generator.py` — new kwargs on `generate_post`, critic
+  invocation between length-enforcement and image pipeline.
+- `app/db/models.py` — `Channel.critic_enabled`, `ChannelPost.pre_critic_text`,
+  `GeneratedPost.pre_critic_text`.
+- `app/channel/workflow.py` — resolve flags, pass through, persist
+  `pre_critic_text`.
+- `app/channel/review/service.py` — same plumbing on the regeneration
+  path.
+- `app/assistant/tools/channel/channels.py` — `set_channel_critic`
+  tool registration alongside existing `list_channels`,
+  `add_channel`, `edit_channel`, `remove_channel`.

--- a/tests/e2e/test_channel_review.py
+++ b/tests/e2e/test_channel_review.py
@@ -61,6 +61,7 @@ class _FakeGeneratedPost:
         self.image_urls: list[str] = []
         self.image_candidates: list[dict] | None = None
         self.image_phashes: list[str] = []
+        self.pre_critic_text: str | None = None
 
 
 # ---- Fixtures ----

--- a/tests/integration/test_generator_with_critic.py
+++ b/tests/integration/test_generator_with_critic.py
@@ -1,0 +1,155 @@
+"""Tests for critic integration inside generate_post."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from app.channel.generator import generate_post
+from app.channel.sources import ContentItem
+
+pytestmark = pytest.mark.asyncio
+
+
+FOOTER = "——\n🔗 **Konnekt** | @konnekt_channel"
+RAW_TEXT = f"🎓 **Headline**\n\nBody with [link](https://x/1) text.\n\n{FOOTER}"
+POLISHED_TEXT = f"🎓 **Tighter Headline**\n\nBody with [link](https://x/1) text.\n\n{FOOTER}"
+
+
+def _fake_generation_result(text: str):
+    from types import SimpleNamespace
+
+    from app.channel.generator import GeneratedPost
+
+    return SimpleNamespace(output=GeneratedPost(text=text))
+
+
+@pytest.fixture
+def sample_items() -> list[ContentItem]:
+    return [
+        ContentItem(
+            source_url="https://rss/x",
+            external_id="abc",
+            title="Headline",
+            body="Body",
+            url="https://x/1",
+        )
+    ]
+
+
+async def test_generate_post_applies_critic_when_enabled(sample_items):
+    with (
+        patch(
+            "app.channel.generator._create_generation_agent",
+            return_value=__import__("types").SimpleNamespace(
+                run=AsyncMock(return_value=_fake_generation_result(RAW_TEXT))
+            ),
+        ),
+        patch(
+            "app.channel.generator.extract_usage_from_pydanticai_result",
+            return_value=None,
+        ),
+        patch(
+            "app.channel.critic.polish_post",
+            new=AsyncMock(return_value=POLISHED_TEXT),
+        ),
+    ):
+        out = await generate_post(
+            sample_items,
+            api_key="k",
+            model="m",
+            footer=FOOTER,
+            critic_enabled=True,
+            critic_model="anthropic/claude-sonnet-4-6",
+        )
+    assert out is not None
+    assert out.text == POLISHED_TEXT
+    assert out.pre_critic_text == RAW_TEXT
+
+
+async def test_generate_post_no_critic_when_disabled(sample_items):
+    with (
+        patch(
+            "app.channel.generator._create_generation_agent",
+            return_value=__import__("types").SimpleNamespace(
+                run=AsyncMock(return_value=_fake_generation_result(RAW_TEXT))
+            ),
+        ),
+        patch(
+            "app.channel.generator.extract_usage_from_pydanticai_result",
+            return_value=None,
+        ),
+        patch("app.channel.critic.polish_post", new=AsyncMock()) as polish_mock,
+    ):
+        out = await generate_post(
+            sample_items,
+            api_key="k",
+            model="m",
+            footer=FOOTER,
+            critic_enabled=False,
+            critic_model="anthropic/claude-sonnet-4-6",
+        )
+    assert out is not None
+    assert out.text == RAW_TEXT
+    assert out.pre_critic_text is None
+    polish_mock.assert_not_awaited()
+
+
+async def test_generate_post_no_critic_when_model_empty(sample_items):
+    with (
+        patch(
+            "app.channel.generator._create_generation_agent",
+            return_value=__import__("types").SimpleNamespace(
+                run=AsyncMock(return_value=_fake_generation_result(RAW_TEXT))
+            ),
+        ),
+        patch(
+            "app.channel.generator.extract_usage_from_pydanticai_result",
+            return_value=None,
+        ),
+        patch("app.channel.critic.polish_post", new=AsyncMock()) as polish_mock,
+    ):
+        out = await generate_post(
+            sample_items,
+            api_key="k",
+            model="m",
+            footer=FOOTER,
+            critic_enabled=True,
+            critic_model="",
+        )
+    assert out is not None
+    assert out.text == RAW_TEXT
+    assert out.pre_critic_text is None
+    polish_mock.assert_not_awaited()
+
+
+async def test_generate_post_silent_fallback_on_critic_error(sample_items):
+    from app.channel.critic import CriticError
+
+    with (
+        patch(
+            "app.channel.generator._create_generation_agent",
+            return_value=__import__("types").SimpleNamespace(
+                run=AsyncMock(return_value=_fake_generation_result(RAW_TEXT))
+            ),
+        ),
+        patch(
+            "app.channel.generator.extract_usage_from_pydanticai_result",
+            return_value=None,
+        ),
+        patch(
+            "app.channel.critic.polish_post",
+            new=AsyncMock(side_effect=CriticError("nope")),
+        ),
+    ):
+        out = await generate_post(
+            sample_items,
+            api_key="k",
+            model="m",
+            footer=FOOTER,
+            critic_enabled=True,
+            critic_model="anthropic/claude-sonnet-4-6",
+        )
+    assert out is not None
+    assert out.text == RAW_TEXT
+    assert out.pre_critic_text is None

--- a/tests/unit/test_assistant_set_channel_critic.py
+++ b/tests/unit/test_assistant_set_channel_critic.py
@@ -1,0 +1,96 @@
+"""Tests for the set_channel_critic assistant tool."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from app.db.models import Channel
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Recorder:
+    """Capture PydanticAI `@agent.tool` registrations so tests can call them."""
+
+    def __init__(self):
+        self.tools: dict = {}
+
+    def tool(self, fn):
+        self.tools[fn.__name__] = fn
+        return fn
+
+
+async def test_set_channel_critic_enables(session_maker):
+    from app.assistant.tools.channel.channels import register_channels_tools
+
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-123, name="X")
+        session.add(ch)
+        await session.commit()
+
+    recorder = _Recorder()
+    register_channels_tools(recorder)  # type: ignore[arg-type]
+    tool = recorder.tools["set_channel_critic"]
+
+    ctx = SimpleNamespace(deps=SimpleNamespace(session_maker=session_maker))
+    msg = await tool(ctx, telegram_id=-123, enabled=True)
+    assert "True" in msg or "включ" in msg.lower()
+
+    async with session_maker() as session:
+        row = (await session.execute(select(Channel).where(Channel.telegram_id == -123))).scalar_one()
+    assert row.critic_enabled is True
+
+
+async def test_set_channel_critic_disables(session_maker):
+    from app.assistant.tools.channel.channels import register_channels_tools
+
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-124, name="X", critic_enabled=True)
+        session.add(ch)
+        await session.commit()
+
+    recorder = _Recorder()
+    register_channels_tools(recorder)  # type: ignore[arg-type]
+    tool = recorder.tools["set_channel_critic"]
+
+    ctx = SimpleNamespace(deps=SimpleNamespace(session_maker=session_maker))
+    await tool(ctx, telegram_id=-124, enabled=False)
+
+    async with session_maker() as session:
+        row = (await session.execute(select(Channel).where(Channel.telegram_id == -124))).scalar_one()
+    assert row.critic_enabled is False
+
+
+async def test_set_channel_critic_resets_to_global(session_maker):
+    from app.assistant.tools.channel.channels import register_channels_tools
+
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-125, name="X", critic_enabled=True)
+        session.add(ch)
+        await session.commit()
+
+    recorder = _Recorder()
+    register_channels_tools(recorder)  # type: ignore[arg-type]
+    tool = recorder.tools["set_channel_critic"]
+
+    ctx = SimpleNamespace(deps=SimpleNamespace(session_maker=session_maker))
+    msg = await tool(ctx, telegram_id=-125, enabled=None)
+    assert "global" in msg.lower() or "глобал" in msg.lower()
+
+    async with session_maker() as session:
+        row = (await session.execute(select(Channel).where(Channel.telegram_id == -125))).scalar_one()
+    assert row.critic_enabled is None
+
+
+async def test_set_channel_critic_unknown_channel(session_maker):
+    from app.assistant.tools.channel.channels import register_channels_tools
+
+    recorder = _Recorder()
+    register_channels_tools(recorder)  # type: ignore[arg-type]
+    tool = recorder.tools["set_channel_critic"]
+
+    ctx = SimpleNamespace(deps=SimpleNamespace(session_maker=session_maker))
+    msg = await tool(ctx, telegram_id=-9999, enabled=True)
+    assert "не найден" in msg.lower() or "not found" in msg.lower()

--- a/tests/unit/test_critic_columns.py
+++ b/tests/unit/test_critic_columns.py
@@ -1,0 +1,77 @@
+"""Tests for critic DB columns on Channel and ChannelPost."""
+
+from __future__ import annotations
+
+import pytest
+from app.core.enums import PostStatus
+from app.db.models import Channel, ChannelPost
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_channel_critic_enabled_default_none(session_maker):
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-1001, name="X")
+        session.add(ch)
+        await session.commit()
+        await session.refresh(ch)
+        assert ch.critic_enabled is None
+
+
+async def test_channel_critic_enabled_roundtrip(session_maker):
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-1002, name="X", critic_enabled=True)
+        session.add(ch)
+        await session.commit()
+        cid = ch.id
+
+    async with session_maker() as session:
+        row = (await session.execute(select(Channel).where(Channel.id == cid))).scalar_one()
+    assert row.critic_enabled is True
+
+
+async def test_channel_critic_enabled_explicit_false(session_maker):
+    async with session_maker() as session:
+        ch = Channel(telegram_id=-1003, name="X", critic_enabled=False)
+        session.add(ch)
+        await session.commit()
+        cid = ch.id
+
+    async with session_maker() as session:
+        row = (await session.execute(select(Channel).where(Channel.id == cid))).scalar_one()
+    assert row.critic_enabled is False
+
+
+async def test_channel_post_pre_critic_text_default_none(session_maker):
+    async with session_maker() as session:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="x",
+            title="t",
+            post_text="b",
+            status=PostStatus.DRAFT,
+        )
+        session.add(p)
+        await session.commit()
+        await session.refresh(p)
+        assert p.pre_critic_text is None
+
+
+async def test_channel_post_pre_critic_text_roundtrip(session_maker):
+    async with session_maker() as session:
+        p = ChannelPost(
+            channel_id=-100,
+            external_id="y",
+            title="t",
+            post_text="new",
+            status=PostStatus.DRAFT,
+            pre_critic_text="original pre-critic text with **bold**",
+        )
+        session.add(p)
+        await session.commit()
+        pid = p.id
+
+    async with session_maker() as session:
+        row = (await session.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+    assert row.pre_critic_text == "original pre-critic text with **bold**"

--- a/tests/unit/test_critic_columns.py
+++ b/tests/unit/test_critic_columns.py
@@ -75,3 +75,21 @@ async def test_channel_post_pre_critic_text_roundtrip(session_maker):
     async with session_maker() as session:
         row = (await session.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
     assert row.pre_critic_text == "original pre-critic text with **bold**"
+
+
+async def test_generated_post_pre_critic_text_default_none():
+    from app.channel.generator import GeneratedPost
+
+    p = GeneratedPost(text="hello")
+    assert p.pre_critic_text is None
+
+
+async def test_generated_post_pre_critic_text_roundtrip():
+    from app.channel.generator import GeneratedPost
+
+    p = GeneratedPost(text="new text", pre_critic_text="original text")
+    assert p.pre_critic_text == "original text"
+
+    dumped = p.model_dump()
+    restored = GeneratedPost.model_validate(dumped)
+    assert restored.pre_critic_text == "original text"

--- a/tests/unit/test_critic_config.py
+++ b/tests/unit/test_critic_config.py
@@ -1,0 +1,23 @@
+"""Tests for critic-related settings on ChannelAgentSettings."""
+
+from __future__ import annotations
+
+from app.channel.config import ChannelAgentSettings
+
+
+def test_critic_enabled_default_false():
+    s = ChannelAgentSettings()
+    assert s.critic_enabled is False
+
+
+def test_critic_model_default_sonnet():
+    s = ChannelAgentSettings()
+    assert s.critic_model == "anthropic/claude-sonnet-4-6"
+
+
+def test_critic_env_override(monkeypatch):
+    monkeypatch.setenv("CHANNEL_CRITIC_ENABLED", "true")
+    monkeypatch.setenv("CHANNEL_CRITIC_MODEL", "openai/gpt-5.1")
+    s = ChannelAgentSettings()
+    assert s.critic_enabled is True
+    assert s.critic_model == "openai/gpt-5.1"

--- a/tests/unit/test_critic_invariants.py
+++ b/tests/unit/test_critic_invariants.py
@@ -1,0 +1,127 @@
+"""Tests for critic helpers: link extraction, artifact stripping, invariant validation."""
+
+from __future__ import annotations
+
+from app.channel.critic import (
+    CriticError,
+    _extract_md_links,
+    _strip_agent_artifacts,
+    _validate_invariants,
+)
+
+FOOTER = "——\n🔗 **Konnekt** | @konnekt_channel"
+
+
+def test_extract_md_links_empty():
+    assert _extract_md_links("") == []
+
+
+def test_extract_md_links_none():
+    assert _extract_md_links("plain text no links") == []
+
+
+def test_extract_md_links_single():
+    out = _extract_md_links("Check [platform](https://example.com/x) today")
+    assert out == [("platform", "https://example.com/x")]
+
+
+def test_extract_md_links_multiple():
+    out = _extract_md_links("See [a](http://x/1) and [b](http://y/2)")
+    assert out == [("a", "http://x/1"), ("b", "http://y/2")]
+
+
+def test_extract_md_links_ignores_malformed():
+    assert _extract_md_links("broken [text(no close http://x)") == []
+
+
+def test_strip_agent_artifacts_clean_passthrough():
+    text = "🎓 **Headline**\n\nBody.\n\n" + FOOTER
+    assert _strip_agent_artifacts(text) == text
+
+
+def test_strip_agent_artifacts_code_fence():
+    text = "```\n🎓 **H**\n\nBody.\n```"
+    assert _strip_agent_artifacts(text) == "🎓 **H**\n\nBody."
+
+
+def test_strip_agent_artifacts_markdown_fence():
+    text = "```markdown\n🎓 **H**\n```"
+    assert _strip_agent_artifacts(text) == "🎓 **H**"
+
+
+def test_strip_agent_artifacts_prefix():
+    text = "Here's your polished version:\n\n🎓 **H**\n\nBody."
+    out = _strip_agent_artifacts(text)
+    assert out.startswith("🎓"), out
+
+
+def test_strip_agent_artifacts_surrounding_quotes():
+    text = '"🎓 **H** Body."'
+    assert _strip_agent_artifacts(text) == "🎓 **H** Body."
+
+
+def _make_polished(
+    body: str = "Body text with [link](https://x/1). Some extra words to reach the minimum length.",
+) -> str:
+    return f"🎓 **Headline**\n\n{body}\n\n{FOOTER}"
+
+
+def test_validate_invariants_all_valid():
+    original = _make_polished()
+    polished = _make_polished()
+    assert _validate_invariants(original, polished, FOOTER) == []
+
+
+def test_validate_invariants_lost_url():
+    original = _make_polished("Body with [link](https://x/1) here.")
+    polished = _make_polished("Body without the link here.")
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("lost URL" in v for v in violations), violations
+
+
+def test_validate_invariants_link_count_dropped():
+    original = f"🎓 **H**\n\n[a](http://x/1) and [b](http://y/2)\n\n{FOOTER}"
+    polished = f"🎓 **H**\n\nBoth links removed\n\n{FOOTER}"
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("link count" in v or "lost URL" in v for v in violations), violations
+
+
+def test_validate_invariants_missing_footer():
+    original = _make_polished()
+    polished = "🎓 **Headline**\n\nBody text with [link](https://x/1)."
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("footer" in v.lower() for v in violations), violations
+
+
+def test_validate_invariants_length_over_900():
+    original = _make_polished()
+    polished = "🎓 **H**\n\n" + "word " * 300 + f"\n\n{FOOTER}"
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("over 900" in v or "length" in v.lower() for v in violations), violations
+
+
+def test_validate_invariants_output_too_short():
+    original = _make_polished()
+    polished = "🎓 X"
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("too short" in v or "100" in v for v in violations), violations
+
+
+def test_validate_invariants_missing_headline_emoji():
+    original = _make_polished()
+    polished = f"**Headline**\n\nBody text with [link](https://x/1).\n\n{FOOTER}"
+    violations = _validate_invariants(original, polished, FOOTER)
+    assert any("emoji" in v.lower() for v in violations), violations
+
+
+def test_validate_invariants_whitelisted_emojis_pass():
+    for emoji in ["📰", "🎓", "💼", "🎉", "🏠", "💰", "⚡"]:
+        body = "Body text with [link](https://x/1). Some extra words to reach the minimum length."
+        polished = f"{emoji} **Headline**\n\n{body}\n\n{FOOTER}"
+        assert _validate_invariants(polished, polished, FOOTER) == []
+
+
+def test_critic_error_subclass_of_domain():
+    from app.core.exceptions import DomainError
+
+    assert issubclass(CriticError, DomainError)

--- a/tests/unit/test_critic_polish.py
+++ b/tests/unit/test_critic_polish.py
@@ -1,0 +1,118 @@
+"""Tests for polish_post — happy path, retry, and CriticError on persistent failure."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from app.channel.critic import CriticError, polish_post
+
+pytestmark = pytest.mark.asyncio
+
+FOOTER = "——\n🔗 **Konnekt** | @konnekt_channel"
+
+ORIGINAL = (
+    "🎓 **Продлили дедлайн стипендии**\n\n"
+    "ČVUT продлил приём заявок на [стипендию](https://cvut.cz/s) "
+    "до 15 мая. Подать документы можно в деканате.\n\n" + FOOTER
+)
+
+POLISHED_OK = (
+    "🎓 **Дедлайн стипендии ČVUT перенесли**\n\n"
+    "ČVUT принимает заявки на [стипендию](https://cvut.cz/s) до 15 мая. "
+    "Документы — в деканате.\n\n" + FOOTER
+)
+
+POLISHED_MISSING_FOOTER = (
+    "🎓 **Дедлайн стипендии ČVUT перенесли**\n\nČVUT принимает заявки на [стипендию](https://cvut.cz/s) до 15 мая."
+)
+
+
+def _fake_run_result(output: str):
+    """Build an object shaped like a PydanticAI RunResult for our purposes."""
+    return SimpleNamespace(output=output)
+
+
+async def test_polish_post_success():
+    fake_agent = SimpleNamespace(run=AsyncMock(return_value=_fake_run_result(POLISHED_OK)))
+    with (
+        patch("app.channel.critic._create_critic_agent", return_value=fake_agent),
+        patch("app.channel.critic.extract_usage_from_pydanticai_result", return_value=None),
+    ):
+        out = await polish_post(text=ORIGINAL, footer=FOOTER, api_key="k", model="anthropic/claude-sonnet-4-6")
+    assert out == POLISHED_OK
+    assert fake_agent.run.await_count == 1
+
+
+async def test_polish_post_retry_then_success():
+    fake_agent = SimpleNamespace(
+        run=AsyncMock(
+            side_effect=[
+                _fake_run_result(POLISHED_MISSING_FOOTER),  # first call — violates footer
+                _fake_run_result(POLISHED_OK),  # retry — ok
+            ]
+        )
+    )
+    with (
+        patch("app.channel.critic._create_critic_agent", return_value=fake_agent),
+        patch("app.channel.critic.extract_usage_from_pydanticai_result", return_value=None),
+    ):
+        out = await polish_post(text=ORIGINAL, footer=FOOTER, api_key="k", model="anthropic/claude-sonnet-4-6")
+    assert out == POLISHED_OK
+    assert fake_agent.run.await_count == 2
+
+
+async def test_polish_post_fails_after_retry():
+    fake_agent = SimpleNamespace(
+        run=AsyncMock(
+            side_effect=[
+                _fake_run_result(POLISHED_MISSING_FOOTER),
+                _fake_run_result(POLISHED_MISSING_FOOTER),
+            ]
+        )
+    )
+    with (
+        patch("app.channel.critic._create_critic_agent", return_value=fake_agent),
+        patch("app.channel.critic.extract_usage_from_pydanticai_result", return_value=None),
+    ):
+        with pytest.raises(CriticError) as exc_info:
+            await polish_post(text=ORIGINAL, footer=FOOTER, api_key="k", model="anthropic/claude-sonnet-4-6")
+    assert "footer" in str(exc_info.value).lower()
+    assert fake_agent.run.await_count == 2
+
+
+async def test_polish_post_raises_on_llm_exception():
+    fake_agent = SimpleNamespace(run=AsyncMock(side_effect=RuntimeError("openrouter 500")))
+    with (
+        patch("app.channel.critic._create_critic_agent", return_value=fake_agent),
+        patch("app.channel.critic.extract_usage_from_pydanticai_result", return_value=None),
+    ):
+        with pytest.raises(CriticError):
+            await polish_post(text=ORIGINAL, footer=FOOTER, api_key="k", model="anthropic/claude-sonnet-4-6")
+
+
+async def test_polish_post_logs_usage_per_call():
+    fake_agent = SimpleNamespace(
+        run=AsyncMock(
+            side_effect=[
+                _fake_run_result(POLISHED_MISSING_FOOTER),
+                _fake_run_result(POLISHED_OK),
+            ]
+        )
+    )
+    # extract_usage_from_pydanticai_result is SYNC — use regular Mock, not AsyncMock.
+    # Using AsyncMock would return a coroutine (truthy), which would be passed to
+    # log_usage as `usage`, causing await log_usage(coroutine) to fail.
+    extract_mock = Mock(return_value=None)
+    log_mock = AsyncMock()
+    with (
+        patch("app.channel.critic._create_critic_agent", return_value=fake_agent),
+        patch("app.channel.critic.extract_usage_from_pydanticai_result", side_effect=extract_mock),
+        patch("app.channel.critic.log_usage", log_mock),
+    ):
+        await polish_post(text=ORIGINAL, footer=FOOTER, api_key="k", model="anthropic/claude-sonnet-4-6")
+
+    # Two calls → two extract attempts, one per operation value.
+    operations = [call.args[2] for call in extract_mock.call_args_list]
+    assert operations == ["critic", "critic_retry"]

--- a/tests/unit/test_critic_resolve.py
+++ b/tests/unit/test_critic_resolve.py
@@ -1,0 +1,31 @@
+"""Tests for resolve_critic_enabled — per-channel-override-then-global."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from app.channel.critic import resolve_critic_enabled
+
+
+def _mk_channel(critic_enabled):
+    return SimpleNamespace(critic_enabled=critic_enabled)
+
+
+def _mk_settings(global_enabled: bool):
+    return SimpleNamespace(channel=SimpleNamespace(critic_enabled=global_enabled))
+
+
+@pytest.mark.parametrize(
+    ("channel_val", "global_val", "expected"),
+    [
+        (None, False, False),
+        (None, True, True),
+        (True, False, True),
+        (True, True, True),
+        (False, False, False),
+        (False, True, False),
+    ],
+)
+def test_resolve_critic_enabled_matrix(channel_val, global_val, expected):
+    assert resolve_critic_enabled(_mk_channel(channel_val), _mk_settings(global_val)) is expected

--- a/tests/unit/test_workflow_critic_wiring.py
+++ b/tests/unit/test_workflow_critic_wiring.py
@@ -1,0 +1,179 @@
+"""Tests that workflow.generate_post resolves and passes critic flags."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from app.channel.workflow import generate_post as wf_generate
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Channel(SimpleNamespace):
+    pass
+
+
+async def _make_state():
+    channel = _Channel(
+        id=1,
+        telegram_id=-100,
+        name="X",
+        language="ru",
+        footer="——\n🔗 **Konnekt** | @konnekt_channel",
+        footer_template=None,
+        username="konnekt_channel",
+        discovery_query="",
+        critic_enabled=True,  # per-channel override
+    )
+    config = SimpleNamespace(
+        generation_model="gen-model",
+        vision_model="vis-model",
+        image_phash_threshold=10,
+        image_phash_lookback_posts=30,
+        screening_model="sc",
+        http_timeout=30,
+        temperature=0.3,
+        embedding_model="emb",
+        semantic_dedup_threshold=0.9,
+        dedup_lookback_days=30,
+        dedup_query_snippet_chars=200,
+        critic_enabled=False,  # global — ignored because channel is True
+        critic_model="anthropic/claude-sonnet-4-6",
+    )
+
+    return {
+        "relevant_items": [
+            SimpleNamespace(title="T", body="B", url="https://x/1", source_url="https://rss", external_id="e")
+        ],
+        "api_key": "k",
+        "config": config,
+        "channel": channel,
+        "channel_id": 1,
+        "session_maker": AsyncMock(),
+    }
+
+
+class _State:
+    """Simple dict-backed stand-in for Burr's State object."""
+
+    def __init__(self, data: dict | None = None) -> None:
+        self._data: dict = dict(data) if data else {}
+
+    def __getitem__(self, key: str):  # noqa: ANN001
+        return self._data[key]
+
+    def __setitem__(self, key: str, value) -> None:  # noqa: ANN001
+        self._data[key] = value
+
+    def update(self, **kw):  # noqa: ANN002
+        new = _State(self._data)
+        for k, v in kw.items():
+            new._data[k] = v
+        return new
+
+
+async def test_workflow_generate_passes_critic_flags():
+    state = await _make_state()
+    s = _State(state)
+
+    captured: dict = {}
+
+    async def fake_generate(items, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            text="🎓 **H**\n\nB [l](https://x/1)\n\n" + state["channel"].footer,
+            pre_critic_text=None,
+            image_urls=[],
+            image_url=None,
+            image_candidates=None,
+            image_phashes=[],
+            model_dump=lambda: {"text": "x"},
+        )
+
+    async def fake_find_nearest_posts(*args, **kwargs):
+        return []
+
+    async def fake_feedback(**kwargs):
+        return None
+
+    with (
+        patch("app.channel.generator.generate_post", new=fake_generate),
+        patch("app.channel.semantic_dedup.find_nearest_posts", new=fake_find_nearest_posts),
+        patch("app.channel.feedback.get_feedback_summary", new=fake_feedback),
+    ):
+        await wf_generate(s)
+
+    assert captured["critic_enabled"] is True
+    assert captured["critic_model"] == "anthropic/claude-sonnet-4-6"
+
+
+async def test_workflow_generate_channel_none_uses_global():
+    state = await _make_state()
+    state["channel"].critic_enabled = None  # fall back to global
+    state["config"].critic_enabled = True
+
+    s = _State(state)
+
+    captured: dict = {}
+
+    async def fake_generate(items, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            text="🎓 **H**\n\n\n\n" + state["channel"].footer,
+            pre_critic_text=None,
+            image_urls=[],
+            image_url=None,
+            image_candidates=None,
+            image_phashes=[],
+            model_dump=lambda: {"text": "x"},
+        )
+
+    async def fake_find(*args, **kwargs):
+        return []
+
+    async def fake_feedback(**kwargs):
+        return None
+
+    with (
+        patch("app.channel.generator.generate_post", new=fake_generate),
+        patch("app.channel.semantic_dedup.find_nearest_posts", new=fake_find),
+        patch("app.channel.feedback.get_feedback_summary", new=fake_feedback),
+    ):
+        await wf_generate(s)
+
+    assert captured["critic_enabled"] is True
+
+
+async def test_create_review_post_persists_pre_critic_text(session_maker):
+    from app.channel.generator import GeneratedPost
+    from app.channel.review.service import create_review_post
+    from app.channel.sources import ContentItem
+    from app.db.models import ChannelPost
+    from sqlalchemy import select
+
+    post = GeneratedPost(
+        text="🎓 **H**\n\nB [l](https://x/1)\n\n——\n🔗 **K** | @c",
+        pre_critic_text="🎓 **Original**\n\nOrig body\n\n——\n🔗 **K** | @c",
+    )
+    item = ContentItem(
+        source_url="https://rss",
+        external_id="e1",
+        title="T",
+        body="B",
+        url="https://x/1",
+    )
+    async with session_maker() as session:
+        cp = await create_review_post(
+            channel_id=-100,
+            post=post,
+            source_items=[item],
+            review_chat_id=-200,
+            session=session,
+        )
+        await session.commit()
+    assert cp is not None
+    async with session_maker() as session:
+        row = (await session.execute(select(ChannelPost).where(ChannelPost.id == cp.id))).scalar_one()
+    assert row.pre_critic_text.startswith("🎓 **Original**")

--- a/tests/unit/test_workflow_critic_wiring.py
+++ b/tests/unit/test_workflow_critic_wiring.py
@@ -177,3 +177,70 @@ async def test_create_review_post_persists_pre_critic_text(session_maker):
     async with session_maker() as session:
         row = (await session.execute(select(ChannelPost).where(ChannelPost.id == cp.id))).scalar_one()
     assert row.pre_critic_text.startswith("🎓 **Original**")
+
+
+async def test_regen_post_text_threads_critic_and_persists(session_maker, monkeypatch):
+    """regen_post_text must pass critic flags to generate_post and save pre_critic_text."""
+    from app.channel.review.service import regen_post_text
+    from app.core.enums import PostStatus
+    from app.db.models import Channel, ChannelPost
+
+    async with session_maker() as session:
+        ch = Channel(
+            telegram_id=-100,
+            name="X",
+            username="konnekt_channel",
+            footer_template="——\n🔗 **K** | @c",
+            critic_enabled=True,
+        )
+        session.add(ch)
+        await session.flush()
+        p = ChannelPost(
+            channel_id=ch.telegram_id,
+            external_id="e",
+            title="t",
+            post_text="old",
+            status=PostStatus.DRAFT,
+            source_items=[{"title": "T", "url": "https://x/1", "source_url": "https://rss", "external_id": "e"}],
+        )
+        session.add(p)
+        await session.commit()
+        pid = p.id
+
+    captured_kwargs: dict = {}
+
+    async def fake_generate(items, **kwargs):
+        from types import SimpleNamespace
+
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(
+            text="🎓 **New**\n\nBody [l](https://x/1)\n\n——\n🔗 **K** | @c",
+            pre_critic_text="🎓 **Original**\n\nBody [l](https://x/1)\n\n——\n🔗 **K** | @c",
+            image_urls=[],
+            image_url=None,
+            image_candidates=None,
+            image_phashes=[],
+        )
+
+    # The regen path uses `from app.channel.generator import generate_post`
+    # (local import inside regen_post_text). Patch at the module source so the
+    # subsequent local import binds to the fake.
+    monkeypatch.setattr("app.channel.generator.generate_post", fake_generate)
+
+    msg, post = await regen_post_text(
+        session_maker=session_maker,
+        post_id=pid,
+        api_key="k",
+        model="gen-m",
+        language="Russian",
+        footer="——\n🔗 **K** | @c",
+    )
+    assert post is not None
+    assert captured_kwargs.get("critic_enabled") is True
+    assert captured_kwargs.get("critic_model") == "anthropic/claude-sonnet-4-6"
+
+    from sqlalchemy import select
+
+    async with session_maker() as session:
+        row = (await session.execute(select(ChannelPost).where(ChannelPost.id == pid))).scalar_one()
+    assert row.pre_critic_text.startswith("🎓 **Original**")


### PR DESCRIPTION
## Summary

- Adds Claude Sonnet 4.6 post-generation critic that rewrites every generated post to remove clichés, banal openers, dead verbs, and pompous phrasing — while preserving facts, links, footer, structure, and length.
- Behind a global kill-switch (`CHANNEL_CRITIC_ENABLED`, default `false`) + per-channel override column `channels.critic_enabled` (nullable bool). Original text saved to `channel_posts.pre_critic_text`.
- Retry-once-then-silent-fallback on invariant violations (lost URLs, missing footer, length drift, missing headline emoji) or LLM errors. Pipeline keeps working with original text on any failure.
- New `set_channel_critic` assistant tool flips per-channel override without SQL.

## Architecture

Critic lives in `app/channel/critic.py` as a standalone polish pass invoked from `generate_post` between length-enforcement and the image pipeline. Six-check invariant validator + `_strip_agent_artifacts` sanitizer. `resolve_critic_enabled(channel, settings)` resolves per-channel-override-then-global; wired into both the main workflow action and the review-regen path.

## Rollout plan

1. Merge — `critic_enabled=False` globally, no behavior change on deploy.
2. Via assistant: `set_channel_critic(telegram_id=<test908070>, enabled=True)` on Konnekt Dev.
3. Observe ~20-30 posts on dev, check tone + fact preservation + `critic_failed_fallback` log rate.
4. If clean: flip env `CHANNEL_CRITIC_ENABLED=true` — all channels inherit.
5. If an individual channel misbehaves: `set_channel_critic(telegram_id=X, enabled=False)` — no redeploy.

## Test plan

- [x] 52 new tests (invariants 19, polish+retry 5, resolver 6, config 3, DB columns 7, workflow wiring 4, integration 4, assistant tool 4)
- [x] Full suite: 784 passed, 2 skipped
- [x] ruff + ruff-format clean
- [x] ty clean (2 new diagnostics fixed)
- [x] Single alembic head `c663f6310e6f`
- [ ] Post-merge smoke on `@test908070`: enable critic per-channel, observe 20-30 posts, confirm style improvement + no fact drift

Spec: `docs/superpowers/specs/2026-04-17-critic-agent-design.md`
Plan: `docs/superpowers/plans/2026-04-17-critic-agent.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)