### PR TITLE
feat(webui): chart visualizations + mosaic dashboard layout

### DIFF
--- a/webui/src/lib/components/charts/BarChartH.svelte
+++ b/webui/src/lib/components/charts/BarChartH.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	type Item = { label: string; value: number; secondary?: string };
+	type Props = {
+		items: Item[];
+		empty?: string;
+		format?: (n: number) => string;
+		max?: number;
+	};
+	let { items, empty = 'No data', format = (n) => n.toLocaleString(), max }: Props = $props();
+
+	const computedMax = $derived(max ?? Math.max(1, ...items.map((i) => i.value)));
+</script>
+
+{#if items.length === 0}
+	<p class="text-xs text-zinc-500">{empty}</p>
+{:else}
+	<ul class="space-y-2">
+		{#each items as item, i (i)}
+			{@const pct = (Math.max(0, item.value) / computedMax) * 100}
+			<li class="space-y-1">
+				<div class="flex items-baseline justify-between gap-2 text-xs">
+					<span class="truncate text-zinc-700" title={item.label}>{item.label}</span>
+					<span class="shrink-0 tabular-nums text-zinc-500">
+						{item.secondary ?? format(item.value)}
+					</span>
+				</div>
+				<div class="h-1.5 w-full overflow-hidden rounded-full bg-zinc-100">
+					<div
+						class="h-full rounded-full bg-zinc-900/80 transition-[width] duration-300"
+						style:width="{pct}%"
+					></div>
+				</div>
+			</li>
+		{/each}
+	</ul>
+{/if}

--- a/webui/src/lib/components/charts/DivergingBars.svelte
+++ b/webui/src/lib/components/charts/DivergingBars.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	type Item = { label: string; value: number | null; secondary?: string };
+	type Props = { items: Item[]; empty?: string };
+	let { items, empty = 'No data' }: Props = $props();
+
+	const max = $derived(
+		Math.max(1, ...items.map((i) => Math.abs(i.value ?? 0)))
+	);
+</script>
+
+{#if items.length === 0}
+	<p class="text-xs text-zinc-500">{empty}</p>
+{:else}
+	<ul class="space-y-2">
+		{#each items as item, i (i)}
+			{@const v = item.value}
+			{@const pct = v === null ? 0 : (Math.abs(v) / max) * 50}
+			{@const positive = v !== null && v > 0}
+			{@const zero = v === null || v === 0}
+			<li class="space-y-1">
+				<div class="flex items-baseline justify-between gap-2 text-xs">
+					<span class="truncate text-zinc-700" title={item.label}>{item.label}</span>
+					<span
+						class="shrink-0 tabular-nums {v === null
+							? 'text-zinc-400'
+							: positive
+								? 'text-emerald-600'
+								: zero
+									? 'text-zinc-500'
+									: 'text-rose-600'}"
+					>
+						{item.secondary ?? (positive ? `+${v}` : `${v ?? '—'}`)}
+					</span>
+				</div>
+				<div class="relative h-1.5 w-full overflow-hidden rounded-full bg-zinc-100">
+					<div class="absolute top-0 bottom-0 left-1/2 w-px bg-zinc-300"></div>
+					{#if !zero}
+						<div
+							class="absolute top-0 bottom-0 transition-[width,left] duration-300 {positive
+								? 'rounded-r-full bg-emerald-500/80'
+								: 'rounded-l-full bg-rose-500/80'}"
+							style:left="{positive ? 50 : 50 - pct}%"
+							style:width="{pct}%"
+						></div>
+					{/if}
+				</div>
+			</li>
+		{/each}
+	</ul>
+{/if}

--- a/webui/src/lib/components/charts/Donut.svelte
+++ b/webui/src/lib/components/charts/Donut.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+	type Slice = { label: string; value: number };
+	type Props = {
+		slices: Slice[];
+		size?: number;
+		strokeWidth?: number;
+		empty?: string;
+		centerValue?: string | number;
+		centerLabel?: string;
+	};
+	let {
+		slices,
+		size = 140,
+		strokeWidth = 18,
+		empty = 'No data',
+		centerValue,
+		centerLabel
+	}: Props = $props();
+
+	const palette = [
+		'#27272a',
+		'#52525b',
+		'#71717a',
+		'#a1a1aa',
+		'#d4d4d8',
+		'#10b981',
+		'#0ea5e9',
+		'#f59e0b'
+	];
+
+	const nonZero = $derived(slices.filter((s) => s.value > 0));
+	const total = $derived(nonZero.reduce((a, s) => a + s.value, 0));
+	const r = $derived((size - strokeWidth) / 2);
+	const cx = $derived(size / 2);
+	const cy = $derived(size / 2);
+	const circumference = $derived(2 * Math.PI * r);
+
+	const arcs = $derived.by(() => {
+		let cumulative = 0;
+		return nonZero.map((s, i) => {
+			const fraction = s.value / total;
+			const dash = fraction * circumference;
+			const offset = -cumulative * circumference;
+			cumulative += fraction;
+			return {
+				key: `${s.label}-${i}`,
+				label: s.label,
+				value: s.value,
+				color: palette[i % palette.length],
+				dasharray: `${dash} ${circumference - dash}`,
+				dashoffset: offset
+			};
+		});
+	});
+</script>
+
+{#if nonZero.length === 0}
+	<p class="text-xs text-zinc-500">{empty}</p>
+{:else}
+	<div class="flex items-center gap-4">
+		<svg width={size} height={size} viewBox="0 0 {size} {size}" class="shrink-0">
+			<circle {cx} {cy} r={r} fill="none" stroke="#f4f4f5" stroke-width={strokeWidth} />
+			{#each arcs as arc (arc.key)}
+				<circle
+					{cx}
+					{cy}
+					r={r}
+					fill="none"
+					stroke={arc.color}
+					stroke-width={strokeWidth}
+					stroke-dasharray={arc.dasharray}
+					stroke-dashoffset={arc.dashoffset}
+					transform="rotate(-90 {cx} {cy})"
+				>
+					<title>{arc.label}: {arc.value.toLocaleString()}</title>
+				</circle>
+			{/each}
+			{#if centerValue !== undefined}
+				<text
+					x={cx}
+					y={cy}
+					text-anchor="middle"
+					dominant-baseline="central"
+					class="fill-zinc-900 text-xl font-semibold"
+				>
+					{centerValue}
+				</text>
+				{#if centerLabel}
+					<text
+						x={cx}
+						y={cy + 14}
+						text-anchor="middle"
+						dominant-baseline="central"
+						class="fill-zinc-500 text-[10px] uppercase tracking-wider"
+					>
+						{centerLabel}
+					</text>
+				{/if}
+			{/if}
+		</svg>
+		<ul class="min-w-0 flex-1 space-y-1.5 text-xs">
+			{#each arcs as arc (arc.key)}
+				<li class="flex items-center justify-between gap-2">
+					<span class="flex min-w-0 items-center gap-2">
+						<span
+							class="size-2.5 shrink-0 rounded-sm"
+							style:background-color={arc.color}
+						></span>
+						<span class="truncate text-zinc-700" title={arc.label}>{arc.label}</span>
+					</span>
+					<span class="shrink-0 tabular-nums text-zinc-500">{arc.value}</span>
+				</li>
+			{/each}
+		</ul>
+	</div>
+{/if}

--- a/webui/src/lib/components/charts/Sparkline.svelte
+++ b/webui/src/lib/components/charts/Sparkline.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	type Props = {
+		values: number[];
+		width?: number;
+		height?: number;
+		strokeClass?: string;
+		fillClass?: string;
+	};
+	let {
+		values,
+		width = 240,
+		height = 48,
+		strokeClass = 'text-emerald-600',
+		fillClass = 'text-emerald-600/10'
+	}: Props = $props();
+
+	const path = $derived.by(() => {
+		if (values.length === 0) return { line: '', area: '' };
+		const max = Math.max(...values);
+		const min = Math.min(...values);
+		const span = Math.max(1, max - min);
+		const denom = Math.max(1, values.length - 1);
+		const pts = values.map((v, i) => {
+			const x = (i / denom) * width;
+			const y = height - ((v - min) / span) * height;
+			return [x, y] as const;
+		});
+		const line = pts
+			.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`)
+			.join(' ');
+		const area = `${line} L${width.toFixed(1)},${height} L0,${height} Z`;
+		return { line, area };
+	});
+</script>
+
+{#if values.length > 0}
+	<svg {width} {height} viewBox="0 0 {width} {height}" preserveAspectRatio="none">
+		<path d={path.area} class={fillClass} fill="currentColor" stroke="none" />
+		<path d={path.line} class={strokeClass} fill="none" stroke="currentColor" stroke-width="1.5" />
+	</svg>
+{/if}

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+	import BarChartH from '$lib/components/charts/BarChartH.svelte';
+	import DivergingBars from '$lib/components/charts/DivergingBars.svelte';
+	import Donut from '$lib/components/charts/Donut.svelte';
 	import ListTile from '$lib/components/home/ListTile.svelte';
 	import SkeletonTile from '$lib/components/home/SkeletonTile.svelte';
 	import StatTile from '$lib/components/home/StatTile.svelte';
+	import Tile from '$lib/components/home/Tile.svelte';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
 	import type { components } from '$lib/api/types';
 
@@ -45,55 +49,90 @@
 		</div>
 	</header>
 
-	<div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-		<StatTile
-			title="Drafts queue"
-			value={totalDrafts}
-			caption={stats.loading ? 'loading…' : `${stats.data?.drafts.length ?? 0} channels`}
-		/>
-		<ListTile
-			title="Scheduled next 24h"
-			items={(stats.data?.scheduled_next_24h ?? []).map((p) => ({
-				primary: p.title,
-				secondary: fmtWhen(p.scheduled_at)
-			}))}
-			empty={stats.loading ? 'loading…' : 'Nothing scheduled'}
-		/>
-		<StatTile
-			title="LLM cost (session)"
-			value={fmtMoney(sessionCostUsd)}
-			caption="Since last bot restart"
-		/>
-		<ListTile
-			title="Post views (recent)"
-			items={(stats.data?.post_views ?? []).map((p) => ({
-				primary: p.title,
-				secondary: p.views === 0 ? 'no data' : p.views.toLocaleString()
-			}))}
-			empty={stats.loading ? 'loading…' : 'No published posts yet'}
-		/>
-		<ListTile
-			title="Chats heatmap (7d total)"
-			items={(stats.data?.chat_heatmap ?? []).map((c) => ({
-				primary: c.title ?? `#${c.chat_id}`,
-				secondary: c.total_messages.toLocaleString()
-			}))}
-			empty={stats.loading ? 'loading…' : 'No activity recorded'}
-		/>
-		<ListTile
-			title="Members Δ (24h)"
-			items={(stats.data?.members_delta ?? []).map((m) => {
-				const d = m.delta_24h;
-				const sign = d === null || d === undefined ? '' : d > 0 ? '+' : '';
-				const secondary =
-					d === null || d === undefined
-						? `${m.current ?? '—'} (no baseline)`
-						: `${m.current?.toLocaleString() ?? '—'} (${sign}${d})`;
-				return { primary: m.title ?? `#${m.chat_id}`, secondary };
-			})}
-			empty={stats.loading ? 'loading…' : 'No snapshots yet'}
-		/>
-		<SkeletonTile title="Spam pings" phase={3} hint="Needs spam detector." />
-		<SkeletonTile title="Chat graph" phase={3} hint="Needs relationship model." />
+	<div class="grid grid-cols-1 gap-4 md:grid-cols-4 xl:grid-cols-6">
+		<div class="md:col-span-2 xl:col-span-3">
+			<Tile title="Drafts by channel">
+				<Donut
+					slices={(stats.data?.drafts ?? []).map((d) => ({
+						label: d.channel_name,
+						value: d.count
+					}))}
+					centerValue={totalDrafts}
+					centerLabel="drafts"
+					empty={stats.loading ? 'loading…' : 'No drafts queued'}
+				/>
+			</Tile>
+		</div>
+
+		<div class="md:col-span-2 xl:col-span-3">
+			<Tile title="Post views (recent)">
+				<BarChartH
+					items={(stats.data?.post_views ?? []).map((p) => ({
+						label: p.title,
+						value: p.views,
+						secondary: p.views === 0 ? 'no data' : p.views.toLocaleString()
+					}))}
+					empty={stats.loading ? 'loading…' : 'No published posts yet'}
+				/>
+			</Tile>
+		</div>
+
+		<div class="md:col-span-2 xl:col-span-3">
+			<Tile title="Chats heatmap (7d total)">
+				<BarChartH
+					items={(stats.data?.chat_heatmap ?? []).map((c) => ({
+						label: c.title ?? `#${c.chat_id}`,
+						value: c.total_messages
+					}))}
+					empty={stats.loading ? 'loading…' : 'No activity recorded'}
+				/>
+			</Tile>
+		</div>
+
+		<div class="md:col-span-2 xl:col-span-3">
+			<Tile title="Members Δ (24h)">
+				<DivergingBars
+					items={(stats.data?.members_delta ?? []).map((m) => {
+						const d = m.delta_24h;
+						const secondary =
+							d === null || d === undefined
+								? `${m.current?.toLocaleString() ?? '—'} · no baseline`
+								: `${m.current?.toLocaleString() ?? '—'} · ${d > 0 ? '+' : ''}${d}`;
+						return {
+							label: m.title ?? `#${m.chat_id}`,
+							value: d ?? null,
+							secondary
+						};
+					})}
+					empty={stats.loading ? 'loading…' : 'No snapshots yet'}
+				/>
+			</Tile>
+		</div>
+
+		<div class="md:col-span-2 xl:col-span-2">
+			<ListTile
+				title="Scheduled next 24h"
+				items={(stats.data?.scheduled_next_24h ?? []).map((p) => ({
+					primary: p.title,
+					secondary: fmtWhen(p.scheduled_at)
+				}))}
+				empty={stats.loading ? 'loading…' : 'Nothing scheduled'}
+			/>
+		</div>
+
+		<div class="md:col-span-2 xl:col-span-2">
+			<StatTile
+				title="LLM cost (session)"
+				value={fmtMoney(sessionCostUsd)}
+				caption="Since last bot restart"
+			/>
+		</div>
+
+		<div class="md:col-span-2 xl:col-span-1">
+			<SkeletonTile title="Spam pings" phase={3} hint="Needs spam detector." />
+		</div>
+		<div class="md:col-span-2 xl:col-span-1">
+			<SkeletonTile title="Chat graph" phase={3} hint="Needs relationship model." />
+		</div>
 	</div>
 </div>

--- a/webui/src/routes/chats/[id]/+page.svelte
+++ b/webui/src/routes/chats/[id]/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import * as Card from '$lib/components/ui/card/index.js';
 	import HeatmapGrid from '$lib/components/chat/HeatmapGrid.svelte';
+	import Sparkline from '$lib/components/charts/Sparkline.svelte';
+	import * as Card from '$lib/components/ui/card/index.js';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
 	import type { components } from '$lib/api/types';
 
@@ -9,22 +10,6 @@
 
 	const chatId = page.params.id;
 	const detail = useLivePoll<ChatDetail>(`/api/chats/${chatId}`, 60_000);
-
-	function sparklinePath(points: { member_count: number }[]): string {
-		if (points.length === 0) return '';
-		const w = 240;
-		const h = 48;
-		const max = Math.max(...points.map((p) => p.member_count));
-		const min = Math.min(...points.map((p) => p.member_count));
-		const span = Math.max(1, max - min);
-		return points
-			.map((p, i) => {
-				const x = (i / Math.max(1, points.length - 1)) * w;
-				const y = h - ((p.member_count - min) / span) * h;
-				return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
-			})
-			.join(' ');
-	}
 </script>
 
 <div class="mx-auto max-w-5xl space-y-4 px-6 py-6">
@@ -68,9 +53,7 @@
 				{#if detail.data.member_snapshots.length === 0}
 					<p class="text-xs text-zinc-500">No snapshots yet. First snapshot will appear within an hour of bot startup.</p>
 				{:else}
-					<svg width="240" height="48" class="text-emerald-600">
-						<path d={sparklinePath(detail.data.member_snapshots)} fill="none" stroke="currentColor" stroke-width="1.5" />
-					</svg>
+					<Sparkline values={detail.data.member_snapshots.map((p) => p.member_count)} />
 					<p class="text-xs text-zinc-500">
 						{detail.data.member_snapshots.length} snapshots
 					</p>


### PR DESCRIPTION
## Summary

Phase 2.5 — make the home dashboard look like a dashboard, not a stack of tables.

- **Drafts by channel** → donut with `total` in center
- **Post views (recent)** → horizontal bars
- **Chats heatmap (7d total)** → horizontal bars
- **Members Δ (24h)** → diverging bars (red ↓ / green ↑, zero-line in middle)
- Switched grid to **6-col xl mosaic**: charts get `col-span-3`, secondary stats `col-span-2`, P3 skeletons `col-span-1`
- Chat detail's inline sparkline math extracted to `Sparkline.svelte`

Zero new deps — all SVG + Tailwind.

## Test plan
- [x] `pnpm run check` — 0 errors / 0 warnings
- [x] vite dev server serves `/` without compile errors
- [ ] visual smoke: open `/` in browser and confirm donut/bars render with live API data
- [ ] visual smoke: `/chats/<id>` sparkline still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)