### PR TITLE
feat(webui): Phase 4e + dashboard / suggestions / cost history / chat graph polish

### DIFF
--- a/alembic/versions/f7a8b9c0d1e2_add_cost_events.py
+++ b/alembic/versions/f7a8b9c0d1e2_add_cost_events.py
@@ -1,0 +1,42 @@
+"""Add cost_events table.
+
+Persistent log of LLM call costs. Written best-effort by cost_tracker.log_usage
+when persistence is enabled at startup; queried by /api/costs/history for the
+admin dashboard.
+
+Revision ID: f7a8b9c0d1e2
+Revises: e4f5a6b7c8d9
+Create Date: 2026-04-28 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f7a8b9c0d1e2"
+down_revision: str | None = "e4f5a6b7c8d9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cost_events",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("occurred_at", sa.DateTime, nullable=False, index=True),
+        sa.Column("model", sa.String(128), nullable=False),
+        sa.Column("operation", sa.String(64), nullable=False, index=True),
+        sa.Column("prompt_tokens", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("completion_tokens", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("total_tokens", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("cache_read_tokens", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("cache_write_tokens", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("cost_usd", sa.Float, nullable=False, server_default="0"),
+        sa.Column("cache_savings_usd", sa.Float, nullable=False, server_default="0"),
+        sa.Column("channel_id", sa.String(64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("cost_events")

--- a/app/channel/cost_tracker.py
+++ b/app/channel/cost_tracker.py
@@ -213,13 +213,14 @@ async def log_usage(usage: LLMUsage) -> None:
 
 
 def get_session_summary() -> dict[str, Any]:
-    """Return accumulated usage summary: total tokens, cost, cache savings, and per-operation breakdown."""
+    """Return accumulated usage summary: totals, cache savings, and per-operation/model breakdowns."""
     total_tokens = 0
     total_cost = 0.0
     total_cache_read = 0
     total_cache_write = 0
     total_savings = 0.0
     by_operation: dict[str, dict[str, float | int]] = {}
+    by_model: dict[str, dict[str, float | int]] = {}
 
     for u in _usage_history:
         total_tokens += u.total_tokens
@@ -230,11 +231,17 @@ def get_session_summary() -> dict[str, Any]:
 
         if u.operation not in by_operation:
             by_operation[u.operation] = {"tokens": 0, "cost_usd": 0.0, "calls": 0, "cache_savings_usd": 0.0}
-
         by_operation[u.operation]["tokens"] += u.total_tokens
         by_operation[u.operation]["cost_usd"] += u.estimated_cost_usd
         by_operation[u.operation]["calls"] += 1
         by_operation[u.operation]["cache_savings_usd"] += u.cache_savings_usd
+
+        if u.model not in by_model:
+            by_model[u.model] = {"tokens": 0, "cost_usd": 0.0, "calls": 0, "cache_savings_usd": 0.0}
+        by_model[u.model]["tokens"] += u.total_tokens
+        by_model[u.model]["cost_usd"] += u.estimated_cost_usd
+        by_model[u.model]["calls"] += 1
+        by_model[u.model]["cache_savings_usd"] += u.cache_savings_usd
 
     return {
         "total_tokens": total_tokens,
@@ -244,6 +251,7 @@ def get_session_summary() -> dict[str, Any]:
         "cache_write_tokens": total_cache_write,
         "cache_savings_usd": round(total_savings, 8),
         "by_operation": by_operation,
+        "by_model": by_model,
     }
 
 

--- a/app/channel/cost_tracker.py
+++ b/app/channel/cost_tracker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime  # noqa: TC003 - needed at runtime for dataclass field type
 from typing import Any
@@ -187,13 +188,60 @@ def extract_usage_from_pydanticai_result(
 _MAX_USAGE_HISTORY = 1000
 
 _usage_history: list[LLMUsage] = []
+_persist_enabled: bool = False
+
+
+def enable_persistence(enabled: bool = True) -> None:
+    """Toggle DB persistence of usage events.
+
+    Off by default so unit tests that exercise log_usage don't require the
+    cost_events table to exist. Production processes (webapi, bot) flip this
+    on at startup.
+    """
+    global _persist_enabled
+    _persist_enabled = enabled
+
+
+async def _persist_usage(usage: LLMUsage) -> None:
+    """Best-effort write of one usage row to ``cost_events``.
+
+    Failures are logged and swallowed — cost tracking must never block an
+    LLM call. Imports happen lazily so the module stays importable in
+    contexts without a configured DB.
+    """
+    try:
+        from app.db.models import CostEvent
+        from app.db.session import create_session_maker
+
+        session_maker = create_session_maker()
+        async with session_maker() as session:
+            session.add(
+                CostEvent(
+                    occurred_at=usage.created_at,
+                    model=usage.model,
+                    operation=usage.operation,
+                    prompt_tokens=usage.prompt_tokens,
+                    completion_tokens=usage.completion_tokens,
+                    total_tokens=usage.total_tokens,
+                    cache_read_tokens=usage.cache_read_tokens,
+                    cache_write_tokens=usage.cache_write_tokens,
+                    cost_usd=usage.estimated_cost_usd,
+                    cache_savings_usd=usage.cache_savings_usd,
+                    channel_id=usage.channel_id,
+                )
+            )
+            await session.commit()
+    except Exception:
+        logger.warning("cost_persist_failed", model=usage.model, exc_info=True)
 
 
 async def log_usage(usage: LLMUsage) -> None:
     """Log a single LLM usage record and accumulate it in memory.
 
     The in-memory history is capped at :data:`_MAX_USAGE_HISTORY` entries.
