### PR TITLE
feat(webui): Phase 4d — block / unblock users from chat detail

### DIFF
--- a/app/webapi/main.py
+++ b/app/webapi/main.py
@@ -13,7 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.db.session import create_session_maker
-from app.webapi.routes import agent, auth, channels, chats, costs, health, posts, spam, stats
+from app.webapi.routes import agent, auth, channels, chats, costs, health, posts, spam, stats, users
 from app.webapi.services.telethon_stats import TelethonStatsService
 from app.webapi.snapshot_loop import run_snapshot_loop
 
@@ -76,6 +76,7 @@ def create_app() -> FastAPI:
     app.include_router(spam.router, prefix="/api")
     app.include_router(stats.router, prefix="/api")
     app.include_router(agent.router, prefix="/api")
+    app.include_router(users.router, prefix="/api")
 
     # Default no-op singleton for test environments (ASGITransport bypasses
     # lifespan). _lifespan replaces this with the real instance at startup.

--- a/app/webapi/routes/chats.py
+++ b/app/webapi/routes/chats.py
@@ -14,16 +14,17 @@ import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.time import utc_now
-from app.db.models import Chat, ChatMemberSnapshot, Message, SpamPing
+from app.db.models import Chat, ChatMemberSnapshot, Message, SpamPing, User
 from app.webapi.deps import get_session, get_telethon_stats, require_super_admin
 from app.webapi.schemas import (
     ChatDetail,
     ChatNode,
     ChatRead,
+    ChatSender,
     HeatmapCell,
     MemberSnapshotPoint,
     SpamPingRead,
@@ -36,6 +37,8 @@ _HEATMAP_LOOKBACK_DAYS = 7
 _HEATMAP_MAX_ROWS = 50_000
 _SNAPSHOTS_LIMIT = 50
 _SPAM_PINGS_LIMIT = 30
+_RECENT_SENDERS_LOOKBACK_DAYS = 7
+_RECENT_SENDERS_LIMIT = 25
 
 
 def _build_heatmap(timestamps: list[datetime.datetime]) -> list[HeatmapCell]:
@@ -183,6 +186,39 @@ async def get_chat(
         for p in spam_rows
     ]
 
+    senders_since = utc_now() - datetime.timedelta(days=_RECENT_SENDERS_LOOKBACK_DAYS)
+    senders_rows = (
+        await session.execute(
+            select(
+                Message.user_id,
+                func.count(Message.id).label("message_count"),
+                func.max(Message.timestamp).label("last_seen"),
+                User.username,
+                User.first_name,
+                User.last_name,
+                User.blocked,
+            )
+            .outerjoin(User, User.id == Message.user_id)
+            .where(Message.chat_id == chat_id)
+            .where(Message.timestamp >= senders_since)
+            .group_by(Message.user_id, User.username, User.first_name, User.last_name, User.blocked)
+            .order_by(func.count(Message.id).desc())
+            .limit(_RECENT_SENDERS_LIMIT)
+        )
+    ).all()
+    recent_senders = [
+        ChatSender(
+            user_id=r.user_id,
+            username=r.username,
+            first_name=r.first_name,
+            last_name=r.last_name,
+            message_count=int(r.message_count),
+            last_seen=r.last_seen,
+            blocked=bool(r.blocked) if r.blocked is not None else False,
+        )
+        for r in senders_rows
+    ]
+
     return ChatDetail(
         id=chat.id,
         title=chat.title,
@@ -202,4 +238,5 @@ async def get_chat(
         ],
         children=children_nodes,
         spam_pings=spam_pings,
+        recent_senders=recent_senders,
     )

--- a/app/webapi/routes/users.py
+++ b/app/webapi/routes/users.py
@@ -1,0 +1,69 @@
+"""Users — global blacklist (block / unblock) endpoints.
+
+Block/unblock are global ops that touch every managed chat — they reuse the
+existing ``app.moderation.blacklist`` service unchanged. The webapi-owned
+``publish_bot`` (Phase 4b) is the outgoing Telegram client.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from aiogram import Bot
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import UserNotFoundException
+from app.db.models import User
+from app.moderation.blacklist import add_to_blacklist, remove_from_blacklist
+from app.webapi.deps import get_publish_bot, get_session, require_super_admin
+from app.webapi.schemas import UserBlockRequest, UserBlockResponse
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.post("/{user_id}/block", response_model=UserBlockResponse)
+async def block_user(
+    user_id: int,
+    payload: UserBlockRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    bot: Annotated[Bot, Depends(get_publish_bot)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> UserBlockResponse:
+    await add_to_blacklist(session, bot, user_id, revoke_messages=payload.revoke_messages or None)
+    return UserBlockResponse(
+        user_id=user_id,
+        blocked=True,
+        message="User blocked across all managed chats." + (" Messages revoked." if payload.revoke_messages else ""),
+    )
+
+
+@router.delete("/{user_id}/block", response_model=UserBlockResponse)
+async def unblock_user(
+    user_id: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    bot: Annotated[Bot, Depends(get_publish_bot)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> UserBlockResponse:
+    try:
+        await remove_from_blacklist(session, bot, user_id)
+    except UserNotFoundException as err:
+        raise HTTPException(status_code=404, detail=f"User {user_id} not in DB") from err
+    return UserBlockResponse(user_id=user_id, blocked=False, message="User unblocked.")
+
+
+@router.get("/{user_id}", response_model=UserBlockResponse)
+async def get_user_block_status(
+    user_id: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> UserBlockResponse:
+    user = (await session.execute(select(User).where(User.id == user_id))).scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=404, detail=f"User {user_id} not in DB")
+    return UserBlockResponse(
+        user_id=user_id,
+        blocked=user.blocked,
+        message="blocked" if user.blocked else "not blocked",
+    )

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -174,6 +174,18 @@ class MemberSnapshotPoint(BaseModel):
     member_count: int
 
 
+class ChatSender(BaseModel):
+    """Recent sender in a chat — used for moderation actions."""
+
+    user_id: int
+    username: str | None
+    first_name: str | None
+    last_name: str | None
+    message_count: int
+    last_seen: datetime.datetime
+    blocked: bool
+
+
 class ChatDetail(ChatRead):
     """Full chat payload — adds heatmap grid + member-snapshot series + relationships."""
 
@@ -184,6 +196,20 @@ class ChatDetail(ChatRead):
     member_snapshots: list[MemberSnapshotPoint]
     children: list[ChatNode] = []
     spam_pings: list[SpamPingRead] = []
+    recent_senders: list[ChatSender] = []
+
+
+class UserBlockRequest(BaseModel):
+    """Body for POST /api/users/{id}/block. Set ``revoke_messages`` to also
+    delete the user's recorded messages from all known chats."""
+
+    revoke_messages: bool = False
+
+
+class UserBlockResponse(BaseModel):
+    user_id: int
+    blocked: bool
+    message: str
 
 
 ChatNode.model_rebuild()

--- a/tests/webapi/test_chats.py
+++ b/tests/webapi/test_chats.py
@@ -113,3 +113,33 @@ async def test_chat_detail_404(client_factory) -> None:
     async with client_factory() as client:
         resp = await client.get("/api/chats/999999")
     assert resp.status_code == 404
+
+
+async def test_chat_detail_returns_recent_senders(client_factory, db_session_maker) -> None:
+    """Recent senders aggregates message counts per user with their block flag."""
+    from app.core.time import utc_now
+    from app.db.models import User
+
+    chat_id = -1030
+    now = utc_now()
+    async with db_session_maker() as session:
+        session.add(Chat(id=chat_id, title="E"))
+        session.add(User(id=501, username="alice", blocked=False))
+        session.add(User(id=502, username="bob", blocked=True))
+        for i in range(3):
+            m = Message(chat_id=chat_id, user_id=501, message_id=100 + i)
+            m.timestamp = now - datetime.timedelta(hours=i)
+            session.add(m)
+        m = Message(chat_id=chat_id, user_id=502, message_id=200)
+        m.timestamp = now - datetime.timedelta(hours=1)
+        session.add(m)
+        await session.commit()
+
+    async with client_factory() as client:
+        resp = await client.get(f"/api/chats/{chat_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    senders = {s["user_id"]: s for s in body["recent_senders"]}
+    assert senders[501]["message_count"] == 3
+    assert senders[501]["blocked"] is False
+    assert senders[502]["blocked"] is True

--- a/tests/webapi/test_user_blacklist.py
+++ b/tests/webapi/test_user_blacklist.py
@@ -1,0 +1,118 @@
+"""Tests for /api/users/{id}/block — global ban/unban via blacklist service."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+from app.core.config import settings
+from app.db.models import User
+from app.webapi.main import app
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def client_factory(db_session_maker: async_sessionmaker[AsyncSession]):
+    from app.webapi.deps import get_publish_bot, get_session
+
+    async def _override_session():
+        async with db_session_maker() as s:
+            yield s
+
+    fake_bot = AsyncMock()
+
+    async def _override_publish_bot():
+        return fake_bot
+
+    app.dependency_overrides[get_session] = _override_session
+    app.dependency_overrides[get_publish_bot] = _override_publish_bot
+    settings.admin.super_admins = [1]
+    settings.webapi.dev_bypass_auth = True
+    transport = ASGITransport(app=app)
+
+    def make() -> AsyncClient:
+        return AsyncClient(transport=transport, base_url="http://test")
+
+    yield make, fake_bot
+    app.dependency_overrides.pop(get_session, None)
+    app.dependency_overrides.pop(get_publish_bot, None)
+
+
+async def test_block_marks_user_blocked(client_factory, db_session_maker) -> None:
+    make, _bot = client_factory
+    async with db_session_maker() as s:
+        s.add(User(id=42, username="alice"))
+        await s.commit()
+
+    async with make() as client:
+        resp = await client.post("/api/users/42/block", json={"revoke_messages": False})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["blocked"] is True
+
+    async with db_session_maker() as s:
+        u = (await s.execute(select(User).where(User.id == 42))).scalar_one()
+        assert u.blocked is True
+
+
+async def test_block_creates_user_when_unknown(client_factory, db_session_maker) -> None:
+    """Unknown user_id (never seen before) should still produce a User row in
+    blacklisted state — same semantics as the bot's /ban command."""
+    make, _bot = client_factory
+    async with make() as client:
+        resp = await client.post("/api/users/99/block", json={})
+    assert resp.status_code == 200, resp.text
+
+    async with db_session_maker() as s:
+        u = (await s.execute(select(User).where(User.id == 99))).scalar_one()
+        assert u.blocked is True
+
+
+async def test_unblock_clears_flag(client_factory, db_session_maker) -> None:
+    make, _bot = client_factory
+    async with db_session_maker() as s:
+        s.add(User(id=43, username="bob", blocked=True))
+        await s.commit()
+
+    async with make() as client:
+        resp = await client.delete("/api/users/43/block")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["blocked"] is False
+
+    async with db_session_maker() as s:
+        u = (await s.execute(select(User).where(User.id == 43))).scalar_one()
+        assert u.blocked is False
+
+
+async def test_unblock_404_when_user_unknown(client_factory) -> None:
+    make, _bot = client_factory
+    async with make() as client:
+        resp = await client.delete("/api/users/99999/block")
+    assert resp.status_code == 404
+
+
+async def test_get_status_returns_blocked_flag(client_factory, db_session_maker) -> None:
+    make, _bot = client_factory
+    async with db_session_maker() as s:
+        s.add(User(id=44, username="carol", blocked=True))
+        await s.commit()
+
+    async with make() as client:
+        resp = await client.get("/api/users/44")
+    assert resp.status_code == 200
+    assert resp.json()["blocked"] is True
+
+
+async def test_get_status_404_when_unknown(client_factory) -> None:
+    make, _bot = client_factory
+    async with make() as client:
+        resp = await client.get("/api/users/99999")
+    assert resp.status_code == 404

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -409,6 +409,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/users/{user_id}/block": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Block User */
+        post: operations["block_user_api_users__user_id__block_post"];
+        /** Unblock User */
+        delete: operations["unblock_user_api_users__user_id__block_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get User Block Status */
+        get: operations["get_user_block_status_api_users__user_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -703,6 +738,11 @@ export interface components {
              * @default []
              */
             spam_pings: components["schemas"]["SpamPingRead"][];
+            /**
+             * Recent Senders
+             * @default []
+             */
+            recent_senders: components["schemas"]["ChatSender"][];
         };
         /**
          * ChatHeatmapSummary
@@ -766,6 +806,29 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+        };
+        /**
+         * ChatSender
+         * @description Recent sender in a chat — used for moderation actions.
+         */
+        ChatSender: {
+            /** User Id */
+            user_id: number;
+            /** Username */
+            username: string | null;
+            /** First Name */
+            first_name: string | null;
+            /** Last Name */
+            last_name: string | null;
+            /** Message Count */
+            message_count: number;
+            /**
+             * Last Seen
+             * Format: date-time
+             */
+            last_seen: string;
+            /** Blocked */
+            blocked: boolean;
         };
         /**
          * DraftBucket
@@ -1092,6 +1155,27 @@ export interface components {
             hash: string;
         } & {
             [key: string]: unknown;
+        };
+        /**
+         * UserBlockRequest
+         * @description Body for POST /api/users/{id}/block. Set ``revoke_messages`` to also
+         *     delete the user's recorded messages from all known chats.
+         */
+        UserBlockRequest: {
+            /**
+             * Revoke Messages
+             * @default false
+             */
+            revoke_messages: boolean;
+        };
+        /** UserBlockResponse */
+        UserBlockResponse: {
+            /** User Id */
+            user_id: number;
+            /** Blocked */
+            blocked: boolean;
+            /** Message */
+            message: string;
         };
         /** ValidationError */
         ValidationError: {
@@ -1827,6 +1911,103 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    block_user_api_users__user_id__block_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                user_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserBlockRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserBlockResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unblock_user_api_users__user_id__block_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                user_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserBlockResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_user_block_status_api_users__user_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                user_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserBlockResponse"];
                 };
             };
             /** @description Validation Error */

--- a/webui/src/routes/chats/[id]/+page.svelte
+++ b/webui/src/routes/chats/[id]/+page.svelte
@@ -1,16 +1,57 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import HeatmapGrid from '$lib/components/chat/HeatmapGrid.svelte';
 	import Sparkline from '$lib/components/charts/Sparkline.svelte';
 	import SpamPingsList from '$lib/components/spam/SpamPingsList.svelte';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
+	import { apiFetch } from '$lib/api/client';
+	import { toast } from 'svelte-sonner';
 	import type { components } from '$lib/api/types';
 
 	type ChatDetail = components['schemas']['ChatDetail'];
+	type UserBlockResponse = components['schemas']['UserBlockResponse'];
 
 	const chatId = page.params.id;
 	const detail = useLivePoll<ChatDetail>(`/api/chats/${chatId}`, 60_000);
+
+	let busyUserId = $state<number | null>(null);
+
+	function senderLabel(s: components['schemas']['ChatSender']): string {
+		if (s.username) return `@${s.username}`;
+		const name = [s.first_name, s.last_name].filter(Boolean).join(' ').trim();
+		return name || `#${s.user_id}`;
+	}
+
+	async function blockUser(userId: number, revoke: boolean = false): Promise<void> {
+		if (!confirm(`Block user #${userId} across all managed chats?${revoke ? ' Messages will be revoked.' : ''}`)) {
+			return;
+		}
+		busyUserId = userId;
+		const res = await apiFetch<UserBlockResponse>(`/api/users/${userId}/block`, {
+			method: 'POST',
+			body: JSON.stringify({ revoke_messages: revoke })
+		});
+		busyUserId = null;
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success(res.data.message);
+			await detail.refresh();
+		}
+	}
+
+	async function unblockUser(userId: number): Promise<void> {
+		busyUserId = userId;
+		const res = await apiFetch<UserBlockResponse>(`/api/users/${userId}/block`, { method: 'DELETE' });
+		busyUserId = null;
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success(res.data.message);
+			await detail.refresh();
+		}
+	}
 </script>
 
 <div class="mx-auto max-w-5xl space-y-4 px-6 py-6">
