### PR TITLE
fix(assistant): inject current date into system prompt (#25)

### DIFF
--- a/app/assistant/agent.py
+++ b/app/assistant/agent.py
@@ -181,6 +181,16 @@ async def _filter_unavailable_tools(
     return [t for t in tool_defs if t.name not in _TELETHON_TOOLS]
 
 
+def current_date_prompt() -> str:
+    """Anchor the LLM to today's date so it doesn't hallucinate a stale year
+    (e.g. 2024) in web-search queries when its training cutoff predates today.
+    Registered as a dynamic system prompt so it stays current across long
+    conversations that may span midnight UTC."""
+    from app.core.time import utc_now
+
+    return f"Current date: {utc_now().strftime('%Y-%m-%d')}"
+
+
 def create_assistant_agent(model_name: str = "") -> Agent[AssistantDeps, str]:
     """Create the PydanticAI assistant agent with all tools."""
     from app.core.tool_trace import make_history_processor
@@ -204,6 +214,8 @@ def create_assistant_agent(model_name: str = "") -> Agent[AssistantDeps, str]:
         prepare_tools=_filter_unavailable_tools,
         tool_timeout=30,
     )
+
+    agent.system_prompt(dynamic=True)(current_date_prompt)
 
     from app.assistant.tools import register_all_tools
 

--- a/tests/unit/test_assistant.py
+++ b/tests/unit/test_assistant.py
@@ -95,6 +95,17 @@ class TestCreateAssistantAgent:
         assert tool_count >= 30, f"Expected >= 30 tools, got {tool_count}: {list(agent._function_toolset.tools.keys())}"
 
 
+class TestCurrentDatePrompt:
+    def test_current_date_prompt_contains_todays_date(self) -> None:
+        """The prompt must embed today's UTC date so the LLM anchors to it
+        instead of hallucinating its training-cutoff year (issue #25)."""
+        from app.assistant.agent import current_date_prompt
+        from app.core.time import utc_now
+
+        today = utc_now().strftime("%Y-%m-%d")
+        assert today in current_date_prompt()
+
+
 # ---------------------------------------------------------------------------
 # 5. Schedule time regex validation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Assistant bot hallucinated the year 2024 in web-search queries because Claude Sonnet's training cutoff predates today.
- Add a dynamic system prompt (`current_date_prompt`) that anchors the LLM to today's UTC date.
- `dynamic=True` ensures the prompt re-evaluates on every run, so conversations that live for hours stay correct across midnight UTC.

## Test plan
- [x] New unit test asserts today's date is present in `current_date_prompt()`
- [x] `uv run -m pytest tests/unit -x` — 632 passed
- [x] `ruff check` + `ruff format` — clean
- [x] `ty check app/assistant/agent.py tests/unit/test_assistant.py` — no new diagnostics

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)