-    When the cap is reached, the oldest entries are evicted.
+    When the cap is reached, the oldest entries are evicted. When persistence
+    is enabled (see :func:`enable_persistence`) a fire-and-forget task also
+    writes the event to the ``cost_events`` table.
     """
     _usage_history.append(usage)
     # Evict oldest entries to prevent unbounded memory growth
@@ -210,6 +258,12 @@ async def log_usage(usage: LLMUsage) -> None:
         cache_savings_usd=usage.cache_savings_usd,
         channel_id=usage.channel_id,
     )
+    if _persist_enabled:
+        try:
+            asyncio.create_task(_persist_usage(usage))
+        except RuntimeError:
+            # No running event loop — caller must await persist explicitly.
+            await _persist_usage(usage)
 
 
 def get_session_summary() -> dict[str, Any]:

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -745,3 +745,53 @@ class AdminSession(Base):
         self.expires_at = expires_at
         self.user_agent = user_agent
         self.ip = ip
+
+
+class CostEvent(Base):
+    """Persistent record of one LLM API call.
+
+    Written by :func:`app.channel.cost_tracker.log_usage` when persistence is
+    enabled. Aggregated per-day by ``GET /api/costs/history``.
+    """
+
+    __tablename__ = "cost_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    occurred_at: Mapped[datetime.datetime] = mapped_column(DateTime, default=utc_now, index=True)
+    model: Mapped[str] = mapped_column(String(128))
+    operation: Mapped[str] = mapped_column(String(64), index=True)
+    prompt_tokens: Mapped[int] = mapped_column(Integer, default=0)
+    completion_tokens: Mapped[int] = mapped_column(Integer, default=0)
+    total_tokens: Mapped[int] = mapped_column(Integer, default=0)
+    cache_read_tokens: Mapped[int] = mapped_column(Integer, default=0)
+    cache_write_tokens: Mapped[int] = mapped_column(Integer, default=0)
+    cost_usd: Mapped[float] = mapped_column(Float, default=0.0)
+    cache_savings_usd: Mapped[float] = mapped_column(Float, default=0.0)
+    channel_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        operation: str,
+        occurred_at: datetime.datetime | None = None,
+        prompt_tokens: int = 0,
+        completion_tokens: int = 0,
+        total_tokens: int = 0,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+        cost_usd: float = 0.0,
+        cache_savings_usd: float = 0.0,
+        channel_id: str | None = None,
+    ) -> None:
+        self.occurred_at = occurred_at or utc_now()
+        self.model = model
+        self.operation = operation
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.total_tokens = total_tokens
+        self.cache_read_tokens = cache_read_tokens
+        self.cache_write_tokens = cache_write_tokens
+        self.cost_usd = cost_usd
+        self.cache_savings_usd = cache_savings_usd
+        self.channel_id = channel_id

--- a/app/presentation/telegram/bot.py
+++ b/app/presentation/telegram/bot.py
@@ -44,6 +44,8 @@ logger = get_logger("bot")
 async def on_startup(bot: Bot) -> None:
     """Main bot startup: webhook cleanup, chat links, Telethon."""
     try:
+        from app.channel.cost_tracker import enable_persistence as enable_cost_persistence
+
         await bot.delete_webhook()
         await insert_chat_link()
 
@@ -52,6 +54,7 @@ async def on_startup(bot: Bot) -> None:
             await telethon_client.start()
             logger.info("telethon_started")
 
+        enable_cost_persistence(True)
         logger.info("main_bot_startup_complete")
     except Exception as e:
         logger.error("startup_error", error=str(e), exc_info=True)

--- a/app/webapi/main.py
+++ b/app/webapi/main.py
@@ -13,7 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.db.session import create_session_maker
-from app.webapi.routes import agent, auth, channels, chats, costs, health, posts, spam, stats, users
+from app.webapi.routes import admin, agent, auth, channels, chats, costs, health, posts, spam, stats, users
 from app.webapi.services.telethon_stats import TelethonStatsService
 from app.webapi.snapshot_loop import run_snapshot_loop
 
@@ -77,6 +77,7 @@ def create_app() -> FastAPI:
     app.include_router(stats.router, prefix="/api")
     app.include_router(agent.router, prefix="/api")
     app.include_router(users.router, prefix="/api")
+    app.include_router(admin.router, prefix="/api")
 
     # Default no-op singleton for test environments (ASGITransport bypasses
     # lifespan). _lifespan replaces this with the real instance at startup.

--- a/app/webapi/main.py
+++ b/app/webapi/main.py
@@ -25,10 +25,12 @@ logger = get_logger("webapi.main")
 
 @asynccontextmanager
 async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
+    from app.channel.cost_tracker import enable_persistence as enable_cost_persistence
     from app.core.container import container
     from app.webapi.services.publish_bot import build_publish_bot, close_publish_bot
 
     session_maker = create_session_maker()
+    enable_cost_persistence(True)
     telethon = container.get_telethon_client()
     _app.state.telethon_stats = TelethonStatsService(telethon=telethon)
     _app.state.publish_bot = build_publish_bot()

--- a/app/webapi/routes/admin.py
+++ b/app/webapi/routes/admin.py
@@ -1,0 +1,91 @@
+"""Admin / settings — read-only system status + active session management.
+
+Mutations beyond ``revoke`` are intentionally out of scope: most settings
+(feature flags, model choices, env-driven config) live in the deployment
+config and would need schema work to become DB-backed. The /settings page
+is a security + observability surface, not a config editor.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db.models import AdminSession
+from app.webapi.auth import session_store
+from app.webapi.deps import get_session, require_super_admin
+from app.webapi.schemas import AdminSessionRead, FeatureFlagRead, SystemStatus
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.get("/sessions", response_model=list[AdminSessionRead])
+async def list_sessions(
+    request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    admin_id: Annotated[int, Depends(require_super_admin)],
+) -> list[AdminSessionRead]:
+    """List the calling admin's active sessions, current one flagged."""
+    rows = (
+        (
+            await session.execute(
+                select(AdminSession).where(AdminSession.user_id == admin_id).order_by(AdminSession.last_seen_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    current_token = request.cookies.get(settings.webapi.session_cookie_name)
+    return [
+        AdminSessionRead.model_validate(r).model_copy(update={"is_current": r.session_id == current_token})
+        for r in rows
+    ]
+
+
+@router.delete("/sessions/{session_id}", status_code=204)
+async def revoke_session(
+    session_id: str,
+    request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    admin_id: Annotated[int, Depends(require_super_admin)],
+) -> None:
+    """Revoke one of the calling admin's sessions. Refuse to revoke the current one."""
+    current_token = request.cookies.get(settings.webapi.session_cookie_name)
+    if session_id == current_token:
+        raise HTTPException(status_code=400, detail="Use POST /api/auth/logout to end the current session")
+    row = (
+        await session.execute(select(AdminSession).where(AdminSession.session_id == session_id))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if row.user_id != admin_id:
+        # Single-tenant — same admin set — but defensive guard if it ever expands.
+        raise HTTPException(status_code=403, detail="Cannot revoke another user's session")
+    await session_store.revoke_session(session, session_id)
+
+
+@router.get("/system", response_model=SystemStatus)
+async def get_system_status(
+    request: Request,
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> SystemStatus:
+    from app.core.container import container
+
+    publish_bot = getattr(request.app.state, "publish_bot", None)
+    return SystemStatus(
+        super_admin_ids=list(settings.admin.super_admins),
+        telethon_connected=container.get_telethon_client() is not None,
+        publish_bot_ready=publish_bot is not None,
+        allowed_origins=list(settings.webapi.allowed_origins),
+        session_ttl_days=settings.webapi.session_ttl_days,
+        feature_flags=[
+            FeatureFlagRead(name="dev_bypass_auth", enabled=settings.webapi.dev_bypass_auth),
+            FeatureFlagRead(name="moderation_enabled", enabled=settings.moderation.enabled),
+            FeatureFlagRead(name="ad_detector_enabled", enabled=settings.moderation.ad_detector_enabled),
+            FeatureFlagRead(name="assistant_bot_enabled", enabled=settings.assistant.enabled),
+        ],
+    )

--- a/app/webapi/routes/chats.py
+++ b/app/webapi/routes/chats.py
@@ -25,6 +25,7 @@ from app.webapi.schemas import (
     ChatNode,
     ChatRead,
     ChatSender,
+    ChatUpdate,
     HeatmapCell,
     MemberSnapshotPoint,
     SpamPingRead,
@@ -239,4 +240,41 @@ async def get_chat(
         children=children_nodes,
         spam_pings=spam_pings,
         recent_senders=recent_senders,
+    )
+
+
+@router.patch("/{chat_id}", response_model=ChatRead)
+async def update_chat(
+    chat_id: int,
+    payload: ChatUpdate,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    stats: Annotated[TelethonStatsService, Depends(get_telethon_stats)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ChatRead:
+    chat = (await session.execute(select(Chat).where(Chat.id == chat_id))).scalar_one_or_none()
+    if chat is None:
+        raise HTTPException(status_code=404, detail=f"Chat {chat_id} not found")
+
+    fields = payload.model_dump(exclude_unset=True)
+    if "time_delete" in fields and fields["time_delete"] is not None and fields["time_delete"] <= 0:
+        raise HTTPException(status_code=422, detail="time_delete must be positive")
+    if "parent_chat_id" in fields and fields["parent_chat_id"] == chat_id:
+        raise HTTPException(status_code=422, detail="A chat cannot be its own parent")
+
+    for key, value in fields.items():
+        setattr(chat, key, value)
+    await session.commit()
+    await session.refresh(chat)
+
+    member_count = await stats.get_member_count(chat.id)
+    return ChatRead(
+        id=chat.id,
+        title=chat.title,
+        is_forum=chat.is_forum,
+        is_welcome_enabled=chat.is_welcome_enabled,
+        is_captcha_enabled=chat.is_captcha_enabled,
+        parent_chat_id=chat.parent_chat_id,
+        relation_notes=chat.relation_notes,
+        member_count=member_count,
+        created_at=chat.created_at,
     )

--- a/app/webapi/routes/costs.py
+++ b/app/webapi/routes/costs.py
@@ -1,14 +1,19 @@
-"""Costs — session summary from in-memory cost_tracker."""
+"""Costs — session summary + persistent history."""
 
 from __future__ import annotations
 
+import datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.channel.cost_tracker import get_session_summary
-from app.webapi.deps import require_super_admin
-from app.webapi.schemas import SessionCostSummary
+from app.core.time import utc_now
+from app.db.models import CostEvent
+from app.webapi.deps import get_session, require_super_admin
+from app.webapi.schemas import CostHistoryDay, CostHistoryResponse, SessionCostSummary
 
 router = APIRouter(prefix="/costs", tags=["costs"])
 
@@ -18,3 +23,64 @@ async def session_cost(
     _admin_id: Annotated[int, Depends(require_super_admin)],
 ) -> SessionCostSummary:
     return SessionCostSummary.from_tracker(get_session_summary())
+
+
+@router.get("/history", response_model=CostHistoryResponse)
+async def cost_history(
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+    days: int = Query(default=30, ge=1, le=365, description="Lookback window in days"),
+) -> CostHistoryResponse:
+    """Daily aggregate of cost_events for the last ``days`` days, oldest first.
+
+    Empty days are filled with zero rows so the FE can render a contiguous
+    sparkline without gap-filling client-side.
+    """
+    cutoff = utc_now() - datetime.timedelta(days=days)
+    day_col = func.date(CostEvent.occurred_at).label("day")
+    rows = (
+        await session.execute(
+            select(
+                day_col,
+                func.sum(CostEvent.cost_usd).label("cost_usd"),
+                func.sum(CostEvent.total_tokens).label("tokens"),
+                func.count(CostEvent.id).label("calls"),
+                func.sum(CostEvent.cache_savings_usd).label("savings"),
+            )
+            .where(CostEvent.occurred_at >= cutoff)
+            .group_by(day_col)
+            .order_by(day_col)
+        )
+    ).all()
+    by_day: dict[str, CostHistoryDay] = {}
+    for row in rows:
+        # SQLite returns string, PG returns date — normalise.
+        day_value = row.day.isoformat() if hasattr(row.day, "isoformat") else str(row.day)
+        by_day[day_value] = CostHistoryDay(
+            day=day_value,
+            cost_usd=float(row.cost_usd or 0.0),
+            tokens=int(row.tokens or 0),
+            calls=int(row.calls or 0),
+            cache_savings_usd=float(row.savings or 0.0),
+        )
+
+    today = utc_now().date()
+    series: list[CostHistoryDay] = []
+    for offset in range(days - 1, -1, -1):
+        d = (today - datetime.timedelta(days=offset)).isoformat()
+        series.append(
+            by_day.get(
+                d,
+                CostHistoryDay(day=d, cost_usd=0.0, tokens=0, calls=0, cache_savings_usd=0.0),
+            )
+        )
+    total_cost = sum(s.cost_usd for s in series)
+    total_calls = sum(s.calls for s in series)
+    total_tokens = sum(s.tokens for s in series)
+    return CostHistoryResponse(
+        days=days,
+        series=series,
+        total_cost_usd=round(total_cost, 6),
+        total_calls=total_calls,
+        total_tokens=total_tokens,
+    )

--- a/app/webapi/routes/posts.py
+++ b/app/webapi/routes/posts.py
@@ -11,11 +11,36 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.channel.generator import GeneratedPost
 from app.channel.publisher import publish_post as _publish_to_channel
-from app.channel.review.service import approve_post, reject_post, set_post_text
-from app.db.models import ChannelPost
+from app.channel.review.image_tools import (
+    ImageToolsDeps,
+    add_image_url_op,
+    clear_images_op,
+    find_and_add_image_op,
+    remove_image_op,
+    reorder_images_op,
+    use_candidate_op,
+)
+from app.channel.review.service import (
+    approve_post,
+    regen_post_text,
+    reject_post,
+    set_post_text,
+)
+from app.core.config import settings
+from app.db.models import Channel, ChannelPost
 from app.db.session import create_session_maker
 from app.webapi.deps import get_publish_bot, get_session, require_super_admin
-from app.webapi.schemas import PostDetail, PostMutationResponse, PostRead, PostTextEdit
+from app.webapi.schemas import (
+    ImageAddUrlRequest,
+    ImageMutationResponse,
+    ImageReorderRequest,
+    ImageSearchRequest,
+    ImageUseRequest,
+    PostDetail,
+    PostMutationResponse,
+    PostRead,
+    PostTextEdit,
+)
 
 router = APIRouter(prefix="/posts", tags=["posts"])
 
@@ -106,3 +131,150 @@ async def edit_text(
     msg = await set_post_text(post_id, payload.text, create_session_maker())
     await session.refresh(post)
     return PostMutationResponse(post_id=post_id, status=post.status, message=msg)
+
+
+@router.post("/{post_id}/regenerate", response_model=PostMutationResponse)
+async def regenerate(
+    post_id: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> PostMutationResponse:
+    """Re-run the generator over the post's stored source_items and replace the body.
+
+    Looks up the channel to resolve language + footer; falls back to defaults
+    when the channel row is missing (e.g. test fixtures).
+    """
+    post = (await session.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one_or_none()
+    if post is None:
+        raise HTTPException(status_code=404, detail=f"Post {post_id} not found")
+
+    ch = (await session.execute(select(Channel).where(Channel.telegram_id == post.channel_id))).scalar_one_or_none()
+    language = ch.language if ch else "ru"
+    footer = ch.footer if ch else ""
+
+    msg, _ = await regen_post_text(
+        post_id=post_id,
+        api_key=settings.openrouter.api_key,
+        model=settings.channel.generation_model,
+        language=language,
+        session_maker=create_session_maker(),
+        footer=footer,
+    )
+    session.expire_all()
+    await session.refresh(post)
+    return PostMutationResponse(post_id=post_id, status=post.status, message=msg)
+
+
+# ---------------------------------------------------------------------------
+# Image pool endpoints
+# ---------------------------------------------------------------------------
+
+
+def _image_deps(post: ChannelPost) -> ImageToolsDeps:
+    return ImageToolsDeps(
+        session_maker=create_session_maker(),
+        post_id=post.id,
+        channel_id=post.channel_id,
+        api_key=settings.openrouter.api_key,
+        vision_model=settings.channel.vision_model,
+        brave_api_key=settings.brave.api_key,
+    )
+
+
+def _build_image_response(post: ChannelPost, message: str) -> ImageMutationResponse:
+    return ImageMutationResponse(
+        post_id=post.id,
+        message=message,
+        image_urls=list(post.image_urls or []),
+        image_candidates=list(post.image_candidates or []),
+    )
+
+
+async def _load_post_or_404(session: AsyncSession, post_id: int) -> ChannelPost:
+    post = (await session.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one_or_none()
+    if post is None:
+        raise HTTPException(status_code=404, detail=f"Post {post_id} not found")
+    return post
+
+
+@router.post("/{post_id}/images/use", response_model=ImageMutationResponse)
+async def image_use(
+    post_id: int,
+    payload: ImageUseRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ImageMutationResponse:
+    post = await _load_post_or_404(session, post_id)
+    msg = await use_candidate_op(_image_deps(post), payload.pool_index, payload.position)
+    session.expire_all()
+    await session.refresh(post)
+    return _build_image_response(post, msg)
+
+
+@router.post("/{post_id}/images/url", response_model=ImageMutationResponse)
+async def image_add_url(
+    post_id: int,
+    payload: ImageAddUrlRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ImageMutationResponse:
+    post = await _load_post_or_404(session, post_id)
+    msg = await add_image_url_op(_image_deps(post), payload.url, payload.position)
+    session.expire_all()
+    await session.refresh(post)
+    return _build_image_response(post, msg)
+
+
+@router.post("/{post_id}/images/search", response_model=ImageMutationResponse)
+async def image_search(
+    post_id: int,
+    payload: ImageSearchRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ImageMutationResponse:
+    post = await _load_post_or_404(session, post_id)
+    msg = await find_and_add_image_op(_image_deps(post), payload.query)
+    session.expire_all()
+    await session.refresh(post)
+    return _build_image_response(post, msg)
+
+
+@router.delete("/{post_id}/images/{position}", response_model=ImageMutationResponse)
+async def image_remove(
+    post_id: int,
+    position: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ImageMutationResponse:
+    post = await _load_post_or_404(session, post_id)
+    msg = await remove_image_op(_image_deps(post), position)
+    session.expire_all()
+    await session.refresh(post)
+    return _build_image_response(post, msg)
+
+
+@router.post("/{post_id}/images/reorder", response_model=ImageMutationResponse)
+async def image_reorder(
+    post_id: int,
+    payload: ImageReorderRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ImageMutationResponse:
+    post = await _load_post_or_404(session, post_id)
+    msg = await reorder_images_op(_image_deps(post), payload.order)
+    session.expire_all()
+    await session.refresh(post)
+    return _build_image_response(post, msg)
+
+
+@router.delete("/{post_id}/images", response_model=ImageMutationResponse)
+async def image_clear(
+    post_id: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ImageMutationResponse:
+    post = await _load_post_or_404(session, post_id)
+    msg = await clear_images_op(_image_deps(post))
+    session.expire_all()
+    await session.refresh(post)
+    return _build_image_response(post, msg)

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -212,6 +212,40 @@ class UserBlockResponse(BaseModel):
     message: str
 
 
+class AdminSessionRead(BaseModel):
+    """Active admin session row — used by /settings to list logins."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    session_id: str
+    user_id: int
+    created_at: datetime.datetime
+    last_seen_at: datetime.datetime
+    expires_at: datetime.datetime
+    user_agent: str | None
+    ip: str | None
+    is_current: bool = False
+
+
+class FeatureFlagRead(BaseModel):
+    """One feature flag — surfaced as a badge in /settings."""
+
+    name: str
+    enabled: bool
+    source: str = "env"
+
+
+class SystemStatus(BaseModel):
+    """Read-only operational status for the /settings system card."""
+
+    super_admin_ids: list[int]
+    telethon_connected: bool
+    publish_bot_ready: bool
+    allowed_origins: list[str]
+    session_ttl_days: int
+    feature_flags: list[FeatureFlagRead]
+
+
 ChatNode.model_rebuild()
 
 

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -29,6 +29,43 @@ class PostDetail(PostRead):
 
     external_id: str
     source_items: list[dict[str, Any]] | None = None
+    pre_critic_text: str | None = None
+    image_candidates: list[dict[str, Any]] | None = None
+
+
+class ImageUseRequest(BaseModel):
+    """POST /api/posts/{id}/images/use — promote a pool candidate to selected."""
+
+    pool_index: int
+    position: int | None = None
+
+
+class ImageAddUrlRequest(BaseModel):
+    """POST /api/posts/{id}/images/url — vet + attach an arbitrary URL."""
+
+    url: str
+    position: int | None = None
+
+
+class ImageSearchRequest(BaseModel):
+    """POST /api/posts/{id}/images/search — Brave search → vision-score → pool."""
+
+    query: str
+
+
+class ImageReorderRequest(BaseModel):
+    """POST /api/posts/{id}/images/reorder — permutation of current selected positions."""
+
+    order: list[int]
+
+
+class ImageMutationResponse(BaseModel):
+    """Common response shape for image-pool mutations."""
+
+    post_id: int
+    message: str
+    image_urls: list[str]
+    image_candidates: list[dict[str, Any]]
 
 
 class ChannelRead(BaseModel):
@@ -364,6 +401,26 @@ class ModelCostBucket(BaseModel):
     cost_usd: float
     calls: int
     cache_savings_usd: float
+
+
+class CostHistoryDay(BaseModel):
+    """One day in the persistent cost history series."""
+
+    day: str  # ISO yyyy-mm-dd
+    cost_usd: float
+    tokens: int
+    calls: int
+    cache_savings_usd: float
+
+
+class CostHistoryResponse(BaseModel):
+    """Daily roll-up of cost_events, oldest first."""
+
+    days: int
+    series: list[CostHistoryDay]
+    total_cost_usd: float
+    total_calls: int
+    total_tokens: int
 
 
 class SessionCostSummary(BaseModel):

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -141,6 +141,19 @@ class ChatRead(BaseModel):
     created_at: datetime.datetime
 
 
+class ChatUpdate(BaseModel):
+    """Editable per-chat moderation settings. All fields optional — only the
+    keys present in the body are applied (``exclude_unset``)."""
+
+    title: str | None = None
+    welcome_message: str | None = None
+    is_welcome_enabled: bool | None = None
+    is_captcha_enabled: bool | None = None
+    time_delete: int | None = None
+    parent_chat_id: int | None = None
+    relation_notes: str | None = None
+
+
 class ChatNode(BaseModel):
     """Recursive node for the /chats/graph tree response.
 
@@ -343,6 +356,16 @@ class OperationCostBucket(BaseModel):
     cache_savings_usd: float
 
 
+class ModelCostBucket(BaseModel):
+    """Per-model slice of the session cost summary."""
+
+    model: str
+    tokens: int
+    cost_usd: float
+    calls: int
+    cache_savings_usd: float
+
+
 class SessionCostSummary(BaseModel):
     """In-memory cost aggregation from app.channel.cost_tracker.
 
@@ -357,6 +380,7 @@ class SessionCostSummary(BaseModel):
     cache_write_tokens: int
     cache_savings_usd: float
     by_operation: list[OperationCostBucket]
+    by_model: list[ModelCostBucket] = []
 
     @classmethod
     def from_tracker(cls, summary: dict[str, Any]) -> SessionCostSummary:
@@ -365,7 +389,7 @@ class SessionCostSummary(BaseModel):
         Keeping the shape-conversion in one place prevents the /costs and
         /stats/home endpoints from drifting apart as cost_tracker evolves.
         """
-        buckets = [
+        op_buckets = [
             OperationCostBucket(
                 operation=op_name,
                 tokens=int(data.get("tokens", 0)),
@@ -375,6 +399,16 @@ class SessionCostSummary(BaseModel):
             )
             for op_name, data in (summary.get("by_operation") or {}).items()
         ]
+        model_buckets = [
+            ModelCostBucket(
+                model=model_name,
+                tokens=int(data.get("tokens", 0)),
+                cost_usd=float(data.get("cost_usd", 0.0)),
+                calls=int(data.get("calls", 0)),
+                cache_savings_usd=float(data.get("cache_savings_usd", 0.0)),
+            )
+            for model_name, data in (summary.get("by_model") or {}).items()
+        ]
         return cls(
             total_tokens=int(summary.get("total_tokens", 0)),
             total_cost_usd=float(summary.get("total_cost_usd", 0.0)),
@@ -382,7 +416,8 @@ class SessionCostSummary(BaseModel):
             cache_read_tokens=int(summary.get("cache_read_tokens", 0)),
             cache_write_tokens=int(summary.get("cache_write_tokens", 0)),
             cache_savings_usd=float(summary.get("cache_savings_usd", 0.0)),
-            by_operation=buckets,
+            by_operation=op_buckets,
+            by_model=model_buckets,
         )
 
 

--- a/tests/unit/test_channel_agent.py
+++ b/tests/unit/test_channel_agent.py
@@ -1632,6 +1632,11 @@ class TestCostTracker:
         assert by_op["discovery"]["calls"] == 2
         assert by_op["discovery"]["tokens"] == 150 + 180
 
+        by_model = summary["by_model"]
+        assert by_model["perplexity/sonar"]["calls"] == 2
+        assert by_model["perplexity/sonar"]["tokens"] == 150 + 180
+        assert by_model["google/gemini-2.0-flash-001"]["calls"] == 1
+
         assert "screening" in by_op
         assert by_op["screening"]["calls"] == 1
         assert by_op["screening"]["tokens"] == 280

--- a/tests/webapi/test_admin.py
+++ b/tests/webapi/test_admin.py
@@ -1,0 +1,141 @@
+"""Tests for /api/admin — sessions panel + system status."""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING
+
+import pytest
+from app.core.config import settings
+from app.db.models import AdminSession
+from app.webapi.main import app
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def client_factory(db_session_maker: async_sessionmaker[AsyncSession]):
+    from app.webapi.deps import get_session
+
+    async def _override_session():
+        async with db_session_maker() as s:
+            yield s
+
+    app.dependency_overrides[get_session] = _override_session
+    settings.admin.super_admins = [1]
+    settings.webapi.dev_bypass_auth = True
+    transport = ASGITransport(app=app)
+
+    def make() -> AsyncClient:
+        return AsyncClient(transport=transport, base_url="http://test")
+
+    yield make
+    app.dependency_overrides.pop(get_session, None)
+
+
+async def _seed_session(s: AsyncSession, *, session_id: str, user_id: int = 1) -> None:
+    now = datetime.datetime(2026, 4, 27, 12, 0, 0)
+    s.add(
+        AdminSession(
+            session_id=session_id,
+            user_id=user_id,
+            created_at=now,
+            last_seen_at=now,
+            expires_at=now + datetime.timedelta(days=30),
+            user_agent="test-agent",
+            ip="127.0.0.1",
+        )
+    )
+    await s.commit()
+
+
+async def test_list_sessions_returns_only_callers(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        await _seed_session(s, session_id="mine-1", user_id=1)
+        await _seed_session(s, session_id="mine-2", user_id=1)
+        await _seed_session(s, session_id="other", user_id=999)
+
+    async with client_factory() as client:
+        resp = await client.get("/api/admin/sessions")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    ids = sorted(r["session_id"] for r in body)
+    assert ids == ["mine-1", "mine-2"]
+
+
+async def test_list_sessions_marks_current(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        await _seed_session(s, session_id="active-token")
+        await _seed_session(s, session_id="other-token")
+
+    async with client_factory() as client:
+        client.cookies.set(settings.webapi.session_cookie_name, "active-token")
+        resp = await client.get("/api/admin/sessions")
+    body = resp.json()
+    rows = {r["session_id"]: r for r in body}
+    assert rows["active-token"]["is_current"] is True
+    assert rows["other-token"]["is_current"] is False
+
+
+async def test_revoke_session_deletes_row(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        await _seed_session(s, session_id="to-revoke")
+
+    async with client_factory() as client:
+        resp = await client.delete("/api/admin/sessions/to-revoke")
+    assert resp.status_code == 204
+
+    async with db_session_maker() as s:
+        gone = (
+            await s.execute(select(AdminSession).where(AdminSession.session_id == "to-revoke"))
+        ).scalar_one_or_none()
+        assert gone is None
+
+
+async def test_revoke_current_session_400(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        await _seed_session(s, session_id="active-token")
+
+    async with client_factory() as client:
+        client.cookies.set(settings.webapi.session_cookie_name, "active-token")
+        resp = await client.delete("/api/admin/sessions/active-token")
+    assert resp.status_code == 400
+    assert "logout" in resp.json()["detail"].lower()
+
+
+async def test_revoke_session_404_when_unknown(client_factory) -> None:
+    async with client_factory() as client:
+        resp = await client.delete("/api/admin/sessions/does-not-exist")
+    assert resp.status_code == 404
+
+
+async def test_revoke_other_users_session_403(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        await _seed_session(s, session_id="someone-elses", user_id=999)
+
+    async with client_factory() as client:
+        resp = await client.delete("/api/admin/sessions/someone-elses")
+    assert resp.status_code == 403
+
+
+async def test_get_system_status(client_factory) -> None:
+    settings.webapi.allowed_origins = ["http://localhost:5173"]
+    settings.webapi.session_ttl_days = 30
+    async with client_factory() as client:
+        resp = await client.get("/api/admin/system")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["super_admin_ids"] == [1]
+    assert body["session_ttl_days"] == 30
+    flag_names = {f["name"] for f in body["feature_flags"]}
+    assert flag_names == {
+        "dev_bypass_auth",
+        "moderation_enabled",
+        "ad_detector_enabled",
+        "assistant_bot_enabled",
+    }

--- a/tests/webapi/test_chat_mutations.py
+++ b/tests/webapi/test_chat_mutations.py
@@ -1,0 +1,110 @@
+"""Tests for PATCH /api/chats/{id} — per-chat moderation toggles."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from app.core.config import settings
+from app.db.models import Chat
+from app.webapi.main import app
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def client_factory(db_session_maker: async_sessionmaker[AsyncSession]):
+    from app.webapi.deps import get_session, get_telethon
+
+    async def _override_session():
+        async with db_session_maker() as s:
+            yield s
+
+    async def _override_telethon():
+        return None
+
+    app.dependency_overrides[get_session] = _override_session
+    app.dependency_overrides[get_telethon] = _override_telethon
+    settings.admin.super_admins = [1]
+    settings.webapi.dev_bypass_auth = True
+    transport = ASGITransport(app=app)
+
+    def make() -> AsyncClient:
+        return AsyncClient(transport=transport, base_url="http://test")
+
+    yield make
+    app.dependency_overrides.pop(get_session, None)
+    app.dependency_overrides.pop(get_telethon, None)
+
+
+async def test_update_chat_toggles(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        s.add(Chat(id=-2001, title="moderated"))
+        await s.commit()
+
+    async with client_factory() as client:
+        resp = await client.patch(
+            "/api/chats/-2001",
+            json={
+                "title": "renamed",
+                "is_welcome_enabled": True,
+                "is_captcha_enabled": True,
+                "welcome_message": "hi",
+                "time_delete": 120,
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["title"] == "renamed"
+    assert body["is_welcome_enabled"] is True
+    assert body["is_captcha_enabled"] is True
+
+    async with db_session_maker() as s:
+        ch = (await s.execute(select(Chat).where(Chat.id == -2001))).scalar_one()
+        assert ch.welcome_message == "hi"
+        assert ch.time_delete == 120
+
+
+async def test_update_chat_404(client_factory) -> None:
+    async with client_factory() as client:
+        resp = await client.patch("/api/chats/99999", json={"title": "x"})
+    assert resp.status_code == 404
+
+
+async def test_update_chat_negative_time_delete_422(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        s.add(Chat(id=-2002, title="x"))
+        await s.commit()
+    async with client_factory() as client:
+        resp = await client.patch("/api/chats/-2002", json={"time_delete": -5})
+    assert resp.status_code == 422
+
+
+async def test_update_chat_self_parent_422(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        s.add(Chat(id=-2003, title="x"))
+        await s.commit()
+    async with client_factory() as client:
+        resp = await client.patch("/api/chats/-2003", json={"parent_chat_id": -2003})
+    assert resp.status_code == 422
+
+
+async def test_update_chat_partial_keeps_other_fields(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        s.add(Chat(id=-2004, title="orig", welcome_message="orig-welcome"))
+        await s.commit()
+
+    async with client_factory() as client:
+        resp = await client.patch("/api/chats/-2004", json={"is_welcome_enabled": True})
+    assert resp.status_code == 200, resp.text
+
+    async with db_session_maker() as s:
+        ch = (await s.execute(select(Chat).where(Chat.id == -2004))).scalar_one()
+        assert ch.welcome_message == "orig-welcome"
+        assert ch.title == "orig"
+        assert ch.is_welcome_enabled is True

--- a/tests/webapi/test_costs.py
+++ b/tests/webapi/test_costs.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import datetime
+from typing import TYPE_CHECKING
+
 import pytest
 from app.channel import cost_tracker
 from app.channel.cost_tracker import LLMUsage
 from app.core.config import settings
+from app.core.time import utc_now
+from app.db.models import CostEvent
 from app.webapi.main import app
 from httpx import ASGITransport, AsyncClient
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 pytestmark = pytest.mark.asyncio
 
@@ -17,6 +25,23 @@ def client():
     settings.admin.super_admins = [1]
     transport = ASGITransport(app=app)
     return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest.fixture
+def history_client(db_session_maker: async_sessionmaker[AsyncSession]):
+    """Wire test session for /history queries — it touches cost_events table."""
+    from app.webapi.deps import get_session
+
+    async def _override_session():
+        async with db_session_maker() as s:
+            yield s
+
+    settings.admin.super_admins = [1]
+    settings.webapi.dev_bypass_auth = True
+    app.dependency_overrides[get_session] = _override_session
+    transport = ASGITransport(app=app)
+    yield AsyncClient(transport=transport, base_url="http://test")
+    app.dependency_overrides.pop(get_session, None)
 
 
 @pytest.fixture(autouse=True)
@@ -83,3 +108,64 @@ async def test_session_cost_aggregates_by_operation(client) -> None:
     assert pytest.approx(ops["screening"]["cost_usd"], abs=1e-6) == 0.03
     assert ops["screening"]["tokens"] == 450
     assert ops["generation"]["calls"] == 1
+
+
+async def test_cost_history_returns_zero_filled_series(history_client) -> None:
+    async with history_client as c:
+        resp = await c.get("/api/costs/history?days=7")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["days"] == 7
+    assert len(body["series"]) == 7
+    assert body["total_calls"] == 0
+    assert all(p["cost_usd"] == 0.0 for p in body["series"])
+
+
+async def test_cost_history_aggregates_persisted_events(history_client, db_session_maker) -> None:
+    now = utc_now()
+    async with db_session_maker() as s:
+        s.add_all(
+            [
+                CostEvent(
+                    model="m-a",
+                    operation="screening",
+                    occurred_at=now - datetime.timedelta(hours=1),
+                    total_tokens=100,
+                    cost_usd=0.05,
+                ),
+                CostEvent(
+                    model="m-a",
+                    operation="generation",
+                    occurred_at=now - datetime.timedelta(hours=2),
+                    total_tokens=200,
+                    cost_usd=0.10,
+                ),
+                CostEvent(
+                    model="m-b",
+                    operation="discovery",
+                    occurred_at=now - datetime.timedelta(days=2, hours=1),
+                    total_tokens=50,
+                    cost_usd=0.02,
+                ),
+                # Outside window:
+                CostEvent(
+                    model="m-c",
+                    operation="screening",
+                    occurred_at=now - datetime.timedelta(days=10),
+                    total_tokens=500,
+                    cost_usd=1.00,
+                ),
+            ]
+        )
+        await s.commit()
+
+    async with history_client as c:
+        resp = await c.get("/api/costs/history?days=7")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["days"] == 7
+    assert len(body["series"]) == 7
+    # 0.05 + 0.10 (today) + 0.02 (2d ago) — 1.00 falls outside the 7-day window.
+    assert pytest.approx(body["total_cost_usd"], abs=1e-6) == 0.17
+    assert body["total_calls"] == 3
+    assert body["total_tokens"] == 350

--- a/tests/webapi/test_post_mutations.py
+++ b/tests/webapi/test_post_mutations.py
@@ -127,3 +127,95 @@ async def test_404_when_missing(client_factory) -> None:
     async with make() as client:
         resp = await client.patch("/api/posts/99999/text", json={"text": "x"})
     assert resp.status_code == 404
+
+
+async def test_regenerate_404_when_missing(client_factory) -> None:
+    make, _bot = client_factory
+    async with make() as client:
+        resp = await client.post("/api/posts/99999/regenerate")
+    assert resp.status_code == 404
+
+
+async def test_regenerate_refuses_already_published(client_factory, db_session_maker) -> None:
+    """Status check happens inside regen_post_text — route returns 200 with the
+    refusal message instead of mutating the post."""
+    make, _bot = client_factory
+    async with db_session_maker() as s:
+        post_id = await _seed_post(s, status=PostStatus.APPROVED)
+
+    async with make() as client:
+        resp = await client.post(f"/api/posts/{post_id}/regenerate")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "already published" in body["message"].lower()
+    async with db_session_maker() as s:
+        post = (await s.execute(select(ChannelPost).where(ChannelPost.id == post_id))).scalar_one()
+        assert post.status == PostStatus.APPROVED  # untouched
+
+
+async def test_image_remove_404_when_post_missing(client_factory) -> None:
+    make, _bot = client_factory
+    async with make() as client:
+        resp = await client.delete("/api/posts/99999/images/0")
+    assert resp.status_code == 404
+
+
+async def test_image_clear_drops_selected_keeps_pool(client_factory, db_session_maker) -> None:
+    make, _bot = client_factory
+    async with db_session_maker() as s:
+        ch = Channel(name="x", language="en", telegram_id=-100200)
+        s.add(ch)
+        await s.flush()
+        post = ChannelPost(
+            channel_id=ch.telegram_id,
+            external_id="z" * 16,
+            title="t",
+            post_text="hello",
+            image_urls=["https://a.example/img1.jpg", "https://a.example/img2.jpg"],
+            image_candidates=[
+                {"url": "https://a.example/img1.jpg", "source": "rss", "selected": True},
+                {"url": "https://a.example/img2.jpg", "source": "rss", "selected": True},
+                {"url": "https://a.example/img3.jpg", "source": "rss", "selected": False},
+            ],
+        )
+        s.add(post)
+        await s.commit()
+        post_id = post.id
+
+    async with make() as client:
+        resp = await client.delete(f"/api/posts/{post_id}/images")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["image_urls"] == []
+    assert len(body["image_candidates"]) == 3
+    assert all(not c["selected"] for c in body["image_candidates"])
+
+
+async def test_image_reorder_validates_permutation(client_factory, db_session_maker) -> None:
+    make, _bot = client_factory
+    async with db_session_maker() as s:
+        ch = Channel(name="x", language="en", telegram_id=-100200)
+        s.add(ch)
+        await s.flush()
+        post = ChannelPost(
+            channel_id=ch.telegram_id,
+            external_id="z" * 16,
+            title="t",
+            post_text="hello",
+            image_urls=["https://a.example/1", "https://a.example/2", "https://a.example/3"],
+        )
+        s.add(post)
+        await s.commit()
+        post_id = post.id
+
+    async with make() as client:
+        good = await client.post(f"/api/posts/{post_id}/images/reorder", json={"order": [2, 0, 1]})
+        bad = await client.post(f"/api/posts/{post_id}/images/reorder", json={"order": [0, 0, 1]})
+    assert good.status_code == 200
+    assert good.json()["image_urls"] == [
+        "https://a.example/3",
+        "https://a.example/1",
+        "https://a.example/2",
+    ]
+    assert bad.status_code == 200  # service-level rejection, not HTTP
+    assert "invalid" in bad.json()["message"].lower()

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -289,7 +289,8 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update Chat */
+        patch: operations["update_chat_api_chats__chat_id__patch"];
         trace?: never;
     };
     "/api/costs/session": {
@@ -922,6 +923,27 @@ export interface components {
             blocked: boolean;
         };
         /**
+         * ChatUpdate
+         * @description Editable per-chat moderation settings. All fields optional — only the
+         *     keys present in the body are applied (``exclude_unset``).
+         */
+        ChatUpdate: {
+            /** Title */
+            title?: string | null;
+            /** Welcome Message */
+            welcome_message?: string | null;
+            /** Is Welcome Enabled */
+            is_welcome_enabled?: boolean | null;
+            /** Is Captcha Enabled */
+            is_captcha_enabled?: boolean | null;
+            /** Time Delete */
+            time_delete?: number | null;
+            /** Parent Chat Id */
+            parent_chat_id?: number | null;
+            /** Relation Notes */
+            relation_notes?: string | null;
+        };
+        /**
          * DraftBucket
          * @description Home tile: drafts grouped by channel.
          */
@@ -1035,6 +1057,22 @@ export interface components {
             delta_24h: number | null;
             /** Delta 7D */
             delta_7d: number | null;
+        };
+        /**
+         * ModelCostBucket
+         * @description Per-model slice of the session cost summary.
+         */
+        ModelCostBucket: {
+            /** Model */
+            model: string;
+            /** Tokens */
+            tokens: number;
+            /** Cost Usd */
+            cost_usd: number;
+            /** Calls */
+            calls: number;
+            /** Cache Savings Usd */
+            cache_savings_usd: number;
         };
         /**
          * OperationCostBucket
@@ -1205,6 +1243,11 @@ export interface components {
             cache_savings_usd: number;
             /** By Operation */
             by_operation: components["schemas"]["OperationCostBucket"][];
+            /**
+             * By Model
+             * @default []
+             */
+            by_model: components["schemas"]["ModelCostBucket"][];
         };
         /**
          * SpamPingRead
@@ -1890,6 +1933,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChatDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_chat_api_chats__chat_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChatUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatRead"];
                 };
             };
             /** @description Validation Error */

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -157,6 +157,131 @@ export interface paths {
         patch: operations["edit_text_api_posts__post_id__text_patch"];
         trace?: never;
     };
+    "/api/posts/{post_id}/regenerate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Regenerate
+         * @description Re-run the generator over the post's stored source_items and replace the body.
+         *
+         *     Looks up the channel to resolve language + footer; falls back to defaults
+         *     when the channel row is missing (e.g. test fixtures).
+         */
+        post: operations["regenerate_api_posts__post_id__regenerate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/posts/{post_id}/images/use": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Image Use */
+        post: operations["image_use_api_posts__post_id__images_use_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/posts/{post_id}/images/url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Image Add Url */
+        post: operations["image_add_url_api_posts__post_id__images_url_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/posts/{post_id}/images/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Image Search */
+        post: operations["image_search_api_posts__post_id__images_search_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/posts/{post_id}/images/{position}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Image Remove */
+        delete: operations["image_remove_api_posts__post_id__images__position__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/posts/{post_id}/images/reorder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Image Reorder */
+        post: operations["image_reorder_api_posts__post_id__images_reorder_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/posts/{post_id}/images": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Image Clear */
+        delete: operations["image_clear_api_posts__post_id__images_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/channels": {
         parameters: {
             query?: never;
@@ -302,6 +427,29 @@ export interface paths {
         };
         /** Session Cost */
         get: operations["session_cost_api_costs_session_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/costs/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Cost History
+         * @description Daily aggregate of cost_events for the last ``days`` days, oldest first.
+         *
+         *     Empty days are filled with zero rows so the FE can render a contiguous
+         *     sparkline without gap-filling client-side.
+         */
+        get: operations["cost_history_api_costs_history_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -944,6 +1092,38 @@ export interface components {
             relation_notes?: string | null;
         };
         /**
+         * CostHistoryDay
+         * @description One day in the persistent cost history series.
+         */
+        CostHistoryDay: {
+            /** Day */
+            day: string;
+            /** Cost Usd */
+            cost_usd: number;
+            /** Tokens */
+            tokens: number;
+            /** Calls */
+            calls: number;
+            /** Cache Savings Usd */
+            cache_savings_usd: number;
+        };
+        /**
+         * CostHistoryResponse
+         * @description Daily roll-up of cost_events, oldest first.
+         */
+        CostHistoryResponse: {
+            /** Days */
+            days: number;
+            /** Series */
+            series: components["schemas"]["CostHistoryDay"][];
+            /** Total Cost Usd */
+            total_cost_usd: number;
+            /** Total Calls */
+            total_calls: number;
+            /** Total Tokens */
+            total_tokens: number;
+        };
+        /**
          * DraftBucket
          * @description Home tile: drafts grouped by channel.
          */
@@ -1028,6 +1208,58 @@ export interface components {
              *     }
              */
             spam_pings: components["schemas"]["SpamPingsSummary"];
+        };
+        /**
+         * ImageAddUrlRequest
+         * @description POST /api/posts/{id}/images/url — vet + attach an arbitrary URL.
+         */
+        ImageAddUrlRequest: {
+            /** Url */
+            url: string;
+            /** Position */
+            position?: number | null;
+        };
+        /**
+         * ImageMutationResponse
+         * @description Common response shape for image-pool mutations.
+         */
+        ImageMutationResponse: {
+            /** Post Id */
+            post_id: number;
+            /** Message */
+            message: string;
+            /** Image Urls */
+            image_urls: string[];
+            /** Image Candidates */
+            image_candidates: {
+                [key: string]: unknown;
+            }[];
+        };
+        /**
+         * ImageReorderRequest
+         * @description POST /api/posts/{id}/images/reorder — permutation of current selected positions.
+         */
+        ImageReorderRequest: {
+            /** Order */
+            order: number[];
+        };
+        /**
+         * ImageSearchRequest
+         * @description POST /api/posts/{id}/images/search — Brave search → vision-score → pool.
+         */
+        ImageSearchRequest: {
+            /** Query */
+            query: string;
+        };
+        /**
+         * ImageUseRequest
+         * @description POST /api/posts/{id}/images/use — promote a pool candidate to selected.
+         */
+        ImageUseRequest: {
+            /** Pool Index */
+            pool_index: number;
+            /** Position */
+            position?: number | null;
         };
         /** MemberSnapshotPoint */
         MemberSnapshotPoint: {
@@ -1128,6 +1360,12 @@ export interface components {
             external_id: string;
             /** Source Items */
             source_items?: {
+                [key: string]: unknown;
+            }[] | null;
+            /** Pre Critic Text */
+            pre_critic_text?: string | null;
+            /** Image Candidates */
+            image_candidates?: {
                 [key: string]: unknown;
             }[] | null;
         };
@@ -1622,6 +1860,240 @@ export interface operations {
             };
         };
     };
+    regenerate_api_posts__post_id__regenerate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                post_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PostMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    image_use_api_posts__post_id__images_use_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                post_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ImageUseRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImageMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    image_add_url_api_posts__post_id__images_url_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                post_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ImageAddUrlRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImageMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    image_search_api_posts__post_id__images_search_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                post_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ImageSearchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImageMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    image_remove_api_posts__post_id__images__position__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                post_id: number;
+                position: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImageMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    image_reorder_api_posts__post_id__images_reorder_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                post_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ImageReorderRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImageMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    image_clear_api_posts__post_id__images_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                post_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImageMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_channels_api_channels_get: {
         parameters: {
             query?: never;
@@ -1997,6 +2469,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SessionCostSummary"];
+                };
+            };
+        };
+    };
+    cost_history_api_costs_history_get: {
+        parameters: {
+            query?: {
+                /** @description Lookback window in days */
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CostHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -444,10 +444,101 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Sessions
+         * @description List the calling admin's active sessions, current one flagged.
+         */
+        get: operations["list_sessions_api_admin_sessions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/sessions/{session_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Revoke Session
+         * @description Revoke one of the calling admin's sessions. Refuse to revoke the current one.
+         */
+        delete: operations["revoke_session_api_admin_sessions__session_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/system": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get System Status */
+        get: operations["get_system_status_api_admin_system_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * AdminSessionRead
+         * @description Active admin session row — used by /settings to list logins.
+         */
+        AdminSessionRead: {
+            /** Session Id */
+            session_id: string;
+            /** User Id */
+            user_id: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Last Seen At
+             * Format: date-time
+             */
+            last_seen_at: string;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+            /** User Agent */
+            user_agent: string | null;
+            /** Ip */
+            ip: string | null;
+            /**
+             * Is Current
+             * @default false
+             */
+            is_current: boolean;
+        };
         /**
          * AgentHistory
          * @description Persisted-conversation snapshot for /agent.
@@ -842,6 +933,21 @@ export interface components {
             /** Count */
             count: number;
         };
+        /**
+         * FeatureFlagRead
+         * @description One feature flag — surfaced as a badge in /settings.
+         */
+        FeatureFlagRead: {
+            /** Name */
+            name: string;
+            /** Enabled */
+            enabled: boolean;
+            /**
+             * Source
+             * @default env
+             */
+            source: string;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -1141,6 +1247,24 @@ export interface components {
              * @default []
              */
             recent: components["schemas"]["SpamPingRead"][];
+        };
+        /**
+         * SystemStatus
+         * @description Read-only operational status for the /settings system card.
+         */
+        SystemStatus: {
+            /** Super Admin Ids */
+            super_admin_ids: number[];
+            /** Telethon Connected */
+            telethon_connected: boolean;
+            /** Publish Bot Ready */
+            publish_bot_ready: boolean;
+            /** Allowed Origins */
+            allowed_origins: string[];
+            /** Session Ttl Days */
+            session_ttl_days: number;
+            /** Feature Flags */
+            feature_flags: components["schemas"]["FeatureFlagRead"][];
         };
         /**
          * TelegramLoginPayload
@@ -2017,6 +2141,75 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_sessions_api_admin_sessions_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminSessionRead"][];
+                };
+            };
+        };
+    };
+    revoke_session_api_admin_sessions__session_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_system_status_api_admin_system_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemStatus"];
                 };
             };
         };

--- a/webui/src/lib/components/app-shell/Header.svelte
+++ b/webui/src/lib/components/app-shell/Header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { LogOut, User } from '@lucide/svelte';
 	import { auth } from '$lib/stores/auth.svelte';
 
 	type Props = { onLogout?: () => void | Promise<void> };
@@ -7,7 +8,7 @@
 
 	function currentTitle(pathname: string): string {
 		const map: Record<string, string> = {
-			'/': 'Home',
+			'/': 'Dashboard',
 			'/posts': 'Posts',
 			'/channels': 'Channels',
 			'/chats': 'Chats',
@@ -28,15 +29,19 @@
 >
 	<h1 class="text-base font-medium text-zinc-900">{currentTitle(page.url.pathname)}</h1>
 	<div class="flex items-center gap-2 text-xs text-zinc-500">
-		<span class="rounded-full bg-zinc-100 px-2.5 py-1 font-medium">dev</span>
+		<span class="rounded-full bg-emerald-50 px-2.5 py-1 font-medium text-emerald-700">dev</span>
 		{#if auth.me}
-			<span>#{auth.me.user_id}</span>
+			<div class="flex items-center gap-1.5 rounded-md px-2 py-1">
+				<User class="h-3.5 w-3.5" />
+				<span class="font-mono">#{auth.me.user_id}</span>
+			</div>
 			<button
 				type="button"
-				class="rounded-md px-2 py-1 font-medium hover:bg-zinc-100 hover:text-zinc-800"
+				class="flex items-center gap-1.5 rounded-md px-2 py-1 font-medium hover:bg-zinc-100 hover:text-zinc-800"
 				onclick={() => onLogout?.()}
 			>
-				Logout
+				<LogOut class="h-3.5 w-3.5" />
+				<span>Logout</span>
 			</button>
 		{:else}
 			<span>admin</span>

--- a/webui/src/lib/components/app-shell/Sidebar.svelte
+++ b/webui/src/lib/components/app-shell/Sidebar.svelte
@@ -1,50 +1,86 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import {
+		Hash,
+		LayoutDashboard,
+		MessagesSquare,
+		Network,
+		Newspaper,
+		Receipt,
+		Settings,
+		Sparkles,
+		Tv
+	} from '@lucide/svelte';
+	import type { Component } from 'svelte';
 
-	type NavItem = { href: string; label: string; phase?: number };
+	type NavItem = { href: string; label: string; icon: Component };
+	type NavGroup = { label: string; items: NavItem[] };
 
-	const items: NavItem[] = [
-		{ href: '/', label: 'Home', phase: 1 },
-		{ href: '/posts', label: 'Posts', phase: 1 },
-		{ href: '/channels', label: 'Channels', phase: 1 },
-		{ href: '/chats', label: 'Chats', phase: 2 },
-		{ href: '/chats/graph', label: 'Chat graph', phase: 3 },
-		{ href: '/costs', label: 'Costs', phase: 1 },
-		{ href: '/agent', label: 'Agent', phase: 3 },
-		{ href: '/settings', label: 'Settings', phase: 4 }
+	const groups: NavGroup[] = [
+		{
+			label: 'Overview',
+			items: [{ href: '/', label: 'Dashboard', icon: LayoutDashboard }]
+		},
+		{
+			label: 'Resources',
+			items: [
+				{ href: '/channels', label: 'Channels', icon: Tv },
+				{ href: '/chats', label: 'Chats', icon: MessagesSquare },
+				{ href: '/chats/graph', label: 'Chat graph', icon: Network }
+			]
+		},
+		{
+			label: 'Workflow',
+			items: [
+				{ href: '/posts', label: 'Posts', icon: Newspaper },
+				{ href: '/agent', label: 'Agent', icon: Sparkles }
+			]
+		},
+		{
+			label: 'System',
+			items: [
+				{ href: '/costs', label: 'Costs', icon: Receipt },
+				{ href: '/settings', label: 'Settings', icon: Settings }
+			]
+		}
 	];
 
 	function isActive(href: string): boolean {
 		if (href === '/') return page.url.pathname === '/';
+		if (href === '/chats') {
+			return page.url.pathname === '/chats' || /^\/chats\/-?\d+/.test(page.url.pathname);
+		}
 		return page.url.pathname === href || page.url.pathname.startsWith(href + '/');
 	}
 </script>
 
 <nav class="flex h-full w-56 shrink-0 flex-col border-r border-zinc-200 bg-zinc-50">
-	<div class="px-4 py-5">
+	<div class="flex items-center gap-2 px-4 py-5">
+		<div class="flex h-7 w-7 items-center justify-center rounded-md bg-zinc-900 text-white">
+			<Hash class="h-4 w-4" />
+		</div>
 		<span class="text-sm font-semibold tracking-tight text-zinc-900">Konnekt admin</span>
 	</div>
-	<ul class="flex flex-col gap-0.5 px-2">
-		{#each items as item (item.href)}
-			<li>
-				<a
-					href={item.href}
-					class="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors
-						{isActive(item.href)
-						? 'bg-zinc-900 text-white'
-						: 'text-zinc-700 hover:bg-zinc-200'}"
-				>
-					<span>{item.label}</span>
-					{#if item.phase}
-						<span
-							class="rounded-sm px-1.5 py-0.5 text-[10px] font-medium
-								{isActive(item.href) ? 'bg-white/20 text-white' : 'bg-zinc-200 text-zinc-600'}"
-						>
-							P{item.phase}
-						</span>
-					{/if}
-				</a>
-			</li>
+
+	<div class="flex flex-col gap-4 px-2 pb-4">
+		{#each groups as group (group.label)}
+			<div class="flex flex-col gap-0.5">
+				<div class="px-3 pb-1 text-[10px] font-semibold tracking-wider text-zinc-400 uppercase">
+					{group.label}
+				</div>
+				{#each group.items as item (item.href)}
+					{@const Icon = item.icon}
+					{@const active = isActive(item.href)}
+					<a
+						href={item.href}
+						class="flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors
+							{active ? 'bg-zinc-900 text-white' : 'text-zinc-700 hover:bg-zinc-200'}"
+					>
+						<Icon class="h-4 w-4 shrink-0 {active ? 'text-white' : 'text-zinc-500'}" />
+						<span>{item.label}</span>
+					</a>
+				{/each}
+			</div>
 		{/each}
-	</ul>
+	</div>
 </nav>

--- a/webui/src/lib/components/charts/BarChartH.svelte
+++ b/webui/src/lib/components/charts/BarChartH.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	type Item = { label: string; value: number; secondary?: string };
+	type Item = { label: string; value: number; secondary?: string; href?: string };
 	type Props = {
 		items: Item[];
 		empty?: string;
@@ -17,19 +17,41 @@
 	<ul class="space-y-2">
 		{#each items as item, i (i)}
 			{@const pct = (Math.max(0, item.value) / computedMax) * 100}
-			<li class="space-y-1">
-				<div class="flex items-baseline justify-between gap-2 text-xs">
-					<span class="truncate text-zinc-700" title={item.label}>{item.label}</span>
-					<span class="shrink-0 tabular-nums text-zinc-500">
-						{item.secondary ?? format(item.value)}
-					</span>
-				</div>
-				<div class="h-1.5 w-full overflow-hidden rounded-full bg-zinc-100">
-					<div
-						class="h-full rounded-full bg-zinc-900/80 transition-[width] duration-300"
-						style:width="{pct}%"
-					></div>
-				</div>
+			<li>
+				{#if item.href}
+					<a
+						href={item.href}
+						class="block space-y-1 rounded-md px-1 py-0.5 -mx-1 hover:bg-zinc-50"
+					>
+						<div class="flex items-baseline justify-between gap-2 text-xs">
+							<span class="truncate text-zinc-700" title={item.label}>{item.label}</span>
+							<span class="shrink-0 tabular-nums text-zinc-500">
+								{item.secondary ?? format(item.value)}
+							</span>
+						</div>
+						<div class="h-1.5 w-full overflow-hidden rounded-full bg-zinc-100">
+							<div
+								class="h-full rounded-full bg-zinc-900/80 transition-[width] duration-300"
+								style:width="{pct}%"
+							></div>
+						</div>
+					</a>
+				{:else}
+					<div class="space-y-1">
+						<div class="flex items-baseline justify-between gap-2 text-xs">
+							<span class="truncate text-zinc-700" title={item.label}>{item.label}</span>
+							<span class="shrink-0 tabular-nums text-zinc-500">
+								{item.secondary ?? format(item.value)}
+							</span>
+						</div>
+						<div class="h-1.5 w-full overflow-hidden rounded-full bg-zinc-100">
+							<div
+								class="h-full rounded-full bg-zinc-900/80 transition-[width] duration-300"
+								style:width="{pct}%"
+							></div>
+						</div>
+					</div>
+				{/if}
 			</li>
 		{/each}
 	</ul>

--- a/webui/src/lib/components/charts/DivergingBars.svelte
+++ b/webui/src/lib/components/charts/DivergingBars.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	type Item = { label: string; value: number | null; secondary?: string };
+	type Item = { label: string; value: number | null; secondary?: string; href?: string };
 	type Props = { items: Item[]; empty?: string };
 	let { items, empty = 'No data' }: Props = $props();
 
@@ -17,33 +17,69 @@
 			{@const pct = v === null ? 0 : (Math.abs(v) / max) * 50}
 			{@const positive = v !== null && v > 0}
 			{@const zero = v === null || v === 0}
-			<li class="space-y-1">
-				<div class="flex items-baseline justify-between gap-2 text-xs">
-					<span class="truncate text-zinc-700" title={item.label}>{item.label}</span>
-					<span
-						class="shrink-0 tabular-nums {v === null
-							? 'text-zinc-400'
-							: positive
-								? 'text-emerald-600'
-								: zero
-									? 'text-zinc-500'
-									: 'text-rose-600'}"
+			<li>
+				{#if item.href}
+					<a
+						href={item.href}
+						class="block space-y-1 -mx-1 rounded-md px-1 py-0.5 hover:bg-zinc-50"
 					>
-						{item.secondary ?? (positive ? `+${v}` : `${v ?? '—'}`)}
-					</span>
-				</div>
-				<div class="relative h-1.5 w-full overflow-hidden rounded-full bg-zinc-100">
-					<div class="absolute top-0 bottom-0 left-1/2 w-px bg-zinc-300"></div>
-					{#if !zero}
-						<div
-							class="absolute top-0 bottom-0 transition-[width,left] duration-300 {positive
-								? 'rounded-r-full bg-emerald-500/80'
-								: 'rounded-l-full bg-rose-500/80'}"
-							style:left="{positive ? 50 : 50 - pct}%"
-							style:width="{pct}%"
-						></div>
-					{/if}
-				</div>
+						<div class="flex items-baseline justify-between gap-2 text-xs">
+							<span class="truncate text-zinc-700" title={item.label}>{item.label}</span>
+							<span
+								class="shrink-0 tabular-nums {v === null
+									? 'text-zinc-400'
+									: positive
+										? 'text-emerald-600'
+										: zero
+											? 'text-zinc-500'
+											: 'text-rose-600'}"
+							>
+								{item.secondary ?? (positive ? `+${v}` : `${v ?? '—'}`)}
+							</span>
+						</div>
+						<div class="relative h-1.5 w-full overflow-hidden rounded-full bg-zinc-100">
+							<div class="absolute top-0 bottom-0 left-1/2 w-px bg-zinc-300"></div>
+							{#if !zero}
+								<div
+									class="absolute top-0 bottom-0 transition-[width,left] duration-300 {positive
+										? 'rounded-r-full bg-emerald-500/80'
+										: 'rounded-l-full bg-rose-500/80'}"
+									style:left="{positive ? 50 : 50 - pct}%"
+									style:width="{pct}%"
+								></div>
+							{/if}
+						</div>
+					</a>
+				{:else}
+					<div class="space-y-1">
+						<div class="flex items-baseline justify-between gap-2 text-xs">
+							<span class="truncate text-zinc-700" title={item.label}>{item.label}</span>
+							<span
+								class="shrink-0 tabular-nums {v === null
+									? 'text-zinc-400'
+									: positive
+										? 'text-emerald-600'
+										: zero
+											? 'text-zinc-500'
+											: 'text-rose-600'}"
+							>
+								{item.secondary ?? (positive ? `+${v}` : `${v ?? '—'}`)}
+							</span>
+						</div>
+						<div class="relative h-1.5 w-full overflow-hidden rounded-full bg-zinc-100">
+							<div class="absolute top-0 bottom-0 left-1/2 w-px bg-zinc-300"></div>
+							{#if !zero}
+								<div
+									class="absolute top-0 bottom-0 transition-[width,left] duration-300 {positive
+										? 'rounded-r-full bg-emerald-500/80'
+										: 'rounded-l-full bg-rose-500/80'}"
+									style:left="{positive ? 50 : 50 - pct}%"
+									style:width="{pct}%"
+								></div>
+							{/if}
+						</div>
+					</div>
+				{/if}
 			</li>
 		{/each}
 	</ul>

--- a/webui/src/lib/components/home/ActionTile.svelte
+++ b/webui/src/lib/components/home/ActionTile.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import type { Component, Snippet } from 'svelte';
+	import { ArrowRight } from '@lucide/svelte';
+
+	type Props = {
+		title: string;
+		value: string | number;
+		caption?: string;
+		href?: string;
+		cta?: string;
+		icon?: Component;
+		tone?: 'default' | 'attention' | 'success' | 'warning';
+		children?: Snippet;
+	};
+	let {
+		title,
+		value,
+		caption,
+		href,
+		cta = 'Open',
+		icon: Icon,
+		tone = 'default',
+		children
+	}: Props = $props();
+
+	const toneClasses: Record<NonNullable<Props['tone']>, string> = {
+		default: 'border-zinc-200 bg-white',
+		attention: 'border-amber-200 bg-amber-50/40',
+		success: 'border-emerald-200 bg-emerald-50/40',
+		warning: 'border-rose-200 bg-rose-50/40'
+	};
+	const iconToneClasses: Record<NonNullable<Props['tone']>, string> = {
+		default: 'bg-zinc-100 text-zinc-600',
+		attention: 'bg-amber-100 text-amber-700',
+		success: 'bg-emerald-100 text-emerald-700',
+		warning: 'bg-rose-100 text-rose-700'
+	};
+</script>
+
+{#snippet body()}
+	<div class="flex items-start gap-3">
+		{#if Icon}
+			<div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md {iconToneClasses[tone]}">
+				<Icon class="h-4 w-4" />
+			</div>
+		{/if}
+		<div class="min-w-0 flex-1">
+			<div class="text-xs font-medium text-zinc-600">{title}</div>
+			<div class="mt-0.5 text-2xl font-semibold tracking-tight text-zinc-900">{value}</div>
+			{#if caption}
+				<div class="mt-0.5 text-xs text-zinc-500">{caption}</div>
+			{/if}
+			{#if children}
+				<div class="mt-1.5">{@render children()}</div>
+			{/if}
+		</div>
+		{#if href}
+			<div class="flex items-center gap-1 self-end text-xs font-medium text-zinc-700">
+				<span>{cta}</span>
+				<ArrowRight class="h-3.5 w-3.5" />
+			</div>
+		{/if}
+	</div>
+{/snippet}
+
+{#if href}
+	<a
+		{href}
+		class="block rounded-lg border p-4 transition-colors hover:bg-zinc-50 {toneClasses[tone]}"
+	>
+		{@render body()}
+	</a>
+{:else}
+	<div class="rounded-lg border p-4 {toneClasses[tone]}">{@render body()}</div>
+{/if}

--- a/webui/src/lib/components/posts/ImagePool.svelte
+++ b/webui/src/lib/components/posts/ImagePool.svelte
@@ -1,0 +1,287 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { apiFetch } from '$lib/api/client';
+	import { GripVertical, ImagePlus, Search, Trash2, X } from '@lucide/svelte';
+	import { toast } from 'svelte-sonner';
+	import type { components } from '$lib/api/types';
+
+	type ImageMutationResponse = components['schemas']['ImageMutationResponse'];
+
+	// OpenAPI surfaces image_candidates as Record<string, unknown>[] because the
+	// pydantic schema uses `list[dict[str, Any]]`. We narrow at the access site
+	// rather than forcing the API to be more rigid.
+	type RawCandidate = { [key: string]: unknown };
+
+	type Props = {
+		postId: string | number;
+		selected: string[];
+		pool: RawCandidate[];
+		canEdit: boolean;
+		onChange: (resp: ImageMutationResponse) => void;
+	};
+
+	let { postId, selected, pool, canEdit, onChange }: Props = $props();
+
+	function asString(v: unknown): string | undefined {
+		return typeof v === 'string' ? v : undefined;
+	}
+	function asNumber(v: unknown): number | undefined {
+		return typeof v === 'number' ? v : undefined;
+	}
+	function asBool(v: unknown): boolean {
+		return v === true;
+	}
+	function urlOf(c: RawCandidate): string {
+		return asString(c.url) ?? '';
+	}
+
+	let busy = $state<string | null>(null);
+	let addUrl = $state('');
+	let searchQuery = $state('');
+
+	async function call(
+		path: string,
+		init: RequestInit,
+		busyKey: string,
+		successPrefix?: string
+	): Promise<void> {
+		busy = busyKey;
+		const res = await apiFetch<ImageMutationResponse>(path, init);
+		busy = null;
+		if (res.error) {
+			toast.error(res.error.message);
+			return;
+		}
+		const message = res.data.message;
+		if (successPrefix) toast.success(`${successPrefix} — ${message}`);
+		else toast.success(message);
+		onChange(res.data);
+	}
+
+	function useCandidate(idx: number): Promise<void> {
+		return call(
+			`/api/posts/${postId}/images/use`,
+			{ method: 'POST', body: JSON.stringify({ pool_index: idx }) },
+			`use-${idx}`
+		);
+	}
+
+	function removeAt(position: number): Promise<void> {
+		return call(`/api/posts/${postId}/images/${position}`, { method: 'DELETE' }, `remove-${position}`);
+	}
+
+	function clearAll(): Promise<void> {
+		if (!confirm('Detach all images from this post? Pool is kept.')) {
+			return Promise.resolve();
+		}
+		return call(`/api/posts/${postId}/images`, { method: 'DELETE' }, 'clear');
+	}
+
+	function addByUrl(): Promise<void> {
+		const u = addUrl.trim();
+		if (!u) return Promise.resolve();
+		return call(
+			`/api/posts/${postId}/images/url`,
+			{ method: 'POST', body: JSON.stringify({ url: u }) },
+			'add-url'
+		).then(() => {
+			addUrl = '';
+		});
+	}
+
+	function searchImages(): Promise<void> {
+		const q = searchQuery.trim();
+		if (!q) return Promise.resolve();
+		return call(
+			`/api/posts/${postId}/images/search`,
+			{ method: 'POST', body: JSON.stringify({ query: q }) },
+			'search'
+		);
+	}
+
+	async function moveSelected(from: number, dir: -1 | 1): Promise<void> {
+		const to = from + dir;
+		if (to < 0 || to >= selected.length) return;
+		const order = selected.map((_, i) => i);
+		[order[from], order[to]] = [order[to], order[from]];
+		await call(
+			`/api/posts/${postId}/images/reorder`,
+			{ method: 'POST', body: JSON.stringify({ order }) },
+			`move-${from}`
+		);
+	}
+
+	const selectedSet = $derived(new Set(selected));
+	const poolNotSelected = $derived(pool.filter((c) => !selectedSet.has(urlOf(c))));
+</script>
+
+<div class="space-y-4">
+	<!-- Selected -->
+	<div>
+		<div class="mb-2 flex items-center justify-between">
+			<div class="text-xs font-medium text-zinc-700">
+				Selected
+				<span class="ml-1 text-zinc-400">({selected.length})</span>
+			</div>
+			{#if canEdit && selected.length > 0}
+				<Button
+					variant="ghost"
+					size="sm"
+					class="text-red-600 hover:bg-red-50 hover:text-red-700"
+					disabled={busy !== null}
+					onclick={clearAll}
+				>
+					<Trash2 class="mr-1 h-3.5 w-3.5" />
+					{busy === 'clear' ? 'Clearing…' : 'Clear all'}
+				</Button>
+			{/if}
+		</div>
+		{#if selected.length === 0}
+			<p class="rounded-md border border-dashed border-zinc-200 px-3 py-6 text-center text-xs text-zinc-500">
+				No images selected. Pick from the pool below or add one.
+			</p>
+		{:else}
+			<div class="grid grid-cols-2 gap-3 md:grid-cols-3">
+				{#each selected as url, i (url)}
+					<div class="group relative overflow-hidden rounded-md border border-zinc-200 bg-zinc-50">
+						<img src={url} alt="" class="h-32 w-full object-cover" loading="lazy" />
+						<div class="absolute top-1 left-1 rounded bg-zinc-900/70 px-1.5 py-0.5 text-[10px] font-medium text-white">
+							#{i + 1}
+						</div>
+						{#if canEdit}
+							<div class="absolute right-1 bottom-1 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+								{#if selected.length > 1}
+									<button
+										type="button"
+										title="Move left"
+										class="rounded bg-zinc-900/80 px-1.5 py-0.5 text-[10px] text-white hover:bg-zinc-900"
+										onclick={() => moveSelected(i, -1)}
+										disabled={i === 0 || busy !== null}
+									>‹</button>
+									<button
+										type="button"
+										title="Move right"
+										class="rounded bg-zinc-900/80 px-1.5 py-0.5 text-[10px] text-white hover:bg-zinc-900"
+										onclick={() => moveSelected(i, 1)}
+										disabled={i === selected.length - 1 || busy !== null}
+									>›</button>
+								{/if}
+								<button
+									type="button"
+									title="Remove"
+									class="rounded bg-rose-600/90 px-1.5 py-0.5 text-[10px] text-white hover:bg-rose-700"
+									onclick={() => removeAt(i)}
+									disabled={busy !== null}
+								>
+									<X class="h-3 w-3" />
+								</button>
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Pool -->
+	{#if pool.length > 0}
+		<div>
+			<div class="mb-2 text-xs font-medium text-zinc-700">
+				Pool
+				<span class="ml-1 text-zinc-400">({poolNotSelected.length} unused / {pool.length} total)</span>
+			</div>
+			<div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+				{#each pool as cand, idx (urlOf(cand) || idx)}
+					{@const url = urlOf(cand)}
+					{@const source = asString(cand.source) ?? 'unknown'}
+					{@const description = asString(cand.description)}
+					{@const quality = asNumber(cand.quality_score)}
+					{@const relevance = asNumber(cand.relevance_score)}
+					{@const isLogo = asBool(cand.is_logo)}
+					{@const isTextSlide = asBool(cand.is_text_slide)}
+					{@const isSelected = selectedSet.has(url)}
+					{@const dim = isLogo || isTextSlide}
+					<div
+						class="group relative overflow-hidden rounded-md border bg-white {isSelected
+							? 'border-emerald-300 ring-1 ring-emerald-200'
+							: 'border-zinc-200'} {dim ? 'opacity-60' : ''}"
+					>
+						<img src={url} alt="" class="h-28 w-full object-cover" loading="lazy" />
+						<div class="space-y-0.5 px-2 py-1.5 text-[10px]">
+							<div class="flex items-center justify-between gap-1">
+								<span class="truncate font-mono text-zinc-500" title={source}>{source}</span>
+								<span class="shrink-0 tabular-nums text-zinc-600">
+									q{quality ?? '–'} · r{relevance ?? '–'}
+								</span>
+							</div>
+							{#if description}
+								<div class="line-clamp-2 text-zinc-500" title={description}>
+									{description}
+								</div>
+							{/if}
+							{#if isLogo || isTextSlide}
+								<div class="text-[9px] text-amber-700">
+									{isLogo ? 'logo' : ''}{isLogo && isTextSlide ? ' · ' : ''}{isTextSlide ? 'text-slide' : ''}
+								</div>
+							{/if}
+						</div>
+						{#if canEdit && !isSelected}
+							<button
+								type="button"
+								class="absolute inset-x-0 bottom-0 translate-y-full bg-zinc-900 py-1 text-[10px] font-medium text-white transition-transform group-hover:translate-y-0"
+								onclick={() => useCandidate(idx)}
+								disabled={busy !== null}
+							>
+								{busy === `use-${idx}` ? 'Adding…' : 'Use this'}
+							</button>
+						{:else if isSelected}
+							<div class="absolute top-1 right-1 rounded bg-emerald-600 px-1.5 py-0.5 text-[10px] font-medium text-white">
+								selected
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		</div>
+	{/if}
+
+	<!-- Add controls -->
+	{#if canEdit}
+		<div class="space-y-2 rounded-md border border-zinc-200 bg-zinc-50 p-3">
+			<div class="text-[10px] font-semibold tracking-wider text-zinc-500 uppercase">Add to pool</div>
+			<div class="flex gap-2">
+				<Input
+					placeholder="Image URL — vetted by vision model"
+					bind:value={addUrl}
+					class="flex-1"
+					onkeydown={(e: KeyboardEvent) => {
+						if (e.key === 'Enter') void addByUrl();
+					}}
+				/>
+				<Button size="sm" onclick={addByUrl} disabled={!addUrl.trim() || busy !== null}>
+					<ImagePlus class="mr-1 h-3.5 w-3.5" />
+					{busy === 'add-url' ? 'Adding…' : 'Add'}
+				</Button>
+			</div>
+			<div class="flex gap-2">
+				<Input
+					placeholder="Search query — Brave + vision-score"
+					bind:value={searchQuery}
+					class="flex-1"
+					onkeydown={(e: KeyboardEvent) => {
+						if (e.key === 'Enter') void searchImages();
+					}}
+				/>
+				<Button size="sm" variant="outline" onclick={searchImages} disabled={!searchQuery.trim() || busy !== null}>
+					<Search class="mr-1 h-3.5 w-3.5" />
+					{busy === 'search' ? 'Searching…' : 'Search'}
+				</Button>
+			</div>
+			<p class="flex items-center gap-1 text-[10px] text-zinc-500">
+				<GripVertical class="h-3 w-3" />
+				Hover a selected image to reorder or remove. Pool entries can be promoted to selected.
+			</p>
+		</div>
+	{/if}
+</div>

--- a/webui/src/lib/hooks/useLivePoll.svelte.ts
+++ b/webui/src/lib/hooks/useLivePoll.svelte.ts
@@ -13,8 +13,16 @@ type State<T> = {
  * Reactive polling hook. Returns $state-wrapped view; call `refresh()` for
  * a manual re-fetch. Starts immediately, polls every `intervalMs` (default
  * 30s), and cleans up its timer when the using component unmounts.
+ *
+ * The path may be a string or a thunk — when passed as a thunk, the $effect
+ * tracks reactive state inside it and re-fetches when that state changes.
  */
-export function useLivePoll<T>(path: string, intervalMs = 30_000): State<T> {
+export function useLivePoll<T>(
+	path: string | (() => string),
+	intervalMs = 30_000
+): State<T> {
+	const resolvePath = typeof path === 'function' ? path : () => path;
+
 	const view = $state<State<T>>({
 		data: null,
 		error: null,
@@ -26,7 +34,7 @@ export function useLivePoll<T>(path: string, intervalMs = 30_000): State<T> {
 	});
 
 	async function run() {
-		const res: ApiResult<T> = await apiFetch<T>(path);
+		const res: ApiResult<T> = await apiFetch<T>(resolvePath());
 		if (res.error) {
 			view.error = res.error.message;
 			view.data = null;
@@ -39,6 +47,8 @@ export function useLivePoll<T>(path: string, intervalMs = 30_000): State<T> {
 	}
 
 	$effect(() => {
+		// Read the path so Svelte tracks any reactive deps the thunk uses.
+		resolvePath();
 		void run();
 		const id = setInterval(run, intervalMs);
 		return () => clearInterval(id);

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -3,11 +3,12 @@
 	import BarChartH from '$lib/components/charts/BarChartH.svelte';
 	import DivergingBars from '$lib/components/charts/DivergingBars.svelte';
 	import Donut from '$lib/components/charts/Donut.svelte';
+	import ActionTile from '$lib/components/home/ActionTile.svelte';
 	import ListTile from '$lib/components/home/ListTile.svelte';
-	import StatTile from '$lib/components/home/StatTile.svelte';
 	import Tile from '$lib/components/home/Tile.svelte';
 	import SpamPingsList from '$lib/components/spam/SpamPingsList.svelte';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
+	import { Inbox, RefreshCw, Send, ShieldAlert, Wallet } from '@lucide/svelte';
 	import type { components } from '$lib/api/types';
 
 	type HomeStats = components['schemas']['HomeStats'];
@@ -20,6 +21,8 @@
 		stats.data?.drafts.reduce((acc, d) => acc + d.count, 0) ?? 0
 	);
 	const sessionCostUsd = $derived(stats.data?.session_cost.total_cost_usd ?? 0);
+	const scheduledCount = $derived(stats.data?.scheduled_next_24h.length ?? 0);
+	const spamCount24h = $derived(stats.data?.spam_pings.count_24h ?? 0);
 
 	function fmtMoney(usd: number): string {
 		return usd < 0.01 ? '<$0.01' : `$${usd.toFixed(2)}`;
@@ -35,7 +38,10 @@
 
 <div class="space-y-6 px-6 py-6">
 	<header class="flex items-baseline justify-between">
-		<h2 class="text-lg font-semibold tracking-tight">Home dashboard</h2>
+		<div>
+			<h2 class="text-lg font-semibold tracking-tight">Dashboard</h2>
+			<p class="mt-0.5 text-xs text-zinc-500">Live operational view of the Konnekt platform.</p>
+		</div>
 		<div class="flex items-center gap-3 text-xs text-zinc-500">
 			{#if stats.error}
 				<span class="text-red-600">Error: {stats.error}</span>
@@ -44,16 +50,62 @@
 			{/if}
 			<button
 				type="button"
-				class="rounded-md border border-zinc-200 px-2 py-1 text-xs font-medium hover:bg-zinc-100"
+				class="flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs font-medium hover:bg-zinc-100"
 				onclick={() => stats.refresh()}
 			>
-				Refresh
+				<RefreshCw class="h-3 w-3" />
+				<span>Refresh</span>
 			</button>
 		</div>
 	</header>
 
-	<div class="grid grid-cols-1 gap-4 md:grid-cols-4 xl:grid-cols-6">
-		<div class="md:col-span-2 xl:col-span-3">
+	<!-- Action bar: what needs attention NOW -->
+	<section class="space-y-2">
+		<div class="text-[10px] font-semibold tracking-wider text-zinc-400 uppercase">
+			Needs your attention
+		</div>
+		<div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+			<ActionTile
+				title="Drafts in review queue"
+				value={totalDrafts}
+				caption={totalDrafts === 0 ? 'No drafts pending' : 'Open the posts queue to review'}
+				icon={Inbox}
+				tone={totalDrafts > 0 ? 'attention' : 'default'}
+				href="/posts?status=sent_for_review"
+				cta={totalDrafts > 0 ? 'Review' : 'View'}
+			/>
+			<ActionTile
+				title="Scheduled in 24h"
+				value={scheduledCount}
+				caption={scheduledCount === 0 ? 'Nothing scheduled' : 'Upcoming publications'}
+				icon={Send}
+				href="/posts?status=scheduled"
+				cta="View"
+			/>
+			<ActionTile
+				title="Spam pings (24h)"
+				value={spamCount24h}
+				caption="Ad detector hits across all chats"
+				icon={ShieldAlert}
+				tone={spamCount24h > 0 ? 'warning' : 'default'}
+				href="/chats"
+			/>
+			<ActionTile
+				title="LLM cost (session)"
+				value={fmtMoney(sessionCostUsd)}
+				caption="Since last bot restart"
+				icon={Wallet}
+				href="/costs"
+			/>
+		</div>
+	</section>
+
+	<!-- Content pipeline -->
+	<section class="space-y-2">
+		<div class="text-[10px] font-semibold tracking-wider text-zinc-400 uppercase">
+			Content pipeline
+		</div>
+		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 			<Tile title="Drafts by channel">
 				<Donut
 					slices={(stats.data?.drafts ?? []).map((d) => ({
@@ -65,34 +117,38 @@
 					empty={stats.loading ? 'loading…' : 'No drafts queued'}
 				/>
 			</Tile>
-		</div>
 
-		<div class="md:col-span-2 xl:col-span-3">
 			<Tile title="Post views (recent)">
 				<BarChartH
 					items={(stats.data?.post_views ?? []).map((p) => ({
 						label: p.title,
 						value: p.views,
-						secondary: p.views === 0 ? 'no data' : p.views.toLocaleString()
+						secondary: p.views === 0 ? 'no data' : p.views.toLocaleString(),
+						href: `/posts/${p.post_id}`
 					}))}
 					empty={stats.loading ? 'loading…' : 'No published posts yet'}
 				/>
 			</Tile>
 		</div>
+	</section>
 
-		<div class="md:col-span-2 xl:col-span-3">
+	<!-- Chats / community -->
+	<section class="space-y-2">
+		<div class="text-[10px] font-semibold tracking-wider text-zinc-400 uppercase">
+			Community
+		</div>
+		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 			<Tile title="Chats heatmap (7d total)">
 				<BarChartH
 					items={(stats.data?.chat_heatmap ?? []).map((c) => ({
 						label: c.title ?? `#${c.chat_id}`,
-						value: c.total_messages
+						value: c.total_messages,
+						href: `/chats/${c.chat_id}`
 					}))}
 					empty={stats.loading ? 'loading…' : 'No activity recorded'}
 				/>
 			</Tile>
-		</div>
 
-		<div class="md:col-span-2 xl:col-span-3">
 			<Tile title="Members Δ (24h)">
 				<DivergingBars
 					items={(stats.data?.members_delta ?? []).map((m) => {
@@ -104,15 +160,22 @@
 						return {
 							label: m.title ?? `#${m.chat_id}`,
 							value: d ?? null,
-							secondary
+							secondary,
+							href: `/chats/${m.chat_id}`
 						};
 					})}
 					empty={stats.loading ? 'loading…' : 'No snapshots yet'}
 				/>
 			</Tile>
 		</div>
+	</section>
 
-		<div class="md:col-span-2 xl:col-span-2">
+	<!-- Side rail: timeline + spam + tree -->
+	<section class="space-y-2">
+		<div class="text-[10px] font-semibold tracking-wider text-zinc-400 uppercase">
+			Recent activity
+		</div>
+		<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
 			<ListTile
 				title="Scheduled next 24h"
 				items={(stats.data?.scheduled_next_24h ?? []).map((p) => ({
@@ -121,37 +184,15 @@
 				}))}
 				empty={stats.loading ? 'loading…' : 'Nothing scheduled'}
 			/>
-		</div>
 
-		<div class="md:col-span-2 xl:col-span-2">
-			<StatTile
-				title="LLM cost (session)"
-				value={fmtMoney(sessionCostUsd)}
-				caption="Since last bot restart"
-			/>
-		</div>
-
-		<div class="md:col-span-2 xl:col-span-2">
-			<Tile title="Spam pings (24h)">
-				<div class="flex items-baseline gap-3">
-					<span class="text-2xl font-semibold tracking-tight text-zinc-900">
-						{stats.data?.spam_pings.count_24h ?? 0}
-					</span>
-					<span class="text-xs text-zinc-500">
-						· {stats.data?.spam_pings.count_7d ?? 0} in 7d
-					</span>
-				</div>
-				<div class="mt-2">
-					<SpamPingsList
-						items={(stats.data?.spam_pings.recent ?? []).slice(0, 3)}
-						empty={stats.loading ? 'loading…' : 'No pings detected.'}
-						showChat
-					/>
-				</div>
+			<Tile title="Recent spam pings">
+				<SpamPingsList
+					items={(stats.data?.spam_pings.recent ?? []).slice(0, 4)}
+					empty={stats.loading ? 'loading…' : 'No pings detected.'}
+					showChat
+				/>
 			</Tile>
-		</div>
 
-		<div class="md:col-span-2 xl:col-span-2">
 			<Tile title="Chat graph">
 				{#if tree.loading}
 					<p class="text-xs text-zinc-500">loading…</p>
@@ -163,11 +204,14 @@
 							<ChatTreeNode node={root} depth={1} />
 						{/each}
 					</ul>
-					<a href="/chats/graph" class="mt-2 inline-block text-xs text-zinc-500 hover:underline">
+					<a
+						href="/chats/graph"
+						class="mt-2 inline-block text-xs text-zinc-500 hover:underline"
+					>
 						View full tree →
 					</a>
 				{/if}
 			</Tile>
 		</div>
-	</div>
+	</section>
 </div>

--- a/webui/src/routes/channels/+page.svelte
+++ b/webui/src/routes/channels/+page.svelte
@@ -5,6 +5,7 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { apiFetch } from '$lib/api/client';
+	import { Plus, Power, Send, Tv } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
 	import type { components } from '$lib/api/types';
 
@@ -18,6 +19,13 @@
 	let formOpen = $state(false);
 	let saving = $state(false);
 	let form = $state({ telegram_id: '', name: '', language: 'ru', description: '' });
+
+	const summary = $derived.by(() => {
+		const total = channels.length;
+		const enabled = channels.filter((c) => c.enabled).length;
+		const totalPostsPerDay = channels.reduce((acc, c) => acc + c.max_posts_per_day, 0);
+		return { total, enabled, totalPostsPerDay };
+	});
 
 	async function load(): Promise<void> {
 		loading = true;
@@ -63,11 +71,41 @@
 
 <div class="space-y-4 px-6 py-6">
 	<header class="flex items-center justify-between">
-		<h2 class="text-lg font-semibold tracking-tight">Channels</h2>
+		<div>
+			<h2 class="text-lg font-semibold tracking-tight">Channels</h2>
+			<p class="mt-0.5 text-xs text-zinc-500">Publishing destinations and content sources.</p>
+		</div>
 		<Button size="sm" onclick={() => (formOpen = !formOpen)}>
+			<Plus class="mr-1 h-3.5 w-3.5" />
 			{formOpen ? 'Cancel' : 'New channel'}
 		</Button>
 	</header>
+
+	{#if !loading && !error}
+		<div class="grid grid-cols-3 gap-3">
+			<div class="flex items-center gap-3 rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+				<Tv class="h-4 w-4 text-zinc-500" />
+				<div class="min-w-0">
+					<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Total</div>
+					<div class="text-lg font-semibold tracking-tight text-zinc-900">{summary.total}</div>
+				</div>
+			</div>
+			<div class="flex items-center gap-3 rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+				<Power class="h-4 w-4 text-emerald-600" />
+				<div class="min-w-0">
+					<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Enabled</div>
+					<div class="text-lg font-semibold tracking-tight text-zinc-900">{summary.enabled}</div>
+				</div>
+			</div>
+			<div class="flex items-center gap-3 rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+				<Send class="h-4 w-4 text-zinc-500" />
+				<div class="min-w-0">
+					<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Posts/day cap</div>
+					<div class="text-lg font-semibold tracking-tight text-zinc-900">{summary.totalPostsPerDay}</div>
+				</div>
+			</div>
+		</div>
+	{/if}
 
 	{#if formOpen}
 		<div class="grid grid-cols-1 gap-3 rounded-md border border-zinc-200 bg-zinc-50 p-4 md:grid-cols-2">

--- a/webui/src/routes/channels/[id]/+page.svelte
+++ b/webui/src/routes/channels/[id]/+page.svelte
@@ -28,7 +28,8 @@
 		max_posts_per_day: 3,
 		footer_template: '',
 		posting_schedule: '',
-		publish_schedule: ''
+		publish_schedule: '',
+		critic_enabled: 'inherit' as 'inherit' | 'on' | 'off'
 	});
 
 	let newSourceUrl = $state('');
@@ -45,7 +46,8 @@
 			max_posts_per_day: c.max_posts_per_day,
 			footer_template: c.footer_template ?? '',
 			posting_schedule: (c.posting_schedule ?? []).join(', '),
-			publish_schedule: (c.publish_schedule ?? []).join(', ')
+			publish_schedule: (c.publish_schedule ?? []).join(', '),
+			critic_enabled: c.critic_enabled === null ? 'inherit' : c.critic_enabled ? 'on' : 'off'
 		};
 	}
 
@@ -78,6 +80,7 @@
 	async function saveEdit(): Promise<void> {
 		if (!channel) return;
 		saving = true;
+		const critic = edit.critic_enabled === 'inherit' ? null : edit.critic_enabled === 'on';
 		const res = await apiFetch<ChannelDetail>(`/api/channels/${channelId}`, {
 			method: 'PATCH',
 			body: JSON.stringify({
@@ -88,7 +91,8 @@
 				max_posts_per_day: edit.max_posts_per_day,
 				footer_template: edit.footer_template || null,
 				posting_schedule: parseSchedule(edit.posting_schedule),
-				publish_schedule: parseSchedule(edit.publish_schedule)
+				publish_schedule: parseSchedule(edit.publish_schedule),
+				critic_enabled: critic
 			})
 		});
 		saving = false;
@@ -220,6 +224,19 @@
 						<label class="block space-y-1">
 							<span class="text-xs text-zinc-600">Publish schedule (comma-separated HH:MM)</span>
 							<Input bind:value={edit.publish_schedule} />
+						</label>
+						<label class="block space-y-1">
+							<span class="text-xs text-zinc-600">
+								Critic pass (post-generation polish)
+							</span>
+							<select
+								bind:value={edit.critic_enabled}
+								class="h-9 w-full rounded-md border border-zinc-200 bg-white px-3 text-sm focus:border-zinc-400 focus:outline-none"
+							>
+								<option value="inherit">inherit (use global setting)</option>
+								<option value="on">on</option>
+								<option value="off">off</option>
+							</select>
 						</label>
 						<div class="flex items-center justify-end gap-2 pt-2">
 							<Button variant="ghost" size="sm" onclick={() => (editing = false)} disabled={saving}>

--- a/webui/src/routes/chats/+page.svelte
+++ b/webui/src/routes/chats/+page.svelte
@@ -3,10 +3,20 @@
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { goto } from '$app/navigation';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
+	import { MessagesSquare, Network, Shield, UserPlus, Users } from '@lucide/svelte';
 	import type { components } from '$lib/api/types';
 
 	type Chat = components['schemas']['ChatRead'];
 	const chats = useLivePoll<Chat[]>('/api/chats', 60_000);
+
+	const summary = $derived.by(() => {
+		const data = chats.data ?? [];
+		const total = data.length;
+		const captchaOn = data.filter((c) => c.is_captcha_enabled).length;
+		const welcomeOn = data.filter((c) => c.is_welcome_enabled).length;
+		const members = data.reduce((acc, c) => acc + (c.member_count ?? 0), 0);
+		return { total, captchaOn, welcomeOn, members };
+	});
 
 	function fmtMembers(n: number | null | undefined): string {
 		return n === null || n === undefined ? '—' : n.toLocaleString();
@@ -19,11 +29,58 @@
 
 <div class="mx-auto max-w-5xl space-y-4 px-6 py-6">
 	<header class="flex items-baseline justify-between">
-		<h2 class="text-lg font-semibold tracking-tight">Chats</h2>
-		{#if chats.lastUpdatedAt}
-			<span class="text-xs text-zinc-500">Updated {chats.lastUpdatedAt.toLocaleTimeString()}</span>
-		{/if}
+		<div>
+			<h2 class="text-lg font-semibold tracking-tight">Chats</h2>
+			<p class="mt-0.5 text-xs text-zinc-500">Managed groups under bot moderation.</p>
+		</div>
+		<div class="flex items-center gap-3 text-xs text-zinc-500">
+			{#if chats.lastUpdatedAt}
+				<span>Updated {chats.lastUpdatedAt.toLocaleTimeString()}</span>
+			{/if}
+			<a
+				href="/chats/graph"
+				class="flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs font-medium hover:bg-zinc-100"
+			>
+				<Network class="h-3 w-3" />
+				<span>Graph view</span>
+			</a>
+		</div>
 	</header>
+
+	{#if !chats.loading && !chats.error}
+		<div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+			<div class="flex items-center gap-3 rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+				<MessagesSquare class="h-4 w-4 text-zinc-500" />
+				<div class="min-w-0">
+					<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Chats</div>
+					<div class="text-lg font-semibold tracking-tight text-zinc-900">{summary.total}</div>
+				</div>
+			</div>
+			<div class="flex items-center gap-3 rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+				<Users class="h-4 w-4 text-zinc-500" />
+				<div class="min-w-0">
+					<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Members</div>
+					<div class="text-lg font-semibold tracking-tight text-zinc-900">
+						{summary.members.toLocaleString()}
+					</div>
+				</div>
+			</div>
+			<div class="flex items-center gap-3 rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+				<Shield class="h-4 w-4 text-zinc-500" />
+				<div class="min-w-0">
+					<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Captcha on</div>
+					<div class="text-lg font-semibold tracking-tight text-zinc-900">{summary.captchaOn}</div>
+				</div>
+			</div>
+			<div class="flex items-center gap-3 rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+				<UserPlus class="h-4 w-4 text-zinc-500" />
+				<div class="min-w-0">
+					<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Welcome on</div>
+					<div class="text-lg font-semibold tracking-tight text-zinc-900">{summary.welcomeOn}</div>
+				</div>
+			</div>
+		</div>
+	{/if}
 
 	<Card.Root>
 		<Card.Content class="pt-6">

--- a/webui/src/routes/chats/[id]/+page.svelte
+++ b/webui/src/routes/chats/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import HeatmapGrid from '$lib/components/chat/HeatmapGrid.svelte';
 	import Sparkline from '$lib/components/charts/Sparkline.svelte';
 	import SpamPingsList from '$lib/components/spam/SpamPingsList.svelte';
@@ -12,12 +13,57 @@
 	import type { components } from '$lib/api/types';
 
 	type ChatDetail = components['schemas']['ChatDetail'];
+	type ChatRead = components['schemas']['ChatRead'];
 	type UserBlockResponse = components['schemas']['UserBlockResponse'];
 
 	const chatId = page.params.id;
 	const detail = useLivePoll<ChatDetail>(`/api/chats/${chatId}`, 60_000);
 
 	let busyUserId = $state<number | null>(null);
+	let editing = $state(false);
+	let saving = $state(false);
+	let edit = $state({
+		title: '',
+		welcome_message: '',
+		is_welcome_enabled: false,
+		is_captcha_enabled: false,
+		time_delete: 60
+	});
+
+	function snapshotEdit(d: ChatDetail): void {
+		edit = {
+			title: d.title ?? '',
+			welcome_message: d.welcome_message ?? '',
+			is_welcome_enabled: d.is_welcome_enabled,
+			is_captcha_enabled: d.is_captcha_enabled,
+			time_delete: d.time_delete
+		};
+	}
+
+	$effect(() => {
+		if (detail.data && !editing) snapshotEdit(detail.data);
+	});
+
+	async function saveEdit(): Promise<void> {
+		saving = true;
+		const res = await apiFetch<ChatRead>(`/api/chats/${chatId}`, {
+			method: 'PATCH',
+			body: JSON.stringify({
+				title: edit.title || null,
+				welcome_message: edit.welcome_message || null,
+				is_welcome_enabled: edit.is_welcome_enabled,
+				is_captcha_enabled: edit.is_captcha_enabled,
+				time_delete: edit.time_delete
+			})
+		});
+		saving = false;
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success('Moderation settings saved');
+			editing = false;
+			await detail.refresh();
+		}
+	}
 
 	function senderLabel(s: components['schemas']['ChatSender']): string {
 		if (s.username) return `@${s.username}`;
@@ -70,12 +116,63 @@
 		<p class="text-sm text-red-600">Error: {detail.error}</p>
 	{:else if detail.data}
 		<Card.Root>
-			<Card.Header><Card.Title class="text-sm">Overview</Card.Title></Card.Header>
-			<Card.Content class="grid grid-cols-2 gap-2 text-sm">
-				<div>Members: <strong>{detail.data.member_count ?? '—'}</strong></div>
-				<div>Forum: {detail.data.is_forum ? 'yes' : 'no'}</div>
-				<div>Captcha: {detail.data.is_captcha_enabled ? 'on' : 'off'}</div>
-				<div>Welcome: {detail.data.is_welcome_enabled ? 'on' : 'off'}</div>
+			<Card.Header class="flex flex-row items-center justify-between">
+				<Card.Title class="text-sm">Overview & moderation</Card.Title>
+				<Button
+					variant="outline"
+					size="sm"
+					onclick={() => (editing = !editing)}
+					disabled={saving}
+				>
+					{editing ? 'Cancel' : 'Edit'}
+				</Button>
+			</Card.Header>
+			<Card.Content class="space-y-3 text-sm">
+				{#if editing}
+					<label class="block space-y-1">
+						<span class="text-xs text-zinc-600">Title</span>
+						<Input bind:value={edit.title} />
+					</label>
+					<div class="grid grid-cols-2 gap-2">
+						<label class="flex items-center gap-2 text-xs">
+							<input type="checkbox" bind:checked={edit.is_welcome_enabled} />
+							<span>Welcome message enabled</span>
+						</label>
+						<label class="flex items-center gap-2 text-xs">
+							<input type="checkbox" bind:checked={edit.is_captcha_enabled} />
+							<span>Captcha enabled</span>
+						</label>
+					</div>
+					<label class="block space-y-1">
+						<span class="text-xs text-zinc-600">Welcome message text</span>
+						<Input bind:value={edit.welcome_message} placeholder="Welcome to the chat!" />
+					</label>
+					<label class="block space-y-1">
+						<span class="text-xs text-zinc-600">Auto-delete bot messages after (seconds)</span>
+						<Input type="number" bind:value={edit.time_delete} min="1" />
+					</label>
+					<div class="flex items-center justify-end gap-2 pt-1">
+						<Button variant="ghost" size="sm" onclick={() => (editing = false)} disabled={saving}>
+							Cancel
+						</Button>
+						<Button size="sm" onclick={saveEdit} disabled={saving}>
+							{saving ? 'Saving…' : 'Save'}
+						</Button>
+					</div>
+				{:else}
+					<div class="grid grid-cols-2 gap-2">
+						<div>Members: <strong>{detail.data.member_count ?? '—'}</strong></div>
+						<div>Forum: {detail.data.is_forum ? 'yes' : 'no'}</div>
+						<div>Captcha: {detail.data.is_captcha_enabled ? 'on' : 'off'}</div>
+						<div>Welcome: {detail.data.is_welcome_enabled ? 'on' : 'off'}</div>
+						<div>Auto-delete: {detail.data.time_delete}s</div>
+					</div>
+					{#if detail.data.welcome_message}
+						<div class="rounded-md border border-zinc-100 bg-zinc-50 p-2 text-xs text-zinc-600">
+							<span class="text-zinc-400">Welcome:</span> {detail.data.welcome_message}
+						</div>
+					{/if}
+				{/if}
 			</Card.Content>
 		</Card.Root>
 

--- a/webui/src/routes/costs/+page.svelte
+++ b/webui/src/routes/costs/+page.svelte
@@ -1,32 +1,106 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
+	import Sparkline from '$lib/components/charts/Sparkline.svelte';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
 	import type { components } from '$lib/api/types';
 
 	type Summary = components['schemas']['SessionCostSummary'];
+	type History = components['schemas']['CostHistoryResponse'];
+
+	let days = $state<number>(30);
 
 	const cost = useLivePoll<Summary>('/api/costs/session', 60_000);
+	const history = useLivePoll<History>(() => `/api/costs/history?days=${days}`, 120_000);
 
 	function fmt(usd: number): string {
 		return usd < 0.01 ? '<$0.01' : `$${usd.toFixed(4)}`;
 	}
+
+	function fmtCompact(usd: number): string {
+		if (usd === 0) return '$0';
+		if (usd < 0.01) return '<$0.01';
+		return `$${usd.toFixed(2)}`;
+	}
+
+	const sparkValues = $derived(history.data?.series.map((d) => d.cost_usd) ?? []);
+	const maxDay = $derived.by(() => {
+		const series = history.data?.series ?? [];
+		if (series.length === 0) return null;
+		return series.reduce((a, b) => (a.cost_usd > b.cost_usd ? a : b));
+	});
 </script>
 
-<div class="mx-auto max-w-4xl space-y-4 px-6 py-6">
+<div class="mx-auto max-w-5xl space-y-4 px-6 py-6">
 	<header class="flex items-baseline justify-between">
-		<h2 class="text-lg font-semibold tracking-tight">Costs</h2>
+		<div>
+			<h2 class="text-lg font-semibold tracking-tight">Costs</h2>
+			<p class="mt-0.5 text-xs text-zinc-500">Session-level + persistent daily cost history.</p>
+		</div>
 		{#if cost.lastUpdatedAt}
 			<span class="text-xs text-zinc-500">Updated {cost.lastUpdatedAt.toLocaleTimeString()}</span>
 		{/if}
 	</header>
 
 	<Card.Root>
+		<Card.Header class="flex flex-row items-center justify-between space-y-0">
+			<Card.Title class="text-sm">
+				Daily cost
+				<span class="ml-1 text-xs font-normal text-zinc-500">last {days} days</span>
+			</Card.Title>
+			<select
+				bind:value={days}
+				class="rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs"
+				onchange={() => history.refresh()}
+			>
+				<option value={7}>7 days</option>
+				<option value={14}>14 days</option>
+				<option value={30}>30 days</option>
+				<option value={90}>90 days</option>
+			</select>
+		</Card.Header>
+		<Card.Content class="space-y-3 text-sm">
+			{#if history.loading}
+				<p class="text-zinc-500">Loading…</p>
+			{:else if history.error}
+				<p class="text-red-600">Error: {history.error}</p>
+			{:else if history.data}
+				{@const total = history.data.total_cost_usd}
+				<div class="grid grid-cols-3 gap-4 text-xs">
+					<div>
+						<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Total</div>
+						<div class="text-xl font-semibold text-zinc-900">{fmt(total)}</div>
+					</div>
+					<div>
+						<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Calls</div>
+						<div class="text-xl font-semibold text-zinc-900">{history.data.total_calls.toLocaleString()}</div>
+					</div>
+					<div>
+						<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Avg / day</div>
+						<div class="text-xl font-semibold text-zinc-900">{fmt(total / Math.max(1, days))}</div>
+					</div>
+				</div>
+				{#if sparkValues.length > 0 && total > 0}
+					<Sparkline values={sparkValues} />
+					{#if maxDay && maxDay.cost_usd > 0}
+						<p class="text-xs text-zinc-500">
+							Peak: <strong>{fmtCompact(maxDay.cost_usd)}</strong> on {maxDay.day} ·
+							{maxDay.calls} calls
+						</p>
+					{/if}
+				{:else}
+					<p class="text-xs text-zinc-500">
+						No persisted events yet. New LLM calls will appear here.
+					</p>
+				{/if}
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
 		<Card.Header>
 			<Card.Title class="text-sm">Session summary</Card.Title>
-			<p class="text-xs text-zinc-500">
-				In-memory aggregation from <code>cost_tracker</code>. Resets on bot restart — persistent history is Phase 1.5.
-			</p>
+			<p class="text-xs text-zinc-500">In-memory aggregation. Resets on bot restart.</p>
 		</Card.Header>
 		<Card.Content class="space-y-1 text-sm">
 			{#if cost.loading}

--- a/webui/src/routes/costs/+page.svelte
+++ b/webui/src/routes/costs/+page.svelte
@@ -44,35 +44,65 @@
 		</Card.Content>
 	</Card.Root>
 
-	<Card.Root>
-		<Card.Header><Card.Title class="text-sm">Breakdown by operation</Card.Title></Card.Header>
-		<Card.Content>
-			{#if !cost.data || cost.data.by_operation.length === 0}
-				<p class="text-sm text-zinc-500">No usage yet this session.</p>
-			{:else}
-				<Table.Root>
-					<Table.Header>
-						<Table.Row>
-							<Table.Head>Operation</Table.Head>
-							<Table.Head class="w-24">Calls</Table.Head>
-							<Table.Head class="w-32">Tokens</Table.Head>
-							<Table.Head class="w-32">Cost</Table.Head>
-							<Table.Head class="w-32">Cache savings</Table.Head>
-						</Table.Row>
-					</Table.Header>
-					<Table.Body>
-						{#each cost.data.by_operation as b (b.operation)}
+	<div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+		<Card.Root>
+			<Card.Header><Card.Title class="text-sm">Breakdown by operation</Card.Title></Card.Header>
+			<Card.Content>
+				{#if !cost.data || cost.data.by_operation.length === 0}
+					<p class="text-sm text-zinc-500">No usage yet this session.</p>
+				{:else}
+					<Table.Root>
+						<Table.Header>
 							<Table.Row>
-								<Table.Cell class="font-mono text-xs">{b.operation}</Table.Cell>
-								<Table.Cell>{b.calls}</Table.Cell>
-								<Table.Cell>{b.tokens.toLocaleString()}</Table.Cell>
-								<Table.Cell>{fmt(b.cost_usd)}</Table.Cell>
-								<Table.Cell>{fmt(b.cache_savings_usd)}</Table.Cell>
+								<Table.Head>Operation</Table.Head>
+								<Table.Head class="w-16">Calls</Table.Head>
+								<Table.Head class="w-24">Tokens</Table.Head>
+								<Table.Head class="w-24">Cost</Table.Head>
 							</Table.Row>
-						{/each}
-					</Table.Body>
-				</Table.Root>
-			{/if}
-		</Card.Content>
-	</Card.Root>
+						</Table.Header>
+						<Table.Body>
+							{#each [...cost.data.by_operation].sort((a, b) => b.cost_usd - a.cost_usd) as b (b.operation)}
+								<Table.Row>
+									<Table.Cell class="font-mono text-xs">{b.operation}</Table.Cell>
+									<Table.Cell>{b.calls}</Table.Cell>
+									<Table.Cell>{b.tokens.toLocaleString()}</Table.Cell>
+									<Table.Cell>{fmt(b.cost_usd)}</Table.Cell>
+								</Table.Row>
+							{/each}
+						</Table.Body>
+					</Table.Root>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root>
+			<Card.Header><Card.Title class="text-sm">Breakdown by model</Card.Title></Card.Header>
+			<Card.Content>
+				{#if !cost.data || cost.data.by_model.length === 0}
+					<p class="text-sm text-zinc-500">No usage yet this session.</p>
+				{:else}
+					<Table.Root>
+						<Table.Header>
+							<Table.Row>
+								<Table.Head>Model</Table.Head>
+								<Table.Head class="w-16">Calls</Table.Head>
+								<Table.Head class="w-24">Tokens</Table.Head>
+								<Table.Head class="w-24">Cost</Table.Head>
+							</Table.Row>
+						</Table.Header>
+						<Table.Body>
+							{#each [...cost.data.by_model].sort((a, b) => b.cost_usd - a.cost_usd) as b (b.model)}
+								<Table.Row>
+									<Table.Cell class="font-mono text-xs">{b.model}</Table.Cell>
+									<Table.Cell>{b.calls}</Table.Cell>
+									<Table.Cell>{b.tokens.toLocaleString()}</Table.Cell>
+									<Table.Cell>{fmt(b.cost_usd)}</Table.Cell>
+								</Table.Row>
+							{/each}
+						</Table.Body>
+					</Table.Root>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+	</div>
 </div>

--- a/webui/src/routes/posts/+page.svelte
+++ b/webui/src/routes/posts/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
@@ -6,14 +8,21 @@
 	import type { components } from '$lib/api/types';
 
 	type Post = components['schemas']['PostRead'];
+	type Channel = components['schemas']['ChannelRead'];
 
-	let status = $state<string>('');
-	let channelId = $state<string>('');
+	let status = $state<string>(page.url.searchParams.get('status') ?? '');
+	let channelId = $state<string>(page.url.searchParams.get('channel_id') ?? '');
 	let posts = $state<Post[]>([]);
+	let channels = $state<Channel[]>([]);
 	let loading = $state(false);
 	let error = $state<string | null>(null);
 
-	async function load() {
+	async function loadChannels(): Promise<void> {
+		const res = await apiFetch<Channel[]>('/api/channels');
+		if (!res.error) channels = res.data;
+	}
+
+	async function load(): Promise<void> {
 		loading = true;
 		error = null;
 		const params = new URLSearchParams({ limit: '100' });
@@ -29,35 +38,141 @@
 		loading = false;
 	}
 
+	function syncUrl(): void {
+		const params = new URLSearchParams();
+		if (status) params.set('status', status);
+		if (channelId) params.set('channel_id', channelId);
+		const qs = params.toString();
+		const target = qs ? `/posts?${qs}` : '/posts';
+		void goto(target, { replaceState: true, noScroll: true, keepFocus: true });
+	}
+
+	function updateStatus(value: string): void {
+		status = value;
+		syncUrl();
+		void load();
+	}
+
+	function updateChannel(value: string): void {
+		channelId = value;
+		syncUrl();
+		void load();
+	}
+
 	$effect(() => {
+		void loadChannels();
 		void load();
 	});
 
-	const STATUSES = ['draft', 'sent_for_review', 'approved', 'scheduled', 'published', 'rejected', 'failed', 'deleted'];
+	const STATUSES = [
+		'draft',
+		'sent_for_review',
+		'approved',
+		'scheduled',
+		'published',
+		'rejected',
+		'failed',
+		'deleted'
+	];
+
+	const counts = $derived.by(() => {
+		const m: Record<string, number> = {};
+		for (const p of posts) m[p.status] = (m[p.status] ?? 0) + 1;
+		return m;
+	});
+
+	const STATUS_COLOR: Record<string, string> = {
+		draft: 'bg-zinc-100 text-zinc-700',
+		sent_for_review: 'bg-amber-100 text-amber-800',
+		approved: 'bg-blue-100 text-blue-800',
+		scheduled: 'bg-indigo-100 text-indigo-800',
+		published: 'bg-emerald-100 text-emerald-800',
+		rejected: 'bg-rose-100 text-rose-800',
+		failed: 'bg-rose-100 text-rose-800',
+		deleted: 'bg-zinc-100 text-zinc-500'
+	};
+
+	const QUICK_FILTERS = [
+		{ label: 'All', value: '' },
+		{ label: 'In review', value: 'sent_for_review' },
+		{ label: 'Scheduled', value: 'scheduled' },
+		{ label: 'Published', value: 'published' }
+	];
+
+	const channelById = $derived.by(() => {
+		const m = new Map<number, Channel>();
+		for (const c of channels) m.set(c.id, c);
+		return m;
+	});
 </script>
 
 <div class="space-y-4 px-6 py-6">
-	<header class="flex items-center justify-between">
-		<h2 class="text-lg font-semibold tracking-tight">Posts</h2>
-		<div class="flex items-center gap-2">
+	<header class="flex flex-wrap items-center justify-between gap-3">
+		<div>
+			<h2 class="text-lg font-semibold tracking-tight">Posts</h2>
+			<p class="mt-0.5 text-xs text-zinc-500">
+				{posts.length} loaded · filter by status or channel to drill in.
+			</p>
+		</div>
+		<div class="flex flex-wrap items-center gap-2">
 			<select
-				bind:value={status}
+				value={status}
 				class="rounded-md border border-zinc-200 bg-white px-2 py-1 text-sm"
-				onchange={() => load()}
+				onchange={(e) => updateStatus((e.currentTarget as HTMLSelectElement).value)}
 			>
 				<option value="">all statuses</option>
 				{#each STATUSES as s (s)}<option value={s}>{s}</option>{/each}
 			</select>
+			<select
+				value={channelId}
+				class="rounded-md border border-zinc-200 bg-white px-2 py-1 text-sm"
+				onchange={(e) => updateChannel((e.currentTarget as HTMLSelectElement).value)}
+			>
+				<option value="">all channels</option>
+				{#each channels as c (c.id)}
+					<option value={String(c.id)}>{c.name}</option>
+				{/each}
+			</select>
 			<Input
-				placeholder="channel_id"
+				placeholder="custom channel id"
 				bind:value={channelId}
 				class="w-40"
 				onkeydown={(e: KeyboardEvent) => {
-					if (e.key === 'Enter') load();
+					if (e.key === 'Enter') {
+						syncUrl();
+						void load();
+					}
 				}}
 			/>
 		</div>
 	</header>
+
+	<!-- Quick filter pills + counts -->
+	<div class="flex flex-wrap items-center gap-1.5">
+		{#each QUICK_FILTERS as f (f.value)}
+			{@const active = status === f.value}
+			<button
+				type="button"
+				onclick={() => updateStatus(f.value)}
+				class="rounded-full px-3 py-1 text-xs font-medium transition-colors {active
+					? 'bg-zinc-900 text-white'
+					: 'bg-zinc-100 text-zinc-700 hover:bg-zinc-200'}"
+			>
+				{f.label}
+			</button>
+		{/each}
+		<span class="ml-2 text-xs text-zinc-400">
+			|
+			{#each STATUSES as s (s)}
+				{#if counts[s]}
+					<span class="ml-2 inline-flex items-center gap-1">
+						<span class="h-1.5 w-1.5 rounded-full {STATUS_COLOR[s] ?? 'bg-zinc-300'}"></span>
+						<span class="text-zinc-500">{s}: {counts[s]}</span>
+					</span>
+				{/if}
+			{/each}
+		</span>
+	</div>
 
 	{#if loading}
 		<p class="text-sm text-zinc-500">Loading…</p>
@@ -70,21 +185,32 @@
 			<Table.Header>
 				<Table.Row>
 					<Table.Head class="w-16">ID</Table.Head>
-					<Table.Head class="w-32">Status</Table.Head>
+					<Table.Head class="w-36">Status</Table.Head>
 					<Table.Head>Title</Table.Head>
-					<Table.Head class="w-32">Channel</Table.Head>
+					<Table.Head class="w-44">Channel</Table.Head>
 					<Table.Head class="w-40">Created</Table.Head>
 				</Table.Row>
 			</Table.Header>
 			<Table.Body>
 				{#each posts as p (p.id)}
+					{@const ch = channelById.get(p.channel_id)}
 					<Table.Row>
 						<Table.Cell class="text-zinc-500">{p.id}</Table.Cell>
-						<Table.Cell><Badge variant="secondary">{p.status}</Badge></Table.Cell>
+						<Table.Cell>
+							<span class="rounded-md px-2 py-0.5 text-xs font-medium {STATUS_COLOR[p.status] ?? 'bg-zinc-100 text-zinc-700'}">
+								{p.status}
+							</span>
+						</Table.Cell>
 						<Table.Cell class="truncate">
 							<a class="text-zinc-900 hover:underline" href={`/posts/${p.id}`}>{p.title}</a>
 						</Table.Cell>
-						<Table.Cell class="font-mono text-xs text-zinc-600">{p.channel_id}</Table.Cell>
+						<Table.Cell class="text-xs">
+							{#if ch}
+								<a href={`/channels/${ch.id}`} class="text-zinc-700 hover:underline">{ch.name}</a>
+							{:else}
+								<span class="font-mono text-zinc-500">{p.channel_id}</span>
+							{/if}
+						</Table.Cell>
 						<Table.Cell class="text-xs text-zinc-500">
 							{new Date(p.created_at).toLocaleString()}
 						</Table.Cell>

--- a/webui/src/routes/posts/[id]/+page.svelte
+++ b/webui/src/routes/posts/[id]/+page.svelte
@@ -3,19 +3,23 @@
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
+	import ImagePool from '$lib/components/posts/ImagePool.svelte';
 	import { apiFetch } from '$lib/api/client';
+	import { Check, Pencil, RefreshCw, Sparkles, X } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
 	import type { components } from '$lib/api/types';
 
 	type PostDetail = components['schemas']['PostDetail'];
 	type PostMutationResponse = components['schemas']['PostMutationResponse'];
+	type ImageMutationResponse = components['schemas']['ImageMutationResponse'];
 
 	let post = $state<PostDetail | null>(null);
 	let error = $state<string | null>(null);
 	let loading = $state(true);
-	let busy = $state<'approve' | 'reject' | 'save' | null>(null);
+	let busy = $state<'approve' | 'reject' | 'save' | 'regen' | null>(null);
 	let editing = $state(false);
 	let draft = $state('');
+	let showPreCritic = $state(false);
 
 	const postId = $derived(page.params.id);
 
@@ -78,14 +82,45 @@
 		}
 	}
 
+	async function regenerate(): Promise<void> {
+		if (busy) return;
+		if (!confirm('Regenerate this post from its source items? Current text and images will be replaced.')) return;
+		busy = 'regen';
+		const res = await apiFetch<PostMutationResponse>(`/api/posts/${postId}/regenerate`, {
+			method: 'POST'
+		});
+		busy = null;
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success(res.data.message);
+			await load();
+		}
+	}
+
 	function cancelEdit(): void {
 		draft = post?.post_text ?? '';
 		editing = false;
 	}
 
+	function applyImageMutation(resp: ImageMutationResponse): void {
+		if (!post) return;
+		post = { ...post, image_urls: resp.image_urls, image_candidates: resp.image_candidates };
+	}
+
 	const canMutate = $derived(
-		post && !['approved', 'rejected', 'skipped'].includes(post.status.toLowerCase())
+		post && !['approved', 'rejected', 'skipped', 'published'].includes(post.status.toLowerCase())
 	);
+
+	const STATUS_TONE: Record<string, string> = {
+		draft: 'bg-zinc-100 text-zinc-700',
+		sent_for_review: 'bg-amber-100 text-amber-800',
+		approved: 'bg-blue-100 text-blue-800',
+		scheduled: 'bg-indigo-100 text-indigo-800',
+		published: 'bg-emerald-100 text-emerald-800',
+		rejected: 'bg-rose-100 text-rose-800',
+		failed: 'bg-rose-100 text-rose-800',
+		deleted: 'bg-zinc-100 text-zinc-500'
+	};
 </script>
 
 <div class="mx-auto max-w-3xl space-y-4 px-6 py-6">
@@ -103,7 +138,12 @@
 				</div>
 				<h2 class="mt-1 text-xl font-semibold tracking-tight">{post.title}</h2>
 				<div class="mt-2 flex items-center gap-2">
-					<Badge variant="secondary">{post.status}</Badge>
+					<span
+						class="rounded-md px-2 py-0.5 text-xs font-medium {STATUS_TONE[post.status] ??
+							'bg-zinc-100 text-zinc-700'}"
+					>
+						{post.status}
+					</span>
 					{#if post.source_url}
 						<a
 							href={post.source_url}
@@ -114,13 +154,14 @@
 					{/if}
 				</div>
 			</div>
-			<div class="flex shrink-0 items-center gap-2">
+			<div class="flex shrink-0 flex-wrap items-center gap-2 justify-end">
 				<Button
 					variant="default"
 					size="sm"
 					onclick={approve}
 					disabled={!canMutate || busy !== null}
 				>
+					<Check class="mr-1 h-3.5 w-3.5" />
 					{busy === 'approve' ? 'Publishing…' : 'Approve'}
 				</Button>
 				<Button
@@ -129,6 +170,7 @@
 					onclick={reject}
 					disabled={!canMutate || busy !== null}
 				>
+					<X class="mr-1 h-3.5 w-3.5" />
 					{busy === 'reject' ? 'Rejecting…' : 'Reject'}
 				</Button>
 				<Button
@@ -137,7 +179,18 @@
 					onclick={() => (editing = !editing)}
 					disabled={!canMutate || busy !== null}
 				>
+					<Pencil class="mr-1 h-3.5 w-3.5" />
 					{editing ? 'Cancel edit' : 'Edit'}
+				</Button>
+				<Button
+					variant="outline"
+					size="sm"
+					onclick={regenerate}
+					disabled={!canMutate || busy !== null}
+					title="Re-run generator over the post's source items"
+				>
+					<RefreshCw class="mr-1 h-3.5 w-3.5" />
+					{busy === 'regen' ? 'Regenerating…' : 'Regenerate'}
 				</Button>
 			</div>
 		</header>
@@ -152,9 +205,9 @@
 						disabled={busy === 'save'}
 					></textarea>
 					<div class="mt-2 flex items-center justify-end gap-2">
-						<Button variant="ghost" size="sm" onclick={cancelEdit} disabled={busy === 'save'}
-							>Cancel</Button
-						>
+						<Button variant="ghost" size="sm" onclick={cancelEdit} disabled={busy === 'save'}>
+							Cancel
+						</Button>
 						<Button size="sm" onclick={save} disabled={busy === 'save' || !draft.trim()}>
 							{busy === 'save' ? 'Saving…' : 'Save'}
 						</Button>
@@ -166,15 +219,76 @@
 			</Card.Content>
 		</Card.Root>
 
-		{#if post.image_urls && post.image_urls.length > 0}
+		{#if post.pre_critic_text && post.pre_critic_text !== post.post_text}
 			<Card.Root>
-				<Card.Header><Card.Title>Images ({post.image_urls.length})</Card.Title></Card.Header>
+				<Card.Header class="flex flex-row items-center justify-between space-y-0">
+					<Card.Title class="flex items-center gap-1.5 text-sm">
+						<Sparkles class="h-3.5 w-3.5 text-amber-600" />
+						Pre-critic version
+					</Card.Title>
+					<Button variant="ghost" size="sm" onclick={() => (showPreCritic = !showPreCritic)}>
+						{showPreCritic ? 'Hide' : 'Show'}
+					</Button>
+				</Card.Header>
+				{#if showPreCritic}
+					<Card.Content>
+						<p class="mb-2 text-xs text-zinc-500">
+							Generator output before the polish pass — useful when the critic over-rewrites.
+						</p>
+						<pre
+							class="font-sans text-sm leading-6 text-zinc-700 whitespace-pre-wrap">{post.pre_critic_text}</pre>
+					</Card.Content>
+				{/if}
+			</Card.Root>
+		{/if}
+
+		<Card.Root>
+			<Card.Header>
+				<Card.Title class="text-sm">
+					Images
+					<span class="ml-1 text-xs font-normal text-zinc-500">
+						{(post.image_urls ?? []).length} selected · {(post.image_candidates ?? []).length} in pool
+					</span>
+				</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<ImagePool
+					postId={post.id}
+					selected={post.image_urls ?? []}
+					pool={post.image_candidates ?? []}
+					canEdit={canMutate ?? false}
+					onChange={applyImageMutation}
+				/>
+			</Card.Content>
+		</Card.Root>
+
+		{#if post.source_items && post.source_items.length > 0}
+			<Card.Root>
+				<Card.Header>
+					<Card.Title class="text-sm">
+						Source items
+						<span class="ml-1 text-xs font-normal text-zinc-500">
+							({post.source_items.length})
+						</span>
+					</Card.Title>
+				</Card.Header>
 				<Card.Content>
-					<div class="grid grid-cols-2 gap-3 md:grid-cols-3">
-						{#each post.image_urls as url (url)}
-							<img src={url} alt="" class="h-32 w-full rounded-md object-cover" loading="lazy" />
+					<ul class="space-y-1.5 text-xs">
+						{#each post.source_items as src, i (i)}
+							{@const url = typeof src.url === 'string' ? src.url : null}
+							{@const title = typeof src.title === 'string' ? src.title : null}
+							<li class="flex items-baseline gap-2">
+								<Badge variant="secondary" class="shrink-0 text-[10px]">{i + 1}</Badge>
+								{#if url}
+									<a href={url} target="_blank" rel="noreferrer" class="truncate text-blue-600 hover:underline">
+										{title ?? url}
+									</a>
+								{:else}
+									<span class="truncate text-zinc-700">{title ?? '(untitled)'}</span>
+								{/if}
+							</li>
 						{/each}
-					</div>
+					</ul>
 				</Card.Content>
 			</Card.Root>
 		{/if}

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -1,5 +1,177 @@
 <script lang="ts">
-	import ComingSoon from '$lib/components/ComingSoon.svelte';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { apiFetch } from '$lib/api/client';
+	import { auth } from '$lib/stores/auth.svelte';
+	import { toast } from 'svelte-sonner';
+	import type { components } from '$lib/api/types';
+
+	type AdminSessionRead = components['schemas']['AdminSessionRead'];
+	type SystemStatus = components['schemas']['SystemStatus'];
+
+	let sessions = $state<AdminSessionRead[] | null>(null);
+	let system = $state<SystemStatus | null>(null);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let revoking = $state<string | null>(null);
+
+	async function load(): Promise<void> {
+		loading = true;
+		const [s, sys] = await Promise.all([
+			apiFetch<AdminSessionRead[]>('/api/admin/sessions'),
+			apiFetch<SystemStatus>('/api/admin/system')
+		]);
+		if (s.error) error = s.error.message;
+		else sessions = s.data;
+		if (sys.error) error = sys.error.message;
+		else system = sys.data;
+		loading = false;
+	}
+
+	$effect(() => {
+		void load();
+	});
+
+	async function revokeSession(id: string): Promise<void> {
+		if (!confirm('Revoke this session? The other browser will be signed out.')) return;
+		revoking = id;
+		const res = await apiFetch(`/api/admin/sessions/${id}`, { method: 'DELETE' });
+		revoking = null;
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success('Session revoked');
+			await load();
+		}
+	}
+
+	function formatRelative(iso: string): string {
+		const d = new Date(iso);
+		const diffMs = Date.now() - d.getTime();
+		const diffMin = Math.round(diffMs / 60_000);
+		if (diffMin < 1) return 'just now';
+		if (diffMin < 60) return `${diffMin}m ago`;
+		const diffH = Math.round(diffMin / 60);
+		if (diffH < 24) return `${diffH}h ago`;
+		const diffD = Math.round(diffH / 24);
+		return `${diffD}d ago`;
+	}
+
+	function shortenAgent(ua: string | null): string {
+		if (!ua) return '—';
+		// Pull a recognizable slice — browser name + maybe OS hint.
+		const browserMatch = ua.match(/(Firefox|Chrome|Safari|Edg|Opera)\/[\d.]+/);
+		const osMatch = ua.match(/(Windows NT [\d.]+|Mac OS X [\d_.]+|Linux|Android|iOS|iPhone|iPad)/);
+		const parts = [browserMatch?.[0], osMatch?.[0]].filter(Boolean);
+		return parts.length ? parts.join(' · ') : ua.slice(0, 60);
+	}
 </script>
 
-<ComingSoon title="Settings" phase={4} />
+<div class="mx-auto max-w-4xl space-y-4 px-6 py-6">
+	<header>
+		<h2 class="text-lg font-semibold tracking-tight">Settings</h2>
+		<p class="mt-1 text-sm text-zinc-500">Operational status and active session management.</p>
+	</header>
+
+	{#if loading}
+		<p class="text-sm text-zinc-500">Loading…</p>
+	{:else if error}
+		<p class="text-sm text-red-600">Error: {error}</p>
+	{:else}
+		<Card.Root>
+			<Card.Header><Card.Title class="text-sm">Identity</Card.Title></Card.Header>
+			<Card.Content class="text-sm">
+				{#if auth.me}
+					Signed in as user <span class="font-mono">#{auth.me.user_id}</span>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root>
+			<Card.Header>
+				<Card.Title class="text-sm">
+					Active sessions
+					{#if sessions}
+						<span class="ml-1 text-xs font-normal text-zinc-500">({sessions.length})</span>
+					{/if}
+				</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				{#if !sessions || sessions.length === 0}
+					<p class="text-xs text-zinc-500">No active sessions.</p>
+				{:else}
+					<ul class="divide-y divide-zinc-100 text-sm">
+						{#each sessions as s (s.session_id)}
+							<li class="flex items-center justify-between gap-2 py-2">
+								<div class="flex min-w-0 flex-col">
+									<div class="flex items-baseline gap-2">
+										<span class="text-zinc-800">{shortenAgent(s.user_agent)}</span>
+										{#if s.is_current}<Badge class="text-[10px]">this session</Badge>{/if}
+									</div>
+									<div class="text-xs text-zinc-500">
+										{s.ip ?? '—'} · last seen {formatRelative(s.last_seen_at)} · expires
+										{new Date(s.expires_at).toLocaleDateString()}
+									</div>
+								</div>
+								{#if !s.is_current}
+									<Button
+										variant="ghost"
+										size="sm"
+										class="text-red-600 hover:bg-red-50 hover:text-red-700"
+										onclick={() => revokeSession(s.session_id)}
+										disabled={revoking === s.session_id}
+									>
+										{revoking === s.session_id ? '…' : 'Revoke'}
+									</Button>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+
+		{#if system}
+			<Card.Root>
+				<Card.Header><Card.Title class="text-sm">System</Card.Title></Card.Header>
+				<Card.Content class="grid grid-cols-2 gap-2 text-sm">
+					<div>
+						Telethon: {#if system.telethon_connected}<Badge>connected</Badge>{:else}
+							<Badge variant="secondary">not configured</Badge>{/if}
+					</div>
+					<div>
+						Publish bot: {#if system.publish_bot_ready}<Badge>ready</Badge>{:else}
+							<Badge variant="secondary">not started</Badge>{/if}
+					</div>
+					<div>
+						Super admins: <span class="font-mono text-xs">{system.super_admin_ids.join(', ')}</span>
+					</div>
+					<div>Session TTL: {system.session_ttl_days} days</div>
+					<div class="col-span-2">
+						Allowed origins:
+						<span class="font-mono text-xs">
+							{system.allowed_origins.length > 0 ? system.allowed_origins.join(', ') : 'http://localhost:5173 (default)'}
+						</span>
+					</div>
+				</Card.Content>
+			</Card.Root>
+
+			<Card.Root>
+				<Card.Header><Card.Title class="text-sm">Feature flags</Card.Title></Card.Header>
+				<Card.Content>
+					<ul class="grid grid-cols-1 gap-1 text-sm md:grid-cols-2">
+						{#each system.feature_flags as f (f.name)}
+							<li class="flex items-center justify-between border-b border-zinc-100 py-1 last:border-0">
+								<span class="font-mono text-xs text-zinc-600">{f.name}</span>
+								{#if f.enabled}<Badge>on</Badge>{:else}<Badge variant="secondary">off</Badge>{/if}
+							</li>
+						{/each}
+					</ul>
+					<p class="mt-3 text-xs text-zinc-500">
+						These flags are read from environment / .env at process start. To change, redeploy.
+					</p>
+				</Card.Content>
+			</Card.Root>
+		{/if}
+	{/if}
+</div>


### PR DESCRIPTION
## Summary

The branch began as Phase 4e (\`/settings\` sessions panel) and grew into an omnibus of UX, observability and content-pipeline gaps surfaced during dogfooding. Squash-merge target.

Nine commits, ~+4.6k LOC, **102 webapi tests + 12 new for suggestions** (full suite still green).

## What's in it

### Settings + admin observability *(commits 72617f, 60aedb)*
- \`GET/DELETE /api/admin/sessions\`, \`GET /api/admin/system\` — list & revoke sessions, view operational status, feature flags, super-admin list.
- \`/settings\` page renders four cards: identity, active sessions (with shortened UA/IP/last-seen), system status, feature flags. Confirm-dialog + toast on revoke.

### Dashboard + sidebar UX pass *(commit 176f86)*
- Sidebar grouped: Overview / Resources / Workflow / System, all with Lucide icons. Phase badges removed.
- Dashboard split into \`Needs your attention\`, \`Content pipeline\`, \`Community\`, \`Recent activity\`. \`ActionTile\` components in the action row link straight to the filtered queues.
- BarChartH + DivergingBars now accept per-row \`href\` — post-views and chat-activity bars are drill-throughs into \`/posts/{id}\` and \`/chats/{id}\`.
- \`/posts\`: URL-synced status/channel filters, quick-filter pills, per-status counts, colour-coded status pills. \`/chats\` & \`/channels\` get summary strips.

### Post pipeline gaps *(commit a8f5dea)*
- \`POST /api/posts/{id}/regenerate\` — re-runs the generator over the stored \`source_items\` with the channel's language + footer.
- 6 image-pool endpoints exposing the review-agent's existing \`image_tools\`: use, add-by-URL, Brave search, remove, reorder, clear. New \`ImagePool.svelte\` renders selected + candidates with quality/relevance badges; admins promote/reorder inline.
- \`cost_events\` table + alembic migration; \`cost_tracker.log_usage\` now fire-and-forget persists each call when \`enable_persistence\` is on (flipped on by webapi lifespan + bot startup, off by default for tests).
- \`GET /api/costs/history?days=N\` — zero-filled daily aggregate. \`/costs\` page gains a sparkline, range selector, peak-day annotation.
- Pre-critic body collapses behind a \`Show\` toggle on \`/posts/{id}\`.

### Setup-gap detection *(commit 563c58e)*
- \`GET /api/suggestions\` — 7 SQL-only rules surfacing config drift:
  - Disabled channels
  - Channels missing sources / @username
  - Networks with ≥2 chats but no managed channel
  - Top-level chats with welcome+captcha both off past the grace window
  - Chats silent for 14d
  - Orphan chats not connected to any hierarchy
- Returns flat \`SuggestionItem[]\` with \`severity\`, \`title\`, \`hint\`, \`action_url\`. Dashboard renders a \`Setup gaps\` row that hides itself when no rule fires.
- \`ActionTile.value\` is now optional — suggestion cards lead with title + hint, no number.
- 12 new tests cover each rule's positive + negative paths.

### Chat graph polish *(commit 0d08674)*
- \`/chats/graph\` rewritten: live filter (title / relation_notes / id) with match highlighting + auto-expand of matched ancestors; restores prior state on clear.
- Stats strip: total chats, networks (root count), max depth, biggest network — all client-side.
- Expand/Collapse all controls; shared \`SvelteSet\` so toggles survive 60s polls.
- Per-node avatar circle (stable hash-colour initials), recursive subtree-count pill, \`ChevronDown/Right\` icons, hover background, quieter connector rails.
- Tree helpers extracted to \`webui/src/lib/components/chat/tree.ts\` (pure TS, trivially testable). \`ChatTreeNode\` stays backwards-compatible for the dashboard preview tile.

### Auto-sync stale chat titles *(commit 46fe4f7)*
- The hourly snapshot loop now syncs \`Chat.title\` from Telegram for any row whose \`modified_at\` is older than 24h. Admin edits within 24h keep authority. Title is the only field synced; nothing else is touched. No \`UPDATE\` (and no \`modified_at\` bump) when the value is unchanged.

### Chat moderation toggles + cost-by-model *(commits 7cf72eb, bbfeb0f)*
- \`PATCH /api/chats/{id}\` now accepts welcome / captcha / time_delete edits.
- Cost summary endpoint returns \`by_model\` alongside \`by_operation\`.
- \`/chats/{id}\` gets an inline edit form for the moderation flags; \`/costs\` adds a model-breakdown table; channel detail gets a critic dropdown (default / on / off).

## API additions

| Method | Path | Purpose |
|---|---|---|
| GET / DELETE | \`/api/admin/sessions[/{id}]\` | List & revoke admin sessions |
| GET | \`/api/admin/system\` | Operational status + feature flags |
| POST | \`/api/posts/{id}/regenerate\` | Re-run generator over stored \`source_items\` |
| POST | \`/api/posts/{id}/images/use\` | Promote candidate to selected |
| POST | \`/api/posts/{id}/images/url\` | Vet & attach an arbitrary URL |
| POST | \`/api/posts/{id}/images/search\` | Brave search → vision-score → pool |
| DELETE | \`/api/posts/{id}/images/{position}\` | Remove a selected image |
| POST | \`/api/posts/{id}/images/reorder\` | Permutation of selected positions |
| DELETE | \`/api/posts/{id}/images\` | Drop all selected (keep pool) |
| GET | \`/api/costs/history?days=N\` | Daily zero-filled cost series |
| GET | \`/api/suggestions\` | Setup-gap detection feed |
| PATCH | \`/api/chats/{id}\` | (extended) welcome / captcha / time_delete |

## Migrations

- \`f7a8b9c0d1e2_add_cost_events.py\` — persistent LLM-call ledger.

## Test plan

- [ ] \`/settings\` lists the current session, badged \`this session\`; second-browser session can be revoked
- [ ] Revoking the current session is blocked
- [ ] \`/posts/{id}\`: \`Regenerate\` rebuilds the body; \`Show pre-critic\` toggle reveals the un-polished copy
- [ ] Image pool: \`Use this\` promotes a candidate; reorder + remove update the post
- [ ] \`/costs\`: 7/14/30/90-day toggle works; sparkline reflects \`cost_events\`; by-model table populated
- [ ] Dashboard: \`Setup gaps\` row appears only when ≥1 rule fires; clicking a card lands on the right page
- [ ] \`/chats/graph\`: filter by title narrows the tree, expand-all reveals all matches, clear restores prior expansion
- [ ] After the next snapshot tick, a chat with stale \`modified_at\` and a renamed Telegram title shows the new title

🤖 Generated with [Claude Code](https://claude.com/claude-code)