@@ -111,6 +152,70 @@
 			</Card.Header>
 			<Card.Content>
 				<SpamPingsList items={detail.data.spam_pings} empty="No ad-detector hits in this chat." />
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root>
+			<Card.Header>
+				<Card.Title class="text-sm">
+					Recent senders (7 days)
+					{#if detail.data.recent_senders.length > 0}
+						<span class="ml-1 text-xs font-normal text-zinc-500">
+							({detail.data.recent_senders.length})
+						</span>
+					{/if}
+				</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				{#if detail.data.recent_senders.length === 0}
+					<p class="text-xs text-zinc-500">No messages recorded in the last 7 days.</p>
+				{:else}
+					<ul class="divide-y divide-zinc-100 text-sm">
+						{#each detail.data.recent_senders as s (s.user_id)}
+							<li class="flex items-center justify-between gap-2 py-1.5">
+								<div class="flex min-w-0 items-baseline gap-2">
+									<span class="truncate font-medium text-zinc-800">{senderLabel(s)}</span>
+									<span class="shrink-0 font-mono text-xs text-zinc-400">#{s.user_id}</span>
+									<span class="shrink-0 text-xs text-zinc-500">{s.message_count} msg</span>
+									{#if s.blocked}
+										<Badge variant="destructive" class="shrink-0 text-[10px]">blocked</Badge>
+									{/if}
+								</div>
+								<div class="flex shrink-0 items-center gap-1">
+									{#if s.blocked}
+										<Button
+											variant="ghost"
+											size="sm"
+											onclick={() => unblockUser(s.user_id)}
+											disabled={busyUserId === s.user_id}
+										>
+											{busyUserId === s.user_id ? '…' : 'Unblock'}
+										</Button>
+									{:else}
+										<Button
+											variant="outline"
+											size="sm"
+											onclick={() => blockUser(s.user_id, false)}
+											disabled={busyUserId === s.user_id}
+										>
+											{busyUserId === s.user_id ? '…' : 'Block'}
+										</Button>
+										<Button
+											variant="ghost"
+											size="sm"
+											class="text-red-600 hover:bg-red-50 hover:text-red-700"
+											onclick={() => blockUser(s.user_id, true)}
+											disabled={busyUserId === s.user_id}
+											title="Block + delete this user's messages from all known chats"
+										>
+											+ Revoke
+										</Button>
+									{/if}
+								</div>
+							</li>
+						{/each}
+					</ul>
+				{/if}
 			</Card.Content>
 		</Card.Root>
 	{/if}


### PR DESCRIPTION
## Summary

Block and unblock users globally (across all managed chats) from \`/chats/[id]\`. Reuses the existing \`app.moderation.blacklist\` service unchanged — same behavior as the bot's \`/ban\` and \`/unban\` commands.

## Endpoints

| Method | Path | Body | Returns |
|---|---|---|---|
| POST | \`/api/users/{user_id}/block\` | \`{ revoke_messages?: bool }\` | \`UserBlockResponse\` |
| DELETE | \`/api/users/{user_id}/block\` | — | \`UserBlockResponse\` |
| GET | \`/api/users/{user_id}\` | — | \`UserBlockResponse\` (block status) |

When \`revoke_messages: true\`, the blacklist service deletes the user's recorded messages from every chat it has on record. Otherwise it just bans them from each chat going forward.

## Chat detail extension

\`GET /api/chats/{id}\` now includes \`recent_senders: ChatSender[]\` — top 25 unique senders in the last 7 days, ordered by message count, with their global \`blocked\` flag joined from the \`users\` table. Single SQL query (\`outerjoin\` + \`group_by\`); no extra round trips.

## UI

\`/chats/[id]\` gets a "Recent senders" card listing each user with:
- Name (\`@username\` if known, else first/last name, else \`#{user_id}\`)
- Message count badge
- "blocked" badge when applicable
- **Block** button → POST with \`revoke_messages: false\`
- **+ Revoke** button (red) → POST with \`revoke_messages: true\` (block + delete their messages)
- **Unblock** button when already blocked

Confirm dialog on every block; toast feedback; refresh after action.

## Tests

- \`tests/webapi/test_user_blacklist.py\` (6) — block known/unknown user, unblock, unblock 404, status lookup, status 404
- \`tests/webapi/test_chats.py\` — new \`test_chat_detail_returns_recent_senders\` verifies aggregation + blocked-flag join

Full suite: **888 passed**, 2 skipped (pre-existing).

## Out of scope

- **4e** — \`/settings\` functional surface

## Test plan

- [ ] Open \`/chats/<known-chat-id>\` → "Recent senders" card lists last-7d posters
- [ ] Click "Block" on a non-blocked user → confirm → toast + badge appears
- [ ] In Telegram: confirm the user is banned in every managed chat
- [ ] Click "Unblock" → toast + badge gone; user can rejoin
- [ ] Click "+ Revoke" → confirm → toast + their messages disappear from chats
- [ ] \`curl /api/users/<id>\` returns the current block state

🤖 Generated with [Claude Code](https://claude.com/claude-code)