### PR TITLE
feat(webui): Phase 4c — channel CRUD + RSS source management

### DIFF
--- a/app/webapi/routes/channels.py
+++ b/app/webapi/routes/channels.py
@@ -1,4 +1,4 @@
-"""Channels — list and detail endpoints."""
+"""Channels — list, detail, and mutation endpoints."""
 
 from __future__ import annotations
 
@@ -6,11 +6,24 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.channel import channel_repo, source_manager
 from app.db.models import Channel, ChannelPost, ChannelSource
+from app.db.session import create_session_maker
 from app.webapi.deps import get_session, require_super_admin
-from app.webapi.schemas import ChannelDetail, ChannelRead, ChannelSourceRead, PostRead
+from app.webapi.schemas import (
+    ChannelCreate,
+    ChannelDetail,
+    ChannelMutationResponse,
+    ChannelRead,
+    ChannelSourceCreate,
+    ChannelSourceRead,
+    ChannelSourceUpdate,
+    ChannelUpdate,
+    PostRead,
+)
 
 router = APIRouter(prefix="/channels", tags=["channels"])
 
@@ -26,12 +39,153 @@ async def list_channels(
     return list(result.scalars().all())
 
 
+@router.post("", response_model=ChannelDetail, status_code=201)
+async def create_channel(
+    payload: ChannelCreate,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ChannelDetail:
+    try:
+        channel = await channel_repo.create_channel(
+            create_session_maker(),
+            telegram_id=payload.telegram_id,
+            name=payload.name,
+            description=payload.description,
+            language=payload.language,
+            username=payload.username,
+            review_chat_id=payload.review_chat_id,
+            max_posts_per_day=payload.max_posts_per_day,
+            posting_schedule=payload.posting_schedule,
+            discovery_query=payload.discovery_query,
+            source_discovery_query=payload.source_discovery_query,
+        )
+    except IntegrityError as err:
+        raise HTTPException(
+            status_code=409, detail=f"Channel with telegram_id {payload.telegram_id} already exists"
+        ) from err
+    session.expire_all()
+    return await _load_detail(session, channel.id)
+
+
 @router.get("/{channel_id}", response_model=ChannelDetail)
 async def get_channel(
     channel_id: int,
     session: Annotated[AsyncSession, Depends(get_session)],
     _admin_id: Annotated[int, Depends(require_super_admin)],
 ) -> ChannelDetail:
+    return await _load_detail(session, channel_id)
+
+
+@router.patch("/{channel_id}", response_model=ChannelDetail)
+async def update_channel(
+    channel_id: int,
+    payload: ChannelUpdate,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ChannelDetail:
+    channel = (await session.execute(select(Channel).where(Channel.id == channel_id))).scalar_one_or_none()
+    if channel is None:
+        raise HTTPException(status_code=404, detail=f"Channel {channel_id} not found")
+    fields = payload.model_dump(exclude_unset=True)
+    if not fields:
+        return await _load_detail(session, channel_id)
+    updated = await channel_repo.update_channel(create_session_maker(), channel.telegram_id, **fields)
+    if updated is None:
+        raise HTTPException(status_code=404, detail=f"Channel {channel_id} not found")
+    # Repo wrote via its own session; drop request-session's identity map so
+    # the follow-up SELECT in _load_detail sees the new values.
+    session.expire_all()
+    return await _load_detail(session, channel_id)
+
+
+@router.delete("/{channel_id}", response_model=ChannelMutationResponse)
+async def delete_channel(
+    channel_id: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ChannelMutationResponse:
+    channel = (await session.execute(select(Channel).where(Channel.id == channel_id))).scalar_one_or_none()
+    if channel is None:
+        raise HTTPException(status_code=404, detail=f"Channel {channel_id} not found")
+    deleted = await channel_repo.delete_channel(create_session_maker(), channel.telegram_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Channel {channel_id} not found")
+    return ChannelMutationResponse(channel_id=channel_id, message=f"Channel '{channel.name}' deleted.")
+
+
+@router.post("/{channel_id}/sources", response_model=ChannelSourceRead, status_code=201)
+async def add_source(
+    channel_id: int,
+    payload: ChannelSourceCreate,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ChannelSource:
+    channel = (await session.execute(select(Channel).where(Channel.id == channel_id))).scalar_one_or_none()
+    if channel is None:
+        raise HTTPException(status_code=404, detail=f"Channel {channel_id} not found")
+    added = await source_manager.add_source(
+        create_session_maker(),
+        channel_id=channel.telegram_id,
+        url=payload.url,
+        title=payload.title,
+        added_by="webui",
+    )
+    if not added:
+        raise HTTPException(status_code=409, detail="Source URL already exists for this channel")
+    return (
+        await session.execute(
+            select(ChannelSource).where(
+                ChannelSource.channel_id == channel.telegram_id, ChannelSource.url == payload.url
+            )
+        )
+    ).scalar_one()
+
+
+@router.patch("/{channel_id}/sources/{source_id}", response_model=ChannelSourceRead)
+async def update_source(
+    channel_id: int,
+    source_id: int,
+    payload: ChannelSourceUpdate,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ChannelSource:
+    src = (
+        await session.execute(
+            select(ChannelSource)
+            .join(Channel, Channel.telegram_id == ChannelSource.channel_id)
+            .where(ChannelSource.id == source_id, Channel.id == channel_id)
+        )
+    ).scalar_one_or_none()
+    if src is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+    src.enabled = payload.enabled
+    await session.commit()
+    await session.refresh(src)
+    return src
+
+
+@router.delete("/{channel_id}/sources/{source_id}", response_model=ChannelMutationResponse)
+async def delete_source(
+    channel_id: int,
+    source_id: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ChannelMutationResponse:
+    src = (
+        await session.execute(
+            select(ChannelSource)
+            .join(Channel, Channel.telegram_id == ChannelSource.channel_id)
+            .where(ChannelSource.id == source_id, Channel.id == channel_id)
+        )
+    ).scalar_one_or_none()
+    if src is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+    await session.delete(src)
+    await session.commit()
+    return ChannelMutationResponse(channel_id=channel_id, message="Source removed.")
+
+
+async def _load_detail(session: AsyncSession, channel_id: int) -> ChannelDetail:
     channel = (await session.execute(select(Channel).where(Channel.id == channel_id))).scalar_one_or_none()
     if channel is None:
         raise HTTPException(status_code=404, detail=f"Channel {channel_id} not found")

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -78,6 +78,53 @@ class ChannelDetail(ChannelRead):
     recent_posts: list[PostRead]
 
 
+class ChannelCreate(BaseModel):
+    """Required + optional fields for creating a new channel."""
+
+    telegram_id: int
+    name: str
+    description: str = ""
+    language: str = "ru"
+    username: str | None = None
+    review_chat_id: int | None = None
+    max_posts_per_day: int = 3
+    posting_schedule: list[str] | None = None
+    discovery_query: str = ""
+    source_discovery_query: str = ""
+
+
+class ChannelUpdate(BaseModel):
+    """All fields are optional — only the keys present in the body are applied."""
+
+    name: str | None = None
+    description: str | None = None
+    language: str | None = None
+    username: str | None = None
+    enabled: bool | None = None
+    review_chat_id: int | None = None
+    max_posts_per_day: int | None = None
+    posting_schedule: list[str] | None = None
+    publish_schedule: list[str] | None = None
+    footer_template: str | None = None
+    discovery_query: str | None = None
+    source_discovery_query: str | None = None
+    critic_enabled: bool | None = None
+
+
+class ChannelMutationResponse(BaseModel):
+    channel_id: int
+    message: str
+
+
+class ChannelSourceCreate(BaseModel):
+    url: str
+    title: str | None = None
+
+
+class ChannelSourceUpdate(BaseModel):
+    enabled: bool
+
+
 class ChatRead(BaseModel):
     """List-page view of a managed chat."""
 

--- a/tests/webapi/test_channel_mutations.py
+++ b/tests/webapi/test_channel_mutations.py
@@ -1,0 +1,175 @@
+"""Tests for channel + source mutations on /api/channels."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from app.core.config import settings
+from app.db.models import Channel, ChannelSource
+from app.webapi.main import app
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def client_factory(db_session_maker: async_sessionmaker[AsyncSession], monkeypatch):
+    from app.webapi.deps import get_session
+
+    async def _override_session():
+        async with db_session_maker() as s:
+            yield s
+
+    # Mutation handlers reach for `create_session_maker()` to open their own
+    # session for the repo calls — point it at the in-memory test maker.
+    from app.webapi.routes import channels as channels_route
+
+    monkeypatch.setattr(channels_route, "create_session_maker", lambda: db_session_maker)
+
+    app.dependency_overrides[get_session] = _override_session
+    settings.admin.super_admins = [1]
+    settings.webapi.dev_bypass_auth = True
+    transport = ASGITransport(app=app)
+
+    def make() -> AsyncClient:
+        return AsyncClient(transport=transport, base_url="http://test")
+
+    yield make
+    app.dependency_overrides.pop(get_session, None)
+
+
+async def _seed_channel(session: AsyncSession, *, telegram_id: int = -100300) -> int:
+    ch = Channel(name="seed", language="en", telegram_id=telegram_id)
+    session.add(ch)
+    await session.commit()
+    await session.refresh(ch)
+    return ch.id
+
+
+async def test_create_channel_returns_detail(client_factory) -> None:
+    async with client_factory() as client:
+        resp = await client.post(
+            "/api/channels",
+            json={"telegram_id": -100400, "name": "new", "language": "en", "description": "d"},
+        )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "new"
+    assert body["telegram_id"] == -100400
+    assert body["sources"] == []
+    assert body["recent_posts"] == []
+
+
+async def test_create_channel_409_on_duplicate_telegram_id(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        await _seed_channel(s, telegram_id=-100401)
+
+    async with client_factory() as client:
+        resp = await client.post("/api/channels", json={"telegram_id": -100401, "name": "dup"})
+    assert resp.status_code == 409
+
+
+async def test_update_channel_changes_fields(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        channel_id = await _seed_channel(s)
+
+    async with client_factory() as client:
+        resp = await client.patch(
+            f"/api/channels/{channel_id}",
+            json={"name": "renamed", "max_posts_per_day": 7, "enabled": False},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "renamed"
+    assert body["max_posts_per_day"] == 7
+    assert body["enabled"] is False
+
+
+async def test_update_channel_404(client_factory) -> None:
+    async with client_factory() as client:
+        resp = await client.patch("/api/channels/9999", json={"name": "x"})
+    assert resp.status_code == 404
+
+
+async def test_delete_channel(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        channel_id = await _seed_channel(s)
+
+    async with client_factory() as client:
+        resp = await client.delete(f"/api/channels/{channel_id}")
+    assert resp.status_code == 200, resp.text
+
+    async with db_session_maker() as s:
+        gone = (await s.execute(select(Channel).where(Channel.id == channel_id))).scalar_one_or_none()
+        assert gone is None
+
+
+async def test_add_source_creates_row(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        channel_id = await _seed_channel(s)
+
+    async with client_factory() as client:
+        resp = await client.post(
+            f"/api/channels/{channel_id}/sources",
+            json={"url": "https://example.com/feed.xml", "title": "Example"},
+        )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["url"] == "https://example.com/feed.xml"
+    assert body["enabled"] is True
+
+
+async def test_add_source_409_on_duplicate(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        channel_id = await _seed_channel(s)
+        ch = (await s.execute(select(Channel).where(Channel.id == channel_id))).scalar_one()
+        s.add(ChannelSource(channel_id=ch.telegram_id, url="https://dup.example/feed"))
+        await s.commit()
+
+    async with client_factory() as client:
+        resp = await client.post(
+            f"/api/channels/{channel_id}/sources",
+            json={"url": "https://dup.example/feed"},
+        )
+    assert resp.status_code == 409
+
+
+async def test_toggle_source_enabled(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        channel_id = await _seed_channel(s)
+        ch = (await s.execute(select(Channel).where(Channel.id == channel_id))).scalar_one()
+        src = ChannelSource(channel_id=ch.telegram_id, url="https://x.example/feed")
+        s.add(src)
+        await s.commit()
+        source_id = src.id
+
+    async with client_factory() as client:
+        resp = await client.patch(
+            f"/api/channels/{channel_id}/sources/{source_id}",
+            json={"enabled": False},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["enabled"] is False
+
+
+async def test_delete_source(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        channel_id = await _seed_channel(s)
+        ch = (await s.execute(select(Channel).where(Channel.id == channel_id))).scalar_one()
+        src = ChannelSource(channel_id=ch.telegram_id, url="https://y.example/feed")
+        s.add(src)
+        await s.commit()
+        source_id = src.id
+
+    async with client_factory() as client:
+        resp = await client.delete(f"/api/channels/{channel_id}/sources/{source_id}")
+    assert resp.status_code == 200, resp.text
+
+    async with db_session_maker() as s:
+        gone = (await s.execute(select(ChannelSource).where(ChannelSource.id == source_id))).scalar_one_or_none()
+        assert gone is None

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -167,7 +167,8 @@ export interface paths {
         /** List Channels */
         get: operations["list_channels_api_channels_get"];
         put?: never;
-        post?: never;
+        /** Create Channel */
+        post: operations["create_channel_api_channels_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -185,10 +186,47 @@ export interface paths {
         get: operations["get_channel_api_channels__channel_id__get"];
         put?: never;
         post?: never;
+        /** Delete Channel */
+        delete: operations["delete_channel_api_channels__channel_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Channel */
+        patch: operations["update_channel_api_channels__channel_id__patch"];
+        trace?: never;
+    };
+    "/api/channels/{channel_id}/sources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Add Source */
+        post: operations["add_source_api_channels__channel_id__sources_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/api/channels/{channel_id}/sources/{source_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Source */
+        delete: operations["delete_source_api_channels__channel_id__sources__source_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Source */
+        patch: operations["update_source_api_channels__channel_id__sources__source_id__patch"];
         trace?: never;
     };
     "/api/chats": {
@@ -422,6 +460,47 @@ export interface components {
             is_authenticated: boolean;
         };
         /**
+         * ChannelCreate
+         * @description Required + optional fields for creating a new channel.
+         */
+        ChannelCreate: {
+            /** Telegram Id */
+            telegram_id: number;
+            /** Name */
+            name: string;
+            /**
+             * Description
+             * @default
+             */
+            description: string;
+            /**
+             * Language
+             * @default ru
+             */
+            language: string;
+            /** Username */
+            username?: string | null;
+            /** Review Chat Id */
+            review_chat_id?: number | null;
+            /**
+             * Max Posts Per Day
+             * @default 3
+             */
+            max_posts_per_day: number;
+            /** Posting Schedule */
+            posting_schedule?: string[] | null;
+            /**
+             * Discovery Query
+             * @default
+             */
+            discovery_query: string;
+            /**
+             * Source Discovery Query
+             * @default
+             */
+            source_discovery_query: string;
+        };
+        /**
          * ChannelDetail
          * @description Full channel payload — adds config + sources + recent posts summary.
          */
@@ -469,6 +548,13 @@ export interface components {
             /** Recent Posts */
             recent_posts: components["schemas"]["PostRead"][];
         };
+        /** ChannelMutationResponse */
+        ChannelMutationResponse: {
+            /** Channel Id */
+            channel_id: number;
+            /** Message */
+            message: string;
+        };
         /**
          * ChannelRead
          * @description List-page view of a channel — identifying + toggle fields only.
@@ -498,6 +584,13 @@ export interface components {
              */
             created_at: string;
         };
+        /** ChannelSourceCreate */
+        ChannelSourceCreate: {
+            /** Url */
+            url: string;
+            /** Title */
+            title?: string | null;
+        };
         /**
          * ChannelSourceRead
          * @description RSS source attached to a channel.
@@ -523,6 +616,43 @@ export interface components {
             last_fetched_at: string | null;
             /** Last Error */
             last_error: string | null;
+        };
+        /** ChannelSourceUpdate */
+        ChannelSourceUpdate: {
+            /** Enabled */
+            enabled: boolean;
+        };
+        /**
+         * ChannelUpdate
+         * @description All fields are optional — only the keys present in the body are applied.
+         */
+        ChannelUpdate: {
+            /** Name */
+            name?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Language */
+            language?: string | null;
+            /** Username */
+            username?: string | null;
+            /** Enabled */
+            enabled?: boolean | null;
+            /** Review Chat Id */
+            review_chat_id?: number | null;
+            /** Max Posts Per Day */
+            max_posts_per_day?: number | null;
+            /** Posting Schedule */
+            posting_schedule?: string[] | null;
+            /** Publish Schedule */
+            publish_schedule?: string[] | null;
+            /** Footer Template */
+            footer_template?: string | null;
+            /** Discovery Query */
+            discovery_query?: string | null;
+            /** Source Discovery Query */
+            source_discovery_query?: string | null;
+            /** Critic Enabled */
+            critic_enabled?: boolean | null;
         };
         /**
          * ChatDetail
@@ -1261,6 +1391,39 @@ export interface operations {
             };
         };
     };
+    create_channel_api_channels_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChannelCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChannelDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_channel_api_channels__channel_id__get: {
         parameters: {
             query?: never;
@@ -1279,6 +1442,175 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChannelDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_channel_api_channels__channel_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                channel_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChannelMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_channel_api_channels__channel_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                channel_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChannelUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChannelDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    add_source_api_channels__channel_id__sources_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                channel_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChannelSourceCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChannelSourceRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_source_api_channels__channel_id__sources__source_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                channel_id: number;
+                source_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChannelMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_source_api_channels__channel_id__sources__source_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                channel_id: number;
+                source_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChannelSourceUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChannelSourceRead"];
                 };
             };
             /** @description Validation Error */

--- a/webui/src/routes/channels/+page.svelte
+++ b/webui/src/routes/channels/+page.svelte
@@ -1,30 +1,103 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { apiFetch } from '$lib/api/client';
+	import { toast } from 'svelte-sonner';
 	import type { components } from '$lib/api/types';
 
 	type Channel = components['schemas']['ChannelRead'];
+	type ChannelDetail = components['schemas']['ChannelDetail'];
 
 	let channels = $state<Channel[]>([]);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 
+	let formOpen = $state(false);
+	let saving = $state(false);
+	let form = $state({ telegram_id: '', name: '', language: 'ru', description: '' });
+
+	async function load(): Promise<void> {
+		loading = true;
+		const res = await apiFetch<Channel[]>('/api/channels');
+		if (res.error) error = res.error.message;
+		else {
+			channels = res.data;
+			error = null;
+		}
+		loading = false;
+	}
+
 	$effect(() => {
-		void (async () => {
-			const res = await apiFetch<Channel[]>('/api/channels');
-			if (res.error) {
-				error = res.error.message;
-			} else {
-				channels = res.data;
-			}
-			loading = false;
-		})();
+		void load();
 	});
+
+	async function createChannel(): Promise<void> {
+		const tid = parseInt(form.telegram_id, 10);
+		if (!Number.isFinite(tid) || !form.name.trim()) {
+			toast.error('telegram_id (numeric) and name are required');
+			return;
+		}
+		saving = true;
+		const res = await apiFetch<ChannelDetail>('/api/channels', {
+			method: 'POST',
+			body: JSON.stringify({
+				telegram_id: tid,
+				name: form.name.trim(),
+				language: form.language.trim() || 'ru',
+				description: form.description
+			})
+		});
+		saving = false;
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success(`Channel #${res.data.id} created`);
+			formOpen = false;
+			form = { telegram_id: '', name: '', language: 'ru', description: '' };
+			await goto(`/channels/${res.data.id}`);
+		}
+	}
 </script>
 
 <div class="space-y-4 px-6 py-6">
-	<h2 class="text-lg font-semibold tracking-tight">Channels</h2>
+	<header class="flex items-center justify-between">
+		<h2 class="text-lg font-semibold tracking-tight">Channels</h2>
+		<Button size="sm" onclick={() => (formOpen = !formOpen)}>
+			{formOpen ? 'Cancel' : 'New channel'}
+		</Button>
+	</header>
+
+	{#if formOpen}
+		<div class="grid grid-cols-1 gap-3 rounded-md border border-zinc-200 bg-zinc-50 p-4 md:grid-cols-2">
+			<label class="space-y-1 text-xs">
+				<span class="text-zinc-600">Telegram ID</span>
+				<Input bind:value={form.telegram_id} placeholder="-1001234567890" />
+			</label>
+			<label class="space-y-1 text-xs">
+				<span class="text-zinc-600">Name</span>
+				<Input bind:value={form.name} placeholder="My channel" />
+			</label>
+			<label class="space-y-1 text-xs">
+				<span class="text-zinc-600">Language</span>
+				<Input bind:value={form.language} placeholder="ru" />
+			</label>
+			<label class="space-y-1 text-xs md:col-span-2">
+				<span class="text-zinc-600">Description (optional)</span>
+				<Input bind:value={form.description} />
+			</label>
+			<div class="flex items-center justify-end gap-2 md:col-span-2">
+				<Button variant="ghost" size="sm" onclick={() => (formOpen = false)} disabled={saving}>
+					Cancel
+				</Button>
+				<Button size="sm" onclick={createChannel} disabled={saving}>
+					{saving ? 'Creating…' : 'Create'}
+				</Button>
+			</div>
+		</div>
+	{/if}
+
 	{#if loading}
 		<p class="text-sm text-zinc-500">Loading…</p>
 	{:else if error}
@@ -44,12 +117,15 @@
 				{#each channels as c (c.id)}
 					<Table.Row>
 						<Table.Cell>
-							<a href={`/channels/${c.id}`} class="font-medium text-zinc-900 hover:underline">{c.name}</a>
+							<a
+								href={`/channels/${c.id}`}
+								class="font-medium text-zinc-900 hover:underline">{c.name}</a
+							>
 							{#if c.username}
 								<span class="ml-1 text-xs text-zinc-500">@{c.username}</span>
 							{/if}
 						</Table.Cell>
-						<Table.Cell class="text-xs uppercase text-zinc-600">{c.language}</Table.Cell>
+						<Table.Cell class="text-xs text-zinc-600 uppercase">{c.language}</Table.Cell>
 						<Table.Cell>
 							{#if c.enabled}<Badge>on</Badge>{:else}<Badge variant="secondary">off</Badge>{/if}
 						</Table.Cell>

--- a/webui/src/routes/channels/[id]/+page.svelte
+++ b/webui/src/routes/channels/[id]/+page.svelte
@@ -1,33 +1,157 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { apiFetch } from '$lib/api/client';
+	import { toast } from 'svelte-sonner';
 	import type { components } from '$lib/api/types';
 
 	type ChannelDetail = components['schemas']['ChannelDetail'];
+	type ChannelSourceRead = components['schemas']['ChannelSourceRead'];
+	type ChannelMutationResponse = components['schemas']['ChannelMutationResponse'];
 
 	let channel = $state<ChannelDetail | null>(null);
 	let error = $state<string | null>(null);
 	let loading = $state(true);
 
+	let editing = $state(false);
+	let saving = $state(false);
+	let edit = $state({
+		name: '',
+		description: '',
+		language: '',
+		enabled: true,
+		max_posts_per_day: 3,
+		footer_template: '',
+		posting_schedule: '',
+		publish_schedule: ''
+	});
+
+	let newSourceUrl = $state('');
+	let addingSource = $state(false);
+
 	const channelId = $derived(page.params.id);
 
+	function snapshotEdit(c: ChannelDetail): void {
+		edit = {
+			name: c.name,
+			description: c.description ?? '',
+			language: c.language,
+			enabled: c.enabled,
+			max_posts_per_day: c.max_posts_per_day,
+			footer_template: c.footer_template ?? '',
+			posting_schedule: (c.posting_schedule ?? []).join(', '),
+			publish_schedule: (c.publish_schedule ?? []).join(', ')
+		};
+	}
+
+	function parseSchedule(s: string): string[] | null {
+		const parts = s
+			.split(',')
+			.map((p) => p.trim())
+			.filter(Boolean);
+		return parts.length ? parts : null;
+	}
+
+	async function load(): Promise<void> {
+		loading = true;
+		const res = await apiFetch<ChannelDetail>(`/api/channels/${channelId}`);
+		if (res.error) {
+			error = res.error.message;
+			channel = null;
+		} else {
+			channel = res.data;
+			snapshotEdit(res.data);
+			error = null;
+		}
+		loading = false;
+	}
+
 	$effect(() => {
-		void (async () => {
-			loading = true;
-			const res = await apiFetch<ChannelDetail>(`/api/channels/${channelId}`);
-			if (res.error) {
-				error = res.error.message;
-				channel = null;
-			} else {
-				channel = res.data;
-				error = null;
-			}
-			loading = false;
-		})();
+		void load();
 	});
+
+	async function saveEdit(): Promise<void> {
+		if (!channel) return;
+		saving = true;
+		const res = await apiFetch<ChannelDetail>(`/api/channels/${channelId}`, {
+			method: 'PATCH',
+			body: JSON.stringify({
+				name: edit.name,
+				description: edit.description,
+				language: edit.language,
+				enabled: edit.enabled,
+				max_posts_per_day: edit.max_posts_per_day,
+				footer_template: edit.footer_template || null,
+				posting_schedule: parseSchedule(edit.posting_schedule),
+				publish_schedule: parseSchedule(edit.publish_schedule)
+			})
+		});
+		saving = false;
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success('Channel updated');
+			channel = res.data;
+			snapshotEdit(res.data);
+			editing = false;
+		}
+	}
+
+	async function deleteChannel(): Promise<void> {
+		if (!channel) return;
+		if (!confirm(`Delete channel "${channel.name}"? This is permanent.`)) return;
+		const res = await apiFetch<ChannelMutationResponse>(`/api/channels/${channelId}`, {
+			method: 'DELETE'
+		});
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success(res.data.message);
+			await goto('/channels');
+		}
+	}
+
+	async function addSource(): Promise<void> {
+		const url = newSourceUrl.trim();
+		if (!url) return;
+		addingSource = true;
+		const res = await apiFetch<ChannelSourceRead>(`/api/channels/${channelId}/sources`, {
+			method: 'POST',
+			body: JSON.stringify({ url })
+		});
+		addingSource = false;
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success('Source added');
+			newSourceUrl = '';
+			await load();
+		}
+	}
+
+	async function toggleSource(s: ChannelSourceRead): Promise<void> {
+		const res = await apiFetch<ChannelSourceRead>(
+			`/api/channels/${channelId}/sources/${s.id}`,
+			{ method: 'PATCH', body: JSON.stringify({ enabled: !s.enabled }) }
+		);
+		if (res.error) toast.error(res.error.message);
+		else await load();
+	}
+
+	async function removeSource(s: ChannelSourceRead): Promise<void> {
+		if (!confirm(`Remove source "${s.title ?? s.url}"?`)) return;
+		const res = await apiFetch<ChannelMutationResponse>(
+			`/api/channels/${channelId}/sources/${s.id}`,
+			{ method: 'DELETE' }
+		);
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success(res.data.message);
+			await load();
+		}
+	}
 </script>
 
 <div class="mx-auto max-w-4xl space-y-4 px-6 py-6">
@@ -36,42 +160,137 @@
 	{:else if error}
 		<p class="text-sm text-red-600">Error: {error}</p>
 	{:else if channel}
-		<header>
-			<div class="text-xs text-zinc-500">
-				<a href="/channels" class="hover:underline">Channels</a> › <span class="font-mono">#{channel.id}</span>
+		<header class="flex items-start justify-between gap-4">
+			<div>
+				<div class="text-xs text-zinc-500">
+					<a href="/channels" class="hover:underline">Channels</a> ›
+					<span class="font-mono">#{channel.id}</span>
+				</div>
+				<h2 class="mt-1 text-xl font-semibold tracking-tight">{channel.name}</h2>
+				<p class="mt-1 text-sm text-zinc-600">{channel.description || '—'}</p>
 			</div>
-			<h2 class="mt-1 text-xl font-semibold tracking-tight">{channel.name}</h2>
-			<p class="mt-1 text-sm text-zinc-600">{channel.description || '—'}</p>
+			<div class="flex shrink-0 items-center gap-2">
+				<Button
+					variant="outline"
+					size="sm"
+					onclick={() => (editing = !editing)}
+					disabled={saving}
+				>
+					{editing ? 'Cancel edit' : 'Edit'}
+				</Button>
+				<Button variant="outline" size="sm" onclick={deleteChannel} disabled={saving || editing}>
+					Delete
+				</Button>
+			</div>
 		</header>
 
 		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 			<Card.Root>
 				<Card.Header><Card.Title class="text-sm">Config</Card.Title></Card.Header>
-				<Card.Content class="space-y-2 text-sm">
-					<div>Telegram ID: <span class="font-mono">{channel.telegram_id}</span></div>
-					<div>Language: <span class="uppercase">{channel.language}</span></div>
-					<div>Enabled: {channel.enabled ? 'yes' : 'no'}</div>
-					<div>Max posts/day: {channel.max_posts_per_day}</div>
-					<div>Review chat: <span class="font-mono">{channel.review_chat_id ?? '—'}</span></div>
-					<div>Posting schedule: {channel.posting_schedule?.join(', ') ?? '—'}</div>
-					<div>Publish schedule: {channel.publish_schedule?.join(', ') ?? '—'}</div>
-					<div>Critic: {channel.critic_enabled ?? 'inherit'}</div>
+				<Card.Content class="space-y-3 text-sm">
+					{#if editing}
+						<label class="block space-y-1">
+							<span class="text-xs text-zinc-600">Name</span>
+							<Input bind:value={edit.name} />
+						</label>
+						<label class="block space-y-1">
+							<span class="text-xs text-zinc-600">Description</span>
+							<Input bind:value={edit.description} />
+						</label>
+						<label class="block space-y-1">
+							<span class="text-xs text-zinc-600">Language</span>
+							<Input bind:value={edit.language} />
+						</label>
+						<label class="block space-y-1">
+							<span class="text-xs text-zinc-600">Max posts / day</span>
+							<Input type="number" bind:value={edit.max_posts_per_day} min="0" />
+						</label>
+						<label class="flex items-center gap-2 text-xs">
+							<input type="checkbox" bind:checked={edit.enabled} />
+							<span>Enabled</span>
+						</label>
+						<label class="block space-y-1">
+							<span class="text-xs text-zinc-600">Footer template</span>
+							<Input bind:value={edit.footer_template} />
+						</label>
+						<label class="block space-y-1">
+							<span class="text-xs text-zinc-600">Posting schedule (comma-separated HH:MM)</span>
+							<Input bind:value={edit.posting_schedule} placeholder="09:00, 13:00, 18:00" />
+						</label>
+						<label class="block space-y-1">
+							<span class="text-xs text-zinc-600">Publish schedule (comma-separated HH:MM)</span>
+							<Input bind:value={edit.publish_schedule} />
+						</label>
+						<div class="flex items-center justify-end gap-2 pt-2">
+							<Button variant="ghost" size="sm" onclick={() => (editing = false)} disabled={saving}>
+								Cancel
+							</Button>
+							<Button size="sm" onclick={saveEdit} disabled={saving}>
+								{saving ? 'Saving…' : 'Save'}
+							</Button>
+						</div>
+					{:else}
+						<div>Telegram ID: <span class="font-mono">{channel.telegram_id}</span></div>
+						<div>Language: <span class="uppercase">{channel.language}</span></div>
+						<div>Enabled: {channel.enabled ? 'yes' : 'no'}</div>
+						<div>Max posts/day: {channel.max_posts_per_day}</div>
+						<div>Review chat: <span class="font-mono">{channel.review_chat_id ?? '—'}</span></div>
+						<div>Posting schedule: {channel.posting_schedule?.join(', ') ?? '—'}</div>
+						<div>Publish schedule: {channel.publish_schedule?.join(', ') ?? '—'}</div>
+						<div>Footer: <span class="text-xs text-zinc-500">{channel.footer_template ?? '—'}</span></div>
+						<div>Critic: {channel.critic_enabled ?? 'inherit'}</div>
+					{/if}
 				</Card.Content>
 			</Card.Root>
 
 			<Card.Root>
 				<Card.Header><Card.Title class="text-sm">Sources ({channel.sources.length})</Card.Title></Card.Header>
-				<Card.Content>
+				<Card.Content class="space-y-3">
+					<form
+						class="flex items-center gap-2"
+						onsubmit={(e) => {
+							e.preventDefault();
+							void addSource();
+						}}
+					>
+						<Input
+							bind:value={newSourceUrl}
+							placeholder="https://example.com/feed.xml"
+							class="flex-1 text-xs"
+							disabled={addingSource}
+						/>
+						<Button type="submit" size="sm" disabled={addingSource || !newSourceUrl.trim()}>
+							{addingSource ? '…' : 'Add'}
+						</Button>
+					</form>
 					{#if channel.sources.length === 0}
 						<p class="text-sm text-zinc-500">No sources configured.</p>
 					{:else}
 						<ul class="flex flex-col gap-2 text-sm">
 							{#each channel.sources as s (s.id)}
-								<li class="flex items-center justify-between gap-2">
+								<li class="flex items-center justify-between gap-2 border-b border-zinc-100 pb-1 last:border-0">
 									<span class="truncate" title={s.url}>{s.title ?? s.url}</span>
-									<span class="shrink-0">
-										{#if s.enabled}<Badge class="text-[10px]">on</Badge>{:else}<Badge variant="secondary" class="text-[10px]">off</Badge>{/if}
-										{#if s.error_count > 0}<Badge variant="destructive" class="text-[10px]">err×{s.error_count}</Badge>{/if}
+									<span class="flex shrink-0 items-center gap-1">
+										{#if s.error_count > 0}<Badge variant="destructive" class="text-[10px]"
+												>err×{s.error_count}</Badge
+											>{/if}
+										<button
+											type="button"
+											class="rounded-md px-2 py-0.5 text-[10px] {s.enabled
+												? 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200'
+												: 'bg-zinc-100 text-zinc-500 hover:bg-zinc-200'}"
+											onclick={() => toggleSource(s)}
+										>
+											{s.enabled ? 'on' : 'off'}
+										</button>
+										<button
+											type="button"
+											class="rounded-md px-1 text-zinc-400 hover:text-red-600"
+											aria-label="Remove source"
+											onclick={() => removeSource(s)}
+										>
+											✕
+										</button>
 									</span>
 								</li>
 							{/each}
@@ -82,7 +301,9 @@
 		</div>
 
 		<Card.Root>
-			<Card.Header><Card.Title class="text-sm">Recent posts ({channel.recent_posts.length})</Card.Title></Card.Header>
+			<Card.Header
+				><Card.Title class="text-sm">Recent posts ({channel.recent_posts.length})</Card.Title></Card.Header
+			>
 			<Card.Content>
 				{#if channel.recent_posts.length === 0}
 					<p class="text-sm text-zinc-500">No posts yet.</p>
@@ -99,8 +320,12 @@
 							{#each channel.recent_posts as p (p.id)}
 								<Table.Row>
 									<Table.Cell><Badge variant="secondary">{p.status}</Badge></Table.Cell>
-									<Table.Cell><a href={`/posts/${p.id}`} class="hover:underline">{p.title}</a></Table.Cell>
-									<Table.Cell class="text-xs text-zinc-500">{new Date(p.created_at).toLocaleString()}</Table.Cell>
+									<Table.Cell>
+										<a href={`/posts/${p.id}`} class="hover:underline">{p.title}</a>
+									</Table.Cell>
+									<Table.Cell class="text-xs text-zinc-500"
+										>{new Date(p.created_at).toLocaleString()}</Table.Cell
+									>
 								</Table.Row>
 							{/each}
 						</Table.Body>


### PR DESCRIPTION
## Summary

Channels are now manageable from the web UI. Create, edit, and delete channels; add, toggle, and remove RSS sources per channel.

## Endpoints

| Method | Path | Body | Returns |
|---|---|---|---|
| POST | \`/api/channels\` | \`ChannelCreate\` | \`ChannelDetail\` (201) |
| PATCH | \`/api/channels/{id}\` | \`ChannelUpdate\` (partial) | \`ChannelDetail\` |
| DELETE | \`/api/channels/{id}\` | — | \`ChannelMutationResponse\` |
| POST | \`/api/channels/{id}/sources\` | \`ChannelSourceCreate\` | \`ChannelSourceRead\` (201) |
| PATCH | \`/api/channels/{id}/sources/{src_id}\` | \`{ enabled: bool }\` | \`ChannelSourceRead\` |
| DELETE | \`/api/channels/{id}/sources/{src_id}\` | — | \`ChannelMutationResponse\` |

\`ChannelUpdate\` only applies fields actually present in the request body (\`exclude_unset=True\`) — the UI's edit form sends a snapshot, but partial updates from API clients work too.

## Service-layer reuse

- \`channel_repo.create_channel / update_channel / delete_channel\` — all already existed
- \`source_manager.add_source\` — already existed; idempotent on (channel_id, url)

The mutation handlers open their own DB session via \`create_session_maker()\` for the repo write, then call \`session.expire_all()\` on the request-scoped session before re-reading via \`_load_detail\`. This avoids the SQLAlchemy identity-map serving stale data after a write that happened on a different session.

## UI

**\`/channels\`**
- "New channel" button reveals an inline form (telegram_id, name, language, description). On success, redirects to the new detail page.

**\`/channels/[id]\`**
- "Edit" toggles the config card into a form (name, description, language, enabled, max_posts/day, footer template, posting/publish schedules)
- "Delete" with confirmation
- Sources card has an inline URL input ("Add"), per-source on/off badge that toggles, and ✕ to remove
- Toast feedback on every mutation

## Tests

- \`tests/webapi/test_channel_mutations.py\` (9):
  - create returns detail
  - create 409 on duplicate telegram_id
  - update changes fields
  - update 404
  - delete
  - add source creates row
  - add source 409 on duplicate
  - toggle source enabled
  - delete source

Full suite: **881 passed**, 2 skipped (pre-existing).

## Out of scope

- **4d** — chat moderation (ban / unban via global blacklist on \`/chats/[id]\`)
- **4e** — \`/settings\` functional surface

## Test plan

- [ ] Open \`/channels\` → "New channel" → create one with a real telegram_id
- [ ] Channel appears in list, redirected to detail
- [ ] Edit name + max_posts/day → Save → reload → values persist
- [ ] Add an RSS feed URL → toast → source appears in list as "on"
- [ ] Click "on" badge → it flips to "off" → reload preserves state
- [ ] ✕ a source → confirm → removed from list
- [ ] Try creating a channel with the same telegram_id → toast error
- [ ] Delete the test channel → bounced back to \`/channels\`, channel gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)