### PR TITLE
feat(webui): Phase 3a — chat graph (parent_chat_id + tree viewer)

### DIFF
--- a/alembic/versions/b1c2d3e4f5a6_add_chat_parent.py
+++ b/alembic/versions/b1c2d3e4f5a6_add_chat_parent.py
@@ -1,0 +1,39 @@
+"""Add chat parent_chat_id + relation_notes.
+
+Self-referencing FK lets us model the ČVUT → faculty → department tree
+without a separate join table. Single column, nullable for roots.
+
+Revision ID: b1c2d3e4f5a6
+Revises: a2b3c4d5e6f7
+Create Date: 2026-04-21 22:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: str | None = "a2b3c4d5e6f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chats",
+        sa.Column(
+            "parent_chat_id",
+            sa.BigInteger(),
+            sa.ForeignKey("chats.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column("chats", sa.Column("relation_notes", sa.String(), nullable=True))
+    op.create_index("ix_chats_parent_chat_id", "chats", ["parent_chat_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chats_parent_chat_id", table_name="chats")
+    op.drop_column("chats", "relation_notes")
+    op.drop_column("chats", "parent_chat_id")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -3,8 +3,8 @@ from typing import Any
 
 import sqlalchemy as sa
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import JSON, BigInteger, Boolean, DateTime, Float, Index, Integer, String
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import JSON, BigInteger, Boolean, DateTime, Float, ForeignKey, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.enums import EscalationStatus, PostStatus
 from app.core.time import utc_now
@@ -45,11 +45,30 @@ class Chat(Base):
     time_delete: Mapped[int] = mapped_column(Integer, default=60)
     is_welcome_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
     is_captcha_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    parent_chat_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey("chats.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    relation_notes: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(DateTime, default=utc_now)
     modified_at: Mapped[datetime.datetime] = mapped_column(
         DateTime,
         default=utc_now,
         onupdate=utc_now,
+    )
+
+    parent: Mapped["Chat | None"] = relationship(
+        "Chat",
+        remote_side="Chat.id",
+        back_populates="children",
+        lazy="selectin",
+    )
+    children: Mapped[list["Chat"]] = relationship(
+        "Chat",
+        back_populates="parent",
+        cascade="save-update, merge",
     )
 
     def __init__(
@@ -61,6 +80,8 @@ class Chat(Base):
         time_delete: int = 60,
         is_welcome_enabled: bool = False,
         is_captcha_enabled: bool = False,
+        parent_chat_id: int | None = None,
+        relation_notes: str | None = None,
     ) -> None:
         self.id = id
         self.title = title
@@ -69,6 +90,8 @@ class Chat(Base):
         self.time_delete = time_delete
         self.is_welcome_enabled = is_welcome_enabled
         self.is_captcha_enabled = is_captcha_enabled
+        self.parent_chat_id = parent_chat_id
+        self.relation_notes = relation_notes
 
     def enable_welcome(self, message: str | None = None) -> None:
         """Enable welcome message for new members"""

--- a/app/webapi/routes/chats.py
+++ b/app/webapi/routes/chats.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.time import utc_now
 from app.db.models import Chat, ChatMemberSnapshot, Message
 from app.webapi.deps import get_session, get_telethon_stats, require_super_admin
-from app.webapi.schemas import ChatDetail, ChatRead, HeatmapCell, MemberSnapshotPoint
+from app.webapi.schemas import ChatDetail, ChatNode, ChatRead, HeatmapCell, MemberSnapshotPoint
 from app.webapi.services.telethon_stats import TelethonStatsService
 
 router = APIRouter(prefix="/chats", tags=["chats"])
@@ -53,11 +53,54 @@ async def list_chats(
             is_forum=chat.is_forum,
             is_welcome_enabled=chat.is_welcome_enabled,
             is_captcha_enabled=chat.is_captcha_enabled,
+            parent_chat_id=chat.parent_chat_id,
+            relation_notes=chat.relation_notes,
             member_count=member_count,
             created_at=chat.created_at,
         )
         for chat, member_count in zip(chats, member_counts, strict=True)
     ]
+
+
+@router.get("/graph", response_model=list[ChatNode])
+async def get_chat_graph(
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> list[ChatNode]:
+    """Return chat tree with roots first; children nested via parent_chat_id.
+
+    Single SQL query; tree assembly is in-memory. Telethon enrichment is
+    intentionally skipped for the tree endpoint — tile renders 1+ times
+    per poll, member_count drilldown lives on /chats/:id.
+
+    Self-loops (parent_chat_id == id) and orphans (parent_chat_id points
+    to a missing/deleted chat) become roots; multi-hop cycles aren't
+    detected here — admins set parent_chat_id manually so cycles would
+    be intentional misuse, not a runtime hazard.
+    """
+    chats = (await session.execute(select(Chat))).scalars().all()
+    by_id: dict[int, ChatNode] = {
+        c.id: ChatNode(id=c.id, title=c.title, relation_notes=c.relation_notes, children=[]) for c in chats
+    }
+    roots: list[ChatNode] = []
+    for c in chats:
+        node = by_id[c.id]
+        parent_id = c.parent_chat_id
+        if parent_id is not None and parent_id != c.id and parent_id in by_id:
+            by_id[parent_id].children.append(node)
+        else:
+            roots.append(node)
+
+    def _key(n: ChatNode) -> tuple[str, int]:
+        return ((n.title or "").lower(), n.id)
+
+    def _sort(nodes: list[ChatNode]) -> None:
+        nodes.sort(key=_key)
+        for n in nodes:
+            _sort(n.children)
+
+    _sort(roots)
+    return roots
 
 
 @router.get("/{chat_id}", response_model=ChatDetail)
@@ -98,12 +141,21 @@ async def get_chat(
 
     member_count = await stats.get_member_count(chat.id)
 
+    children_rows = (
+        (await session.execute(select(Chat).where(Chat.parent_chat_id == chat_id).order_by(Chat.title))).scalars().all()
+    )
+    children_nodes = [
+        ChatNode(id=c.id, title=c.title, relation_notes=c.relation_notes, children=[]) for c in children_rows
+    ]
+
     return ChatDetail(
         id=chat.id,
         title=chat.title,
         is_forum=chat.is_forum,
         is_welcome_enabled=chat.is_welcome_enabled,
         is_captcha_enabled=chat.is_captcha_enabled,
+        parent_chat_id=chat.parent_chat_id,
+        relation_notes=chat.relation_notes,
         member_count=member_count,
         created_at=chat.created_at,
         welcome_message=chat.welcome_message,
@@ -113,4 +165,5 @@ async def get_chat(
         member_snapshots=[
             MemberSnapshotPoint(captured_at=s.captured_at, member_count=s.member_count) for s in snapshots_ascending
         ],
+        children=children_nodes,
     )

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -88,8 +88,24 @@ class ChatRead(BaseModel):
     is_forum: bool
     is_welcome_enabled: bool
     is_captcha_enabled: bool
+    parent_chat_id: int | None = None
+    relation_notes: str | None = None
     member_count: int | None = None  # enriched from Telethon, None when unavailable
     created_at: datetime.datetime
+
+
+class ChatNode(BaseModel):
+    """Recursive node for the /chats/graph tree response.
+
+    member_count is intentionally NOT enriched here — the tree endpoint
+    skips Telethon to avoid N+1 RPCs on every poll. Drill into /chats/:id
+    for live counts.
+    """
+
+    id: int
+    title: str | None
+    relation_notes: str | None = None
+    children: list[ChatNode] = []
 
 
 class HeatmapCell(BaseModel):
@@ -112,13 +128,17 @@ class MemberSnapshotPoint(BaseModel):
 
 
 class ChatDetail(ChatRead):
-    """Full chat payload — adds heatmap grid + member-snapshot series."""
+    """Full chat payload — adds heatmap grid + member-snapshot series + relationships."""
 
     welcome_message: str | None
     time_delete: int
     modified_at: datetime.datetime
     heatmap: list[HeatmapCell]
     member_snapshots: list[MemberSnapshotPoint]
+    children: list[ChatNode] = []
+
+
+ChatNode.model_rebuild()
 
 
 class PostViewsEntry(BaseModel):

--- a/docs/superpowers/plans/2026-04-21-web-ui-phase-3a-chat-graph.md
+++ b/docs/superpowers/plans/2026-04-21-web-ui-phase-3a-chat-graph.md
@@ -1,0 +1,344 @@
+# Phase 3a — Chat Graph Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans (or do it inline). Each task ends with a commit.
+
+**Goal:** Replace the home `Chat graph` skeleton + the `/chats/graph` ComingSoon stub with a working tree viewer of parent → child chat relationships.
+
+**Architecture:** One self-FK column on `Chat` (`parent_chat_id`) + free-text `relation_notes`. New `GET /api/chats/graph` returns roots with nested children. FE renders a collapsible nested list. No graph library — tree is enough per spec ("Tree over graph").
+
+**Tech Stack:** SQLAlchemy 2.x async, Alembic, FastAPI, SvelteKit 2 + Svelte 5 runes, Tailwind v4.
+
+---
+
+## File Structure
+
+| Path | Purpose |
+|---|---|
+| `alembic/versions/<new>_add_chat_parent_chat_id.py` | Migration: add `parent_chat_id` + `relation_notes` |
+| `app/db/models.py` | Extend `Chat` with `parent_chat_id`, `relation_notes`, optional `parent`/`children` relationships |
+| `app/webapi/schemas.py` | Add `ChatNode` (id, title, member_count, children, relation_notes) |
+| `app/webapi/routes/chats.py` | New `GET /chats/graph`; extend list + detail responses with `parent_chat_id` |
+| `webui/src/routes/chats/graph/+page.svelte` | Replace ComingSoon → collapsible tree |
+| `webui/src/lib/components/chat/ChatTreeNode.svelte` | Recursive tree-row component |
+| `webui/src/routes/chats/[id]/+page.svelte` | Show parent link + children list card |
+| `webui/src/routes/+page.svelte` | Replace `Chat graph` SkeletonTile with live mini-tree (depth ≤ 2) |
+| `tests/unit/test_chat_parent_relationship.py` | ORM-level: parent/children navigation |
+| `tests/webapi/test_chats_graph.py` | API: tree shape, orphans, cycle protection |
+
+---
+
+## Tasks
+
+### Task 1 — Migration: `parent_chat_id` + `relation_notes`
+
+**Files:**
+- Create: `alembic/versions/b1c2d3e4f5a6_add_chat_parent.py`
+
+```python
+"""Add chat parent_chat_id + relation_notes.
+
+Self-referencing FK lets us model the ČVUT → faculty → department tree
+without a separate join table. Single column, nullable for roots.
+
+Revision ID: b1c2d3e4f5a6
+Revises: a2b3c4d5e6f7
+Create Date: 2026-04-21 22:00:00.000000
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: str | None = "a2b3c4d5e6f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chats",
+        sa.Column("parent_chat_id", sa.BigInteger(), sa.ForeignKey("chats.id", ondelete="SET NULL"), nullable=True),
+    )
+    op.add_column("chats", sa.Column("relation_notes", sa.String(), nullable=True))
+    op.create_index("ix_chats_parent_chat_id", "chats", ["parent_chat_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chats_parent_chat_id", table_name="chats")
+    op.drop_column("chats", "relation_notes")
+    op.drop_column("chats", "parent_chat_id")
+```
+
+Commit: `feat(db): add Chat.parent_chat_id + relation_notes migration`
+
+### Task 2 — ORM update + relationship
+
+**Files:**
+- Modify: `app/db/models.py` (Chat class)
+
+Add fields + relationships:
+```python
+parent_chat_id: Mapped[int | None] = mapped_column(
+    BigInteger, ForeignKey("chats.id", ondelete="SET NULL"), nullable=True, index=True
+)
+relation_notes: Mapped[str | None] = mapped_column(String, nullable=True)
+
+parent: Mapped["Chat | None"] = relationship(
+    "Chat", remote_side="Chat.id", back_populates="children", lazy="joined"
+)
+children: Mapped[list["Chat"]] = relationship(
+    "Chat", back_populates="parent", cascade="save-update, merge"
+)
+```
+
+Extend `__init__` to accept `parent_chat_id` and `relation_notes` (optional).
+
+**Test (`tests/unit/test_chat_parent_relationship.py`):**
+- root chat (parent_chat_id=None) → `chat.children == [child1, child2]`
+- child.parent.id == root.id
+- deleting root sets children's parent_chat_id to None (FK ondelete=SET NULL)
+
+Commit: `feat(db): chat parent/children relationship`
+
+### Task 3 — Schema: `ChatNode`
+
+**Files:**
+- Modify: `app/webapi/schemas.py`
+
+```python
+class ChatNode(BaseModel):
+    id: int
+    title: str | None
+    member_count: int | None = None
+    relation_notes: str | None = None
+    children: list["ChatNode"] = []
+
+ChatNode.model_rebuild()
+```
+
+Also extend `ChatRead` and `ChatDetail` with `parent_chat_id: int | None`, `relation_notes: str | None`.
+
+(Phase 3a doesn't enrich tree nodes with member_count to avoid Telethon fan-out on every page load; `member_count` stays default `None` for the tree endpoint; list/detail endpoints keep their existing enrichment.)
+
+### Task 4 — API: `GET /api/chats/graph`
+
+**Files:**
+- Modify: `app/webapi/routes/chats.py`
+
+Add route, just under `list_chats`:
+
+```python
+@router.get("/graph", response_model=list[ChatNode])
+async def get_chat_graph(
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> list[ChatNode]:
+    chats = (await session.execute(select(Chat))).scalars().all()
+    by_id = {c.id: ChatNode(id=c.id, title=c.title, relation_notes=c.relation_notes, children=[]) for c in chats}
+    roots: list[ChatNode] = []
+    for c in chats:
+        node = by_id[c.id]
+        parent_id = c.parent_chat_id
+        if parent_id is not None and parent_id in by_id and parent_id != c.id:
+            by_id[parent_id].children.append(node)
+        else:
+            roots.append(node)
+    # stable order: title, then id
+    def _key(n: ChatNode) -> tuple:
+        return (n.title or "", n.id)
+    def _sort(nodes: list[ChatNode]) -> None:
+        nodes.sort(key=_key)
+        for n in nodes:
+            _sort(n.children)
+    _sort(roots)
+    return roots
+```
+
+**IMPORTANT:** declare this route **before** `@router.get("/{chat_id}")` so `/graph` doesn't get matched as a chat_id.
+
+Also add `parent_chat_id` and `relation_notes` to the existing `ChatRead`/`ChatDetail` build sites.
+
+**Tests (`tests/webapi/test_chats_graph.py`):**
+- empty DB → `[]`
+- 1 root + 2 children → 1 element with 2 children
+- orphan child (parent_chat_id points to nonexistent) → orphan becomes a root
+- self-reference (parent_chat_id == id) → treated as root, not infinite loop
+
+Commit: `feat(webapi): chat graph endpoint + parent fields on chat read/detail`
+
+### Task 5 — Run `pnpm run api:sync`
+
+After task 4 backend lives, regenerate FE types:
+```bash
+cd webui && pnpm run api:sync
+```
+Confirm `ChatNode` appears in `webui/src/lib/api/types.ts`.
+
+### Task 6 — FE: recursive `ChatTreeNode` component
+
+**Files:**
+- Create: `webui/src/lib/components/chat/ChatTreeNode.svelte`
+
+```svelte
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import type { components } from '$lib/api/types';
+  type Node = components['schemas']['ChatNode'];
+  type Props = { node: Node; depth?: number };
+  let { node, depth = 0 }: Props = $props();
+  let expanded = $state(depth < 2);
+</script>
+
+<li class="space-y-1">
+  <div class="flex items-center gap-2">
+    {#if node.children.length > 0}
+      <button class="text-xs text-zinc-500 hover:text-zinc-900"
+              onclick={() => (expanded = !expanded)}>
+        {expanded ? '▾' : '▸'}
+      </button>
+    {:else}
+      <span class="w-3"></span>
+    {/if}
+    <button class="truncate text-sm text-zinc-800 hover:underline"
+            onclick={() => goto(`/chats/${node.id}`)}>
+      {node.title ?? `#${node.id}`}
+    </button>
+    {#if node.relation_notes}
+      <span class="text-xs text-zinc-400">· {node.relation_notes}</span>
+    {/if}
+  </div>
+  {#if expanded && node.children.length > 0}
+    <ul class="ml-4 space-y-1 border-l border-zinc-200 pl-2">
+      {#each node.children as child (child.id)}
+        <ChatTreeNode node={child} depth={depth + 1} />
+      {/each}
+    </ul>
+  {/if}
+</li>
+```
+
+### Task 7 — FE: `/chats/graph` page
+
+**Files:**
+- Modify: `webui/src/routes/chats/graph/+page.svelte`
+
+Replace ComingSoon with:
+```svelte
+<script lang="ts">
+  import * as Card from '$lib/components/ui/card/index.js';
+  import ChatTreeNode from '$lib/components/chat/ChatTreeNode.svelte';
+  import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
+  import type { components } from '$lib/api/types';
+  type Tree = components['schemas']['ChatNode'][];
+  const tree = useLivePoll<Tree>('/api/chats/graph', 60_000);
+</script>
+
+<div class="mx-auto max-w-3xl space-y-4 px-6 py-6">
+  <header class="flex items-baseline justify-between">
+    <h2 class="text-lg font-semibold tracking-tight">Chat graph</h2>
+    {#if tree.lastUpdatedAt}<span class="text-xs text-zinc-500">Updated {tree.lastUpdatedAt.toLocaleTimeString()}</span>{/if}
+  </header>
+  <Card.Root>
+    <Card.Content class="py-4">
+      {#if tree.loading}<p class="text-sm text-zinc-500">Loading…</p>
+      {:else if tree.error}<p class="text-sm text-red-600">Error: {tree.error}</p>
+      {:else if !tree.data || tree.data.length === 0}
+        <p class="text-sm text-zinc-500">No relationships defined yet. Set <code>parent_chat_id</code> on chats to build the tree.</p>
+      {:else}
+        <ul class="space-y-1">
+          {#each tree.data as root (root.id)}<ChatTreeNode node={root} />{/each}
+        </ul>
+      {/if}
+    </Card.Content>
+  </Card.Root>
+</div>
+```
+
+### Task 8 — FE: chat detail shows parent + children
+
+**Files:**
+- Modify: `webui/src/routes/chats/[id]/+page.svelte`
+
+Add a "Relationships" Card after Overview, only if `parent_chat_id` or children exist. Children list comes from filtering the graph endpoint client-side, OR (simpler) we extend `ChatDetail` to include `children: list[ChatNode]` server-side.
+
+**Decision:** server-side. Add to `get_chat` route:
+```python
+children_rows = (await session.execute(
+    select(Chat).where(Chat.parent_chat_id == chat_id)
+)).scalars().all()
+children_nodes = [ChatNode(id=c.id, title=c.title, relation_notes=c.relation_notes, children=[]) for c in children_rows]
+```
+And include `children=children_nodes`, `parent_chat_id=chat.parent_chat_id`, `relation_notes=chat.relation_notes` in `ChatDetail`.
+
+FE card:
+```svelte
+{#if detail.data.parent_chat_id !== null || detail.data.children.length > 0}
+  <Card.Root>
+    <Card.Header><Card.Title class="text-sm">Relationships</Card.Title></Card.Header>
+    <Card.Content class="space-y-2 text-sm">
+      {#if detail.data.parent_chat_id !== null}
+        <div>Parent: <a href="/chats/{detail.data.parent_chat_id}" class="underline">#{detail.data.parent_chat_id}</a></div>
+      {/if}
+      {#if detail.data.children.length > 0}
+        <div>
+          Children:
+          <ul class="ml-4 list-disc">
+            {#each detail.data.children as c (c.id)}
+              <li><a href="/chats/{c.id}" class="underline">{c.title ?? '#' + c.id}</a></li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+    </Card.Content>
+  </Card.Root>
+{/if}
+```
+
+### Task 9 — Home tile: live mini-tree
+
+**Files:**
+- Modify: `webui/src/routes/+page.svelte`
+
+Replace `<SkeletonTile title="Chat graph" phase={3} />` with:
+```svelte
+<div class="md:col-span-2 xl:col-span-2">
+  <Tile title="Chat graph (preview)">
+    {#if treeRoots.length === 0}
+      <p class="text-xs text-zinc-500">No relationships yet.</p>
+    {:else}
+      <ul class="space-y-1">
+        {#each treeRoots.slice(0, 3) as root (root.id)}<ChatTreeNode node={root} depth={1} />{/each}
+      </ul>
+      <a href="/chats/graph" class="mt-2 inline-block text-xs text-zinc-500 hover:underline">View full tree →</a>
+    {/if}
+  </Tile>
+</div>
+```
+
+Tree data fetched via a second `useLivePoll<ChatNode[]>('/api/chats/graph', 120_000)`.
+
+Adjust the trailing skeleton row (only Spam pings remains there, give it `xl:col-span-2`).
+
+### Task 10 — Smoke + commit + PR
+
+```bash
+uv run alembic upgrade head
+uv run -m pytest tests/unit/test_chat_parent_relationship.py tests/webapi/test_chats_graph.py tests/webapi/test_chats.py -x
+ruff check app tests && ruff format --check app tests
+ty check app
+cd webui && pnpm run check
+```
+
+Branch: `webui/phase-3a-chat-graph`. Single PR squashed into main.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** parent_chat_id + relation_notes ✅; nested list viewer ✅; tree (not graph) ✅. Spam detector + agent chat are out of scope (3b, 3c).
+- **Migration safety:** column is nullable, no backfill needed. FK uses `ondelete=SET NULL` so deleting a parent doesn't cascade-delete children.
+- **Cycle protection:** in `get_chat_graph`, `parent_id != c.id` check prevents self-loop. Multi-hop cycles (a→b→a) are not detectable in one pass — left as future hardening; in practice admins won't create cycles by accident, and `parent_chat_id` is admin-only via DB until Phase 4 mutations land.
+- **Telethon load:** tree endpoint deliberately does NOT enrich nodes with member_count to avoid N+1 RPCs on every poll.
+- **Route ordering:** `/graph` must be before `/{chat_id}` in the router or it gets shadowed.
+- **No mutation surface yet:** parent_chat_id is set via DB / future Phase 4 admin UI. Phase 3a is read-only.

--- a/tests/unit/test_chat_parent_relationship.py
+++ b/tests/unit/test_chat_parent_relationship.py
@@ -1,0 +1,48 @@
+"""Unit tests: Chat self-referencing parent/children relationship."""
+
+from __future__ import annotations
+
+import pytest
+from app.db.models import Chat
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_chat_parent_and_children_navigate_both_directions(session) -> None:
+    root = Chat(id=-100, title="ČVUT")
+    child_a = Chat(id=-101, title="FEL", parent_chat_id=-100)
+    child_b = Chat(id=-102, title="FIT", parent_chat_id=-100, relation_notes="faculty")
+    session.add_all([root, child_a, child_b])
+    await session.commit()
+
+    fetched_root = (await session.execute(select(Chat).where(Chat.id == -100))).scalar_one()
+    await session.refresh(fetched_root, ["children"])
+    children_ids = sorted(c.id for c in fetched_root.children)
+    assert children_ids == [-102, -101]
+
+    fetched_child = (await session.execute(select(Chat).where(Chat.id == -101))).scalar_one()
+    await session.refresh(fetched_child, ["parent"])
+    assert fetched_child.parent is not None
+    assert fetched_child.parent.id == -100
+    assert fetched_child.parent.title == "ČVUT"
+
+
+async def test_chat_relation_notes_persists(session) -> None:
+    root = Chat(id=-200, title="Parent")
+    child = Chat(id=-201, title="Child", parent_chat_id=-200, relation_notes="advertised by")
+    session.add_all([root, child])
+    await session.commit()
+
+    fetched = (await session.execute(select(Chat).where(Chat.id == -201))).scalar_one()
+    assert fetched.relation_notes == "advertised by"
+
+
+async def test_chat_default_parent_chat_id_is_none(session) -> None:
+    chat = Chat(id=-300, title="Standalone")
+    session.add(chat)
+    await session.commit()
+
+    fetched = (await session.execute(select(Chat).where(Chat.id == -300))).scalar_one()
+    assert fetched.parent_chat_id is None
+    assert fetched.relation_notes is None

--- a/tests/webapi/test_chats_graph.py
+++ b/tests/webapi/test_chats_graph.py
@@ -1,0 +1,124 @@
+"""Tests for /api/chats/graph tree endpoint."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from app.core.config import settings
+from app.db.models import Chat
+from app.webapi.main import app
+from httpx import ASGITransport, AsyncClient
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def client_factory(db_session_maker: async_sessionmaker[AsyncSession]):
+    from app.webapi.deps import get_session, get_telethon
+
+    async def _override_get_session():
+        async with db_session_maker() as session:
+            yield session
+
+    async def _override_get_telethon():
+        return None
+
+    app.dependency_overrides[get_session] = _override_get_session
+    app.dependency_overrides[get_telethon] = _override_get_telethon
+    settings.admin.super_admins = [1]
+    transport = ASGITransport(app=app)
+
+    def make() -> AsyncClient:
+        return AsyncClient(transport=transport, base_url="http://test")
+
+    yield make
+    app.dependency_overrides.pop(get_session, None)
+    app.dependency_overrides.pop(get_telethon, None)
+
+
+async def _seed(session_maker, chats: list[tuple[int, str | None, int | None]]) -> None:
+    async with session_maker() as session:
+        for chat_id, title, parent_id in chats:
+            session.add(Chat(id=chat_id, title=title, parent_chat_id=parent_id))
+        await session.commit()
+
+
+async def test_graph_empty_db_returns_empty_list(client_factory) -> None:
+    async with client_factory() as client:
+        resp = await client.get("/api/chats/graph")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_graph_one_root_two_children(client_factory, db_session_maker) -> None:
+    await _seed(
+        db_session_maker,
+        [
+            (-100, "ČVUT", None),
+            (-101, "FEL", -100),
+            (-102, "FIT", -100),
+        ],
+    )
+
+    async with client_factory() as client:
+        resp = await client.get("/api/chats/graph")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    root = body[0]
+    assert root["id"] == -100
+    child_ids = sorted(c["id"] for c in root["children"])
+    assert child_ids == [-102, -101]
+    for c in root["children"]:
+        assert c["children"] == []
+
+
+async def test_graph_orphan_becomes_root(client_factory, db_session_maker) -> None:
+    # parent_chat_id points to a chat that doesn't exist in the table
+    await _seed(db_session_maker, [(-101, "Orphan", -999)])
+
+    async with client_factory() as client:
+        resp = await client.get("/api/chats/graph")
+
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["id"] == -101
+
+
+async def test_graph_self_loop_treated_as_root(client_factory, db_session_maker) -> None:
+    await _seed(db_session_maker, [(-200, "SelfRef", -200)])
+
+    async with client_factory() as client:
+        resp = await client.get("/api/chats/graph")
+
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["id"] == -200
+    assert body[0]["children"] == []
+
+
+async def test_graph_three_levels_nested(client_factory, db_session_maker) -> None:
+    await _seed(
+        db_session_maker,
+        [
+            (-1, "Uni", None),
+            (-2, "Faculty", -1),
+            (-3, "Department", -2),
+        ],
+    )
+
+    async with client_factory() as client:
+        resp = await client.get("/api/chats/graph")
+
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["id"] == -1
+    assert len(body[0]["children"]) == 1
+    assert body[0]["children"][0]["id"] == -2
+    assert len(body[0]["children"][0]["children"]) == 1
+    assert body[0]["children"][0]["children"][0]["id"] == -3

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -106,6 +106,35 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chats/graph": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Chat Graph
+         * @description Return chat tree with roots first; children nested via parent_chat_id.
+         *
+         *     Single SQL query; tree assembly is in-memory. Telethon enrichment is
+         *     intentionally skipped for the tree endpoint — tile renders 1+ times
+         *     per poll, member_count drilldown lives on /chats/:id.
+         *
+         *     Self-loops (parent_chat_id == id) and orphans (parent_chat_id points
+         *     to a missing/deleted chat) become roots; multi-hop cycles aren't
+         *     detected here — admins set parent_chat_id manually so cycles would
+         *     be intentional misuse, not a runtime hazard.
+         */
+        get: operations["get_chat_graph_api_chats_graph_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/chats/{chat_id}": {
         parameters: {
             query?: never;
@@ -266,7 +295,7 @@ export interface components {
         };
         /**
          * ChatDetail
-         * @description Full chat payload — adds heatmap grid + member-snapshot series.
+         * @description Full chat payload — adds heatmap grid + member-snapshot series + relationships.
          */
         ChatDetail: {
             /** Id */
@@ -279,6 +308,10 @@ export interface components {
             is_welcome_enabled: boolean;
             /** Is Captcha Enabled */
             is_captcha_enabled: boolean;
+            /** Parent Chat Id */
+            parent_chat_id?: number | null;
+            /** Relation Notes */
+            relation_notes?: string | null;
             /** Member Count */
             member_count?: number | null;
             /**
@@ -299,6 +332,11 @@ export interface components {
             heatmap: components["schemas"]["HeatmapCell"][];
             /** Member Snapshots */
             member_snapshots: components["schemas"]["MemberSnapshotPoint"][];
+            /**
+             * Children
+             * @default []
+             */
+            children: components["schemas"]["ChatNode"][];
         };
         /**
          * ChatHeatmapSummary
@@ -316,6 +354,27 @@ export interface components {
             total_messages: number;
         };
         /**
+         * ChatNode
+         * @description Recursive node for the /chats/graph tree response.
+         *
+         *     member_count is intentionally NOT enriched here — the tree endpoint
+         *     skips Telethon to avoid N+1 RPCs on every poll. Drill into /chats/:id
+         *     for live counts.
+         */
+        ChatNode: {
+            /** Id */
+            id: number;
+            /** Title */
+            title: string | null;
+            /** Relation Notes */
+            relation_notes?: string | null;
+            /**
+             * Children
+             * @default []
+             */
+            children: components["schemas"]["ChatNode"][];
+        };
+        /**
          * ChatRead
          * @description List-page view of a managed chat.
          */
@@ -330,6 +389,10 @@ export interface components {
             is_welcome_enabled: boolean;
             /** Is Captcha Enabled */
             is_captcha_enabled: boolean;
+            /** Parent Chat Id */
+            parent_chat_id?: number | null;
+            /** Relation Notes */
+            relation_notes?: string | null;
             /** Member Count */
             member_count?: number | null;
             /**
@@ -755,6 +818,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChatRead"][];
+                };
+            };
+        };
+    };
+    get_chat_graph_api_chats_graph_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatNode"][];
                 };
             };
         };

--- a/webui/src/lib/components/chat/ChatTreeNode.svelte
+++ b/webui/src/lib/components/chat/ChatTreeNode.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import type { components } from '$lib/api/types';
+	import { untrack } from 'svelte';
+	import Self from './ChatTreeNode.svelte';
+
+	type Node = components['schemas']['ChatNode'];
+	type Props = { node: Node; depth?: number };
+	let { node, depth = 0 }: Props = $props();
+
+	let expanded = $state(untrack(() => depth < 2));
+	const hasChildren = $derived(node.children.length > 0);
+</script>
+
+<li class="space-y-1">
+	<div class="flex items-center gap-2 text-sm">
+		{#if hasChildren}
+			<button
+				type="button"
+				class="w-3 text-xs text-zinc-500 hover:text-zinc-900"
+				aria-label={expanded ? 'Collapse' : 'Expand'}
+				onclick={() => (expanded = !expanded)}
+			>
+				{expanded ? '▾' : '▸'}
+			</button>
+		{:else}
+			<span class="w-3"></span>
+		{/if}
+		<button
+			type="button"
+			class="truncate text-zinc-800 hover:underline"
+			onclick={() => goto(`/chats/${node.id}`)}
+			title={node.title ?? `#${node.id}`}
+		>
+			{node.title ?? `#${node.id}`}
+		</button>
+		{#if node.relation_notes}
+			<span class="truncate text-xs text-zinc-400">· {node.relation_notes}</span>
+		{/if}
+		{#if hasChildren}
+			<span class="ml-auto text-xs text-zinc-400">{node.children.length}</span>
+		{/if}
+	</div>
+	{#if expanded && hasChildren}
+		<ul class="ml-4 space-y-1 border-l border-zinc-200 pl-2">
+			{#each node.children as child (child.id)}
+				<Self node={child} depth={depth + 1} />
+			{/each}
+		</ul>
+	{/if}
+</li>

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ChatTreeNode from '$lib/components/chat/ChatTreeNode.svelte';
 	import BarChartH from '$lib/components/charts/BarChartH.svelte';
 	import DivergingBars from '$lib/components/charts/DivergingBars.svelte';
 	import Donut from '$lib/components/charts/Donut.svelte';
@@ -10,8 +11,10 @@
 	import type { components } from '$lib/api/types';
 
 	type HomeStats = components['schemas']['HomeStats'];
+	type Tree = components['schemas']['ChatNode'][];
 
 	const stats = useLivePoll<HomeStats>('/api/stats/home');
+	const tree = useLivePoll<Tree>('/api/chats/graph', 120_000);
 
 	const totalDrafts = $derived(
 		stats.data?.drafts.reduce((acc, d) => acc + d.count, 0) ?? 0
@@ -128,11 +131,27 @@
 			/>
 		</div>
 
-		<div class="md:col-span-2 xl:col-span-1">
+		<div class="md:col-span-2 xl:col-span-2">
 			<SkeletonTile title="Spam pings" phase={3} hint="Needs spam detector." />
 		</div>
-		<div class="md:col-span-2 xl:col-span-1">
-			<SkeletonTile title="Chat graph" phase={3} hint="Needs relationship model." />
+
+		<div class="md:col-span-2 xl:col-span-2">
+			<Tile title="Chat graph">
+				{#if tree.loading}
+					<p class="text-xs text-zinc-500">loading…</p>
+				{:else if !tree.data || tree.data.length === 0}
+					<p class="text-xs text-zinc-500">No chats yet.</p>
+				{:else}
+					<ul class="space-y-1">
+						{#each tree.data.slice(0, 3) as root (root.id)}
+							<ChatTreeNode node={root} depth={1} />
+						{/each}
+					</ul>
+					<a href="/chats/graph" class="mt-2 inline-block text-xs text-zinc-500 hover:underline">
+						View full tree →
+					</a>
+				{/if}
+			</Tile>
 		</div>
 	</div>
 </div>

--- a/webui/src/routes/chats/[id]/+page.svelte
+++ b/webui/src/routes/chats/[id]/+page.svelte
@@ -60,5 +60,41 @@
 				{/if}
 			</Card.Content>
 		</Card.Root>
+
+		{#if detail.data.parent_chat_id !== null || detail.data.children.length > 0}
+			<Card.Root>
+				<Card.Header><Card.Title class="text-sm">Relationships</Card.Title></Card.Header>
+				<Card.Content class="space-y-2 text-sm">
+					{#if detail.data.parent_chat_id !== null}
+						<div class="flex items-baseline gap-2">
+							<span class="text-zinc-500">Parent:</span>
+							<a href="/chats/{detail.data.parent_chat_id}" class="text-zinc-800 hover:underline">
+								#{detail.data.parent_chat_id}
+							</a>
+							{#if detail.data.relation_notes}
+								<span class="text-xs text-zinc-400">· {detail.data.relation_notes}</span>
+							{/if}
+						</div>
+					{/if}
+					{#if detail.data.children.length > 0}
+						<div class="space-y-1">
+							<span class="text-zinc-500">Children ({detail.data.children.length}):</span>
+							<ul class="ml-4 list-disc space-y-0.5">
+								{#each detail.data.children as c (c.id)}
+									<li>
+										<a href="/chats/{c.id}" class="text-zinc-800 hover:underline">
+											{c.title ?? `#${c.id}`}
+										</a>
+										{#if c.relation_notes}
+											<span class="text-xs text-zinc-400">· {c.relation_notes}</span>
+										{/if}
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
+				</Card.Content>
+			</Card.Root>
+		{/if}
 	{/if}
 </div>

--- a/webui/src/routes/chats/graph/+page.svelte
+++ b/webui/src/routes/chats/graph/+page.svelte
@@ -1,5 +1,59 @@
 <script lang="ts">
-	import ComingSoon from '$lib/components/ComingSoon.svelte';
+	import ChatTreeNode from '$lib/components/chat/ChatTreeNode.svelte';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
+	import type { components } from '$lib/api/types';
+
+	type Tree = components['schemas']['ChatNode'][];
+	const tree = useLivePoll<Tree>('/api/chats/graph', 60_000);
+
+	const totalChats = $derived.by(() => {
+		const count = (nodes: Tree): number =>
+			nodes.reduce((acc, n) => acc + 1 + count(n.children), 0);
+		return tree.data ? count(tree.data) : 0;
+	});
 </script>
 
-<ComingSoon title="Chat graph" phase={3} />
+<div class="mx-auto max-w-3xl space-y-4 px-6 py-6">
+	<header class="flex items-baseline justify-between">
+		<h2 class="text-lg font-semibold tracking-tight">Chat graph</h2>
+		<div class="flex items-center gap-3 text-xs text-zinc-500">
+			{#if !tree.loading && tree.data}
+				<span>{totalChats} chats</span>
+			{/if}
+			{#if tree.error}
+				<span class="text-red-600">Error: {tree.error}</span>
+			{:else if tree.lastUpdatedAt}
+				<span>Updated {tree.lastUpdatedAt.toLocaleTimeString()}</span>
+			{/if}
+			<button
+				type="button"
+				class="rounded-md border border-zinc-200 px-2 py-1 text-xs font-medium hover:bg-zinc-100"
+				onclick={() => tree.refresh()}
+			>
+				Refresh
+			</button>
+		</div>
+	</header>
+
+	<Card.Root>
+		<Card.Content class="py-4">
+			{#if tree.loading}
+				<p class="text-sm text-zinc-500">Loading…</p>
+			{:else if tree.error}
+				<p class="text-sm text-red-600">Error: {tree.error}</p>
+			{:else if !tree.data || tree.data.length === 0}
+				<p class="text-sm text-zinc-500">
+					No chats found. Set <code class="rounded bg-zinc-100 px-1 py-0.5 text-xs">parent_chat_id</code> on any
+					chat row to build the tree.
+				</p>
+			{:else}
+				<ul class="space-y-1">
+					{#each tree.data as root (root.id)}
+						<ChatTreeNode node={root} />
+					{/each}
+				</ul>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+</div>


### PR DESCRIPTION
## Summary

Phase 3a of the admin web UI — turns the \`Chat graph\` skeleton + the \`/chats/graph\` ComingSoon stub into a working tree viewer of parent → child chat relationships.

**Backend**
- Migration adds \`Chat.parent_chat_id\` (self-FK, \`ondelete=SET NULL\`) + \`relation_notes\`. Single nullable column; no backfill.
- \`GET /api/chats/graph\` returns sorted tree of \`ChatNode\` roots with nested \`children\`. Orphans + self-loops become roots; multi-hop cycles aren't detectable in one pass and are out of scope (admin-set field).
- \`ChatRead\` / \`ChatDetail\` now expose \`parent_chat_id\` + \`relation_notes\`; detail embeds \`children\` list.

**Frontend**
- \`ChatTreeNode.svelte\` — recursive collapsible row, click-through to chat detail.
- \`/chats/graph\` — live-poll tree viewer.
- \`/chats/[id]\` — new \`Relationships\` card, rendered only when parent or children exist.
- Home — Chat-graph \`SkeletonTile\` replaced with a live mini-tree (top 3 roots) + \"View full tree →\" link.

## Test plan
- [x] \`alembic upgrade head\` applies migration cleanly
- [x] new ORM tests (3) + API tests (5) — 19 / 19 nearby tests pass
- [x] \`ruff check\` + \`ty check\` clean (the 7 pre-existing ty diagnostics on main are not introduced here)
- [x] \`svelte-check\` — 0 errors / 0 warnings
- [ ] visual smoke on \`/chats/graph\` after merge: set \`parent_chat_id\` on a couple of chats via DB and confirm tree renders + drilldowns work

## Out of scope (Phase 3b / 3c follow-ups)
- Spam / ad detector → Phase 3b
- \`/agent\` SSE chat → Phase 3c
- Mutation UI for setting \`parent_chat_id\` → Phase 4 (today set via DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)