### PR TITLE
feat(webui): recover suggestions row, chat-graph polish, snapshot title refresh

### DIFF
--- a/app/webapi/main.py
+++ b/app/webapi/main.py
@@ -13,7 +13,20 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.db.session import create_session_maker
-from app.webapi.routes import admin, agent, auth, channels, chats, costs, health, posts, spam, stats, users
+from app.webapi.routes import (
+    admin,
+    agent,
+    auth,
+    channels,
+    chats,
+    costs,
+    health,
+    posts,
+    spam,
+    stats,
+    suggestions,
+    users,
+)
 from app.webapi.services.telethon_stats import TelethonStatsService
 from app.webapi.snapshot_loop import run_snapshot_loop
 
@@ -77,6 +90,7 @@ def create_app() -> FastAPI:
     app.include_router(costs.router, prefix="/api")
     app.include_router(spam.router, prefix="/api")
     app.include_router(stats.router, prefix="/api")
+    app.include_router(suggestions.router, prefix="/api")
     app.include_router(agent.router, prefix="/api")
     app.include_router(users.router, prefix="/api")
     app.include_router(admin.router, prefix="/api")

--- a/app/webapi/routes/suggestions.py
+++ b/app/webapi/routes/suggestions.py
@@ -1,0 +1,294 @@
+"""Mechanical setup-gap detection — surfaces suggestion cards on the dashboard.
+
+Each rule is a self-contained handler that returns ``list[SuggestionItem]``.
+The router runs them sequentially against a single session, then concatenates
+the results. New rules just need a new handler + an entry in ``_RULES``.
+
+These rules are deliberately mechanical (pure SQL on existing tables) — no LLM
+calls, no Telethon RPCs. The dashboard can poll this freely.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import exists, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.time import utc_now
+from app.db.models import Channel, ChannelSource, Chat, Message
+from app.webapi.deps import get_session, require_super_admin
+from app.webapi.schemas import SuggestionItem, SuggestionsResponse
+
+router = APIRouter(prefix="/suggestions", tags=["suggestions"])
+
+# Per-rule cap so a misconfigured deployment doesn't drown the dashboard
+# in cards. Total upper bound = len(_RULES) * _PER_RULE_CAP.
+_PER_RULE_CAP = 3
+_SILENT_DAYS = 14
+_UNMODERATED_GRACE_DAYS = 7
+
+
+def _label_chat(chat_id: int, title: str | None) -> str:
+    return title or f"#{chat_id}"
+
+
+# ---------------------------------------------------------------------------
+# Rule handlers
+# ---------------------------------------------------------------------------
+
+
+async def _rule_disabled_channels(session: AsyncSession) -> list[SuggestionItem]:
+    rows = (
+        await session.execute(
+            select(Channel.id, Channel.name)
+            .where(Channel.enabled.is_(False))
+            .order_by(Channel.modified_at.desc())
+            .limit(_PER_RULE_CAP)
+        )
+    ).all()
+    return [
+        SuggestionItem(
+            kind="disabled_channel",
+            severity="info",
+            title=f"Disabled channel: {name}",
+            hint="Re-enable to resume the content pipeline, or delete if it's retired.",
+            target_id=cid,
+            target_label=name,
+            action_url=f"/channels/{cid}",
+            action_label="Open",
+        )
+        for cid, name in rows
+    ]
+
+
+async def _rule_channels_without_sources(session: AsyncSession) -> list[SuggestionItem]:
+    rows = (
+        await session.execute(
+            select(Channel.id, Channel.name)
+            .where(Channel.enabled.is_(True))
+            .where(~exists().where(ChannelSource.channel_id == Channel.id))
+            .order_by(Channel.created_at.desc())
+            .limit(_PER_RULE_CAP)
+        )
+    ).all()
+    return [
+        SuggestionItem(
+            kind="channel_without_sources",
+            severity="warning",
+            title=f"No sources: {name}",
+            hint="Add an RSS feed or run discovery — the pipeline can't generate posts otherwise.",
+            target_id=cid,
+            target_label=name,
+            action_url=f"/channels/{cid}",
+            action_label="Configure",
+        )
+        for cid, name in rows
+    ]
+
+
+async def _rule_channels_without_username(session: AsyncSession) -> list[SuggestionItem]:
+    """A managed Telegram channel without a public @handle is still publishable
+    but breaks footer rendering and link sharing — flag so admins can fill it in."""
+    rows = (
+        await session.execute(
+            select(Channel.id, Channel.name)
+            .where(Channel.enabled.is_(True))
+            .where(Channel.username.is_(None))
+            .where(Channel.telegram_id.is_not(None))
+            .order_by(Channel.created_at.desc())
+            .limit(_PER_RULE_CAP)
+        )
+    ).all()
+    return [
+        SuggestionItem(
+            kind="channel_without_username",
+            severity="info",
+            title=f"No @username: {name}",
+            hint="Set the public handle so footer and share links resolve.",
+            target_id=cid,
+            target_label=name,
+            action_url=f"/channels/{cid}",
+            action_label="Set username",
+        )
+        for cid, name in rows
+    ]
+
+
+async def _rule_unmoderated_chats(session: AsyncSession, now: datetime.datetime) -> list[SuggestionItem]:
+    """Top-level chats with both welcome and captcha disabled, that have been
+    around long enough that "we just added it" is no longer a defence."""
+    cutoff = now - datetime.timedelta(days=_UNMODERATED_GRACE_DAYS)
+    rows = (
+        await session.execute(
+            select(Chat.id, Chat.title)
+            .where(Chat.parent_chat_id.is_(None))
+            .where(Chat.is_welcome_enabled.is_(False))
+            .where(Chat.is_captcha_enabled.is_(False))
+            .where(Chat.modified_at < cutoff)
+            .order_by(Chat.modified_at.desc())
+            .limit(_PER_RULE_CAP)
+        )
+    ).all()
+    return [
+        SuggestionItem(
+            kind="unmoderated_chat",
+            severity="warning",
+            title=f"No welcome/captcha: {_label_chat(cid, title)}",
+            hint="No welcome or captcha — new joiners aren't filtered.",
+            target_id=cid,
+            target_label=_label_chat(cid, title),
+            action_url=f"/chats/{cid}",
+            action_label="Configure",
+        )
+        for cid, title in rows
+    ]
+
+
+async def _rule_silent_chats(session: AsyncSession, now: datetime.datetime) -> list[SuggestionItem]:
+    """Chats with zero recorded messages over the lookback window — likely
+    abandoned/archived. The created_at filter avoids flagging fresh additions."""
+    cutoff = now - datetime.timedelta(days=_SILENT_DAYS)
+    rows = (
+        await session.execute(
+            select(Chat.id, Chat.title)
+            .where(Chat.created_at < cutoff)
+            .where(~exists().where((Message.chat_id == Chat.id) & (Message.timestamp >= cutoff)))
+            .order_by(Chat.created_at.asc())
+            .limit(_PER_RULE_CAP)
+        )
+    ).all()
+    return [
+        SuggestionItem(
+            kind="silent_chat",
+            severity="info",
+            title=f"Silent {_SILENT_DAYS}d: {_label_chat(cid, title)}",
+            hint="No messages recorded in the last fortnight. Archive or revisit.",
+            target_id=cid,
+            target_label=_label_chat(cid, title),
+            action_url=f"/chats/{cid}",
+            action_label="Open",
+        )
+        for cid, title in rows
+    ]
+
+
+async def _rule_orphan_chats(session: AsyncSession) -> list[SuggestionItem]:
+    """Chats neither parented nor parenting any other chat — fully isolated nodes.
+
+    Only surfaces when there are at least two such chats — a single isolated
+    chat can be a deliberate solo, but two+ unconnected ones usually means
+    the admin forgot to wire up the network."""
+    parented_subq = select(Chat.parent_chat_id).where(Chat.parent_chat_id.is_not(None)).distinct().subquery()
+    rows = (
+        await session.execute(
+            select(Chat.id, Chat.title)
+            .where(Chat.parent_chat_id.is_(None))
+            .where(~Chat.id.in_(select(parented_subq.c.parent_chat_id)))
+            .order_by(Chat.created_at.desc())
+            .limit(_PER_RULE_CAP + 1)
+        )
+    ).all()
+    if len(rows) < 2:
+        return []
+    return [
+        SuggestionItem(
+            kind="orphan_chat",
+            severity="info",
+            title=f"Orphan: {_label_chat(cid, title)}",
+            hint="Not connected to any network. Set a parent or attach children.",
+            target_id=cid,
+            target_label=_label_chat(cid, title),
+            action_url=f"/chats/{cid}",
+            action_label="Set parent",
+        )
+        for cid, title in rows[:_PER_RULE_CAP]
+    ]
+
+
+async def _rule_networks_without_channel(session: AsyncSession) -> list[SuggestionItem]:
+    """For every chat-tree (multi-node clusters via parent_chat_id), check
+    whether any managed channel has its review_chat_id pointing into the tree.
+
+    Single-node "trees" don't qualify — those are covered by the orphan rule.
+    Skipped entirely if no channels exist (empty deployment)."""
+    has_channels = (await session.execute(select(exists().select_from(Channel)))).scalar()
+    if not has_channels:
+        return []
+
+    chats = (await session.execute(select(Chat.id, Chat.title, Chat.parent_chat_id))).all()
+    if not chats:
+        return []
+
+    # Build parent → list[child] map and id → (title, parent) lookup.
+    children_of: dict[int, list[int]] = {}
+    chat_meta: dict[int, tuple[str | None, int | None]] = {}
+    for cid, title, parent in chats:
+        chat_meta[cid] = (title, parent)
+        if parent is not None:
+            children_of.setdefault(parent, []).append(cid)
+
+    review_targets = {
+        row[0]
+        for row in (
+            await session.execute(select(Channel.review_chat_id).where(Channel.review_chat_id.is_not(None)))
+        ).all()
+    }
+
+    suggestions: list[SuggestionItem] = []
+    for cid, (title, parent) in chat_meta.items():
+        if parent is not None:
+            continue  # not a root
+        # Walk descendants
+        tree: set[int] = {cid}
+        stack = [cid]
+        while stack:
+            node = stack.pop()
+            for child in children_of.get(node, ()):
+                if child not in tree:
+                    tree.add(child)
+                    stack.append(child)
+        if len(tree) < 2:
+            continue  # single-node, covered by orphan rule
+        if tree & review_targets:
+            continue  # at least one channel points into this network
+        label = _label_chat(cid, title)
+        suggestions.append(
+            SuggestionItem(
+                kind="network_without_channel",
+                severity="attention",
+                title=f"No channel: {label}",
+                hint=f"Network has {len(tree)} chats but no managed channel. Create one to publish posts.",
+                target_id=cid,
+                target_label=label,
+                action_url="/channels",
+                action_label="Create channel",
+            )
+        )
+        if len(suggestions) >= _PER_RULE_CAP:
+            break
+    return suggestions
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=SuggestionsResponse)
+async def list_suggestions(
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> SuggestionsResponse:
+    now = utc_now()
+    items: list[SuggestionItem] = []
+    items.extend(await _rule_networks_without_channel(session))
+    items.extend(await _rule_disabled_channels(session))
+    items.extend(await _rule_channels_without_sources(session))
+    items.extend(await _rule_channels_without_username(session))
+    items.extend(await _rule_unmoderated_chats(session, now))
+    items.extend(await _rule_silent_chats(session, now))
+    items.extend(await _rule_orphan_chats(session))
+    return SuggestionsResponse(items=items, generated_at=now)

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -502,6 +502,30 @@ class AgentTurnRequest(BaseModel):
     message: str
 
 
+class SuggestionItem(BaseModel):
+    """One actionable setup-gap detected by a mechanical rule.
+
+    ``kind`` is a stable id (sibling_orphan, network_without_channel, …) that the
+    UI uses for icon + copy. ``severity`` drives the tone of the card. ``target_id``
+    is the chat / channel id the suggestion is about — the UI uses it to dedupe
+    when the same chat is flagged by multiple rules.
+    """
+
+    kind: str
+    severity: str  # "info" | "warning" | "attention"
+    title: str
+    hint: str
+    target_id: int | None = None
+    target_label: str | None = None
+    action_url: str | None = None
+    action_label: str | None = None
+
+
+class SuggestionsResponse(BaseModel):
+    items: list[SuggestionItem]
+    generated_at: datetime.datetime
+
+
 class HomeStats(BaseModel):
     """Aggregated response backing the home dashboard's live tiles.
 

--- a/app/webapi/snapshot_loop.py
+++ b/app/webapi/snapshot_loop.py
@@ -4,16 +4,23 @@ Runs as a single background asyncio task for the lifetime of the webapi
 process. Intentionally simple: one query per chat per tick, no concurrency,
 no deduplication. If the process dies, we lose the in-flight tick; no
 state is corrupted because each snapshot is an independent row.
+
+Each tick also opportunistically refreshes Chat.title from Telegram for
+rows that haven't been touched in METADATA_STALENESS_HOURS — admins who
+edited a row recently keep their values, but long-untouched rows pick up
+upstream renames automatically.
 """
 
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+import datetime
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import select
 
 from app.core.logging import get_logger
+from app.core.time import utc_now
 from app.db.models import Chat, ChatMemberSnapshot
 
 if TYPE_CHECKING:
@@ -24,6 +31,26 @@ if TYPE_CHECKING:
 logger = get_logger("webapi.snapshot_loop")
 
 SNAPSHOT_INTERVAL_SECONDS = 3600  # 1 hour
+METADATA_STALENESS_HOURS = 24
+
+
+def _refresh_stale_metadata(chat: Chat, info: Any, *, cutoff: datetime.datetime) -> bool:
+    """Sync Chat.title from Telegram when the row's been untouched past the cutoff.
+
+    Returns True iff the title actually changed — caller uses that to count
+    refreshes for the log line. We only sync title because that's the only
+    upstream-managed string surfaced in the UI; everything else (welcome,
+    captcha, parent, notes) is admin-owned.
+    """
+    if chat.modified_at and chat.modified_at >= cutoff:
+        return False
+    upstream_title = getattr(info, "title", None)
+    if not isinstance(upstream_title, str) or not upstream_title:
+        return False
+    if upstream_title == chat.title:
+        return False
+    chat.title = upstream_title
+    return True
 
 
 async def snapshot_once(
@@ -31,12 +58,16 @@ async def snapshot_once(
     session_maker: async_sessionmaker[AsyncSession],
     telethon: TelethonClient | None,
 ) -> int:
-    """Capture one snapshot per chat. Returns the number of rows written."""
+    """Capture one snapshot per chat. Returns the number of snapshot rows
+    written. Stale-metadata refreshes happen opportunistically and are logged
+    separately."""
     if telethon is None or not telethon.is_available:
         logger.info("snapshot_once skipped — telethon unavailable")
         return 0
 
     written = 0
+    refreshed = 0
+    cutoff = utc_now() - datetime.timedelta(hours=METADATA_STALENESS_HOURS)
     async with session_maker() as session:
         chats = (await session.execute(select(Chat))).scalars().all()
         for chat in chats:
@@ -45,12 +76,15 @@ async def snapshot_once(
             except Exception as e:  # noqa: BLE001
                 logger.warning("get_chat_info failed", chat_id=chat.id, error=str(e))
                 continue
-            if info is None or info.member_count is None:
+            if info is None:
                 continue
-            session.add(ChatMemberSnapshot(chat_id=chat.id, member_count=info.member_count))
-            written += 1
+            if info.member_count is not None:
+                session.add(ChatMemberSnapshot(chat_id=chat.id, member_count=info.member_count))
+                written += 1
+            if _refresh_stale_metadata(chat, info, cutoff=cutoff):
+                refreshed += 1
         await session.commit()
-    logger.info("snapshot_once committed", rows=written)
+    logger.info("snapshot_once committed", snapshots=written, metadata_refreshed=refreshed)
     return written
 
 

--- a/tests/webapi/test_snapshot_loop.py
+++ b/tests/webapi/test_snapshot_loop.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from app.core.time import utc_now
 from app.db.models import Chat, ChatMemberSnapshot
-from app.webapi.snapshot_loop import snapshot_once
+from app.webapi.snapshot_loop import METADATA_STALENESS_HOURS, snapshot_once
 from sqlalchemy import select
 
 if TYPE_CHECKING:
@@ -52,3 +54,72 @@ async def test_snapshot_once_writes_rows_for_each_chat(
     async with db_session_maker() as session:
         rows = (await session.execute(select(ChatMemberSnapshot).order_by(ChatMemberSnapshot.chat_id))).scalars().all()
     assert [(r.chat_id, r.member_count) for r in rows] == [(-200, 80), (-100, 50)]
+
+
+async def test_snapshot_once_refreshes_stale_chat_title(
+    db_session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A chat untouched for >24h picks up its current Telegram title."""
+    old = utc_now() - datetime.timedelta(hours=METADATA_STALENESS_HOURS + 1)
+    async with db_session_maker() as session:
+        stale = Chat(id=-300, title="Old Name")
+        stale.modified_at = old
+        session.add(stale)
+        await session.commit()
+
+    tc = MagicMock()
+    tc.is_available = True
+    tc.get_chat_info = AsyncMock(return_value=MagicMock(member_count=10, title="Renamed Upstream"))
+
+    await snapshot_once(session_maker=db_session_maker, telethon=tc)
+
+    async with db_session_maker() as session:
+        chat = (await session.execute(select(Chat).where(Chat.id == -300))).scalar_one()
+    assert chat.title == "Renamed Upstream"
+
+
+async def test_snapshot_once_does_not_overwrite_recent_chat(
+    db_session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Admin edited the row within the staleness window — Telethon's title
+    should NOT win, because we treat recent admin activity as authoritative."""
+    fresh = utc_now() - datetime.timedelta(hours=1)
+    async with db_session_maker() as session:
+        chat = Chat(id=-400, title="Admin's Choice")
+        chat.modified_at = fresh
+        session.add(chat)
+        await session.commit()
+
+    tc = MagicMock()
+    tc.is_available = True
+    tc.get_chat_info = AsyncMock(return_value=MagicMock(member_count=5, title="Telegram Default"))
+
+    await snapshot_once(session_maker=db_session_maker, telethon=tc)
+
+    async with db_session_maker() as session:
+        chat = (await session.execute(select(Chat).where(Chat.id == -400))).scalar_one()
+    assert chat.title == "Admin's Choice"
+
+
+async def test_snapshot_once_skips_unchanged_title(
+    db_session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Same title in DB and Telegram — no UPDATE fires, modified_at stays put."""
+    old = utc_now() - datetime.timedelta(hours=METADATA_STALENESS_HOURS + 1)
+    async with db_session_maker() as session:
+        chat = Chat(id=-500, title="Same Name")
+        chat.modified_at = old
+        session.add(chat)
+        await session.commit()
+
+    tc = MagicMock()
+    tc.is_available = True
+    tc.get_chat_info = AsyncMock(return_value=MagicMock(member_count=7, title="Same Name"))
+
+    await snapshot_once(session_maker=db_session_maker, telethon=tc)
+
+    async with db_session_maker() as session:
+        chat = (await session.execute(select(Chat).where(Chat.id == -500))).scalar_one()
+    # modified_at must remain the original value because no actual UPDATE
+    # happened — the row didn't get bumped just from being inspected.
+    assert chat.modified_at < utc_now() - datetime.timedelta(hours=METADATA_STALENESS_HOURS)

--- a/tests/webapi/test_stats.py
+++ b/tests/webapi/test_stats.py
@@ -115,6 +115,7 @@ async def test_home_includes_post_views(client_factory, db_session_maker) -> Non
     import datetime
 
     from app.core.enums import PostStatus
+    from app.core.time import utc_now
     from app.db.models import Channel, ChannelPost
 
     async with db_session_maker() as session:
@@ -122,7 +123,7 @@ async def test_home_includes_post_views(client_factory, db_session_maker) -> Non
         post = ChannelPost(channel_id=-2001, external_id="e1", title="P1", post_text="x")
         post.status = PostStatus.APPROVED
         post.telegram_message_id = 42
-        post.published_at = datetime.datetime(2026, 4, 21, 10, 0, 0)
+        post.published_at = utc_now() - datetime.timedelta(days=2)
         session.add(post)
         await session.commit()
 
@@ -141,13 +142,15 @@ async def test_home_includes_post_views(client_factory, db_session_maker) -> Non
 async def test_home_includes_chat_heatmap_totals(client_factory, db_session_maker) -> None:
     import datetime
 
+    from app.core.time import utc_now
     from app.db.models import Chat, Message
 
     async with db_session_maker() as session:
         session.add(Chat(id=-3001, title="H"))
+        recent = utc_now() - datetime.timedelta(days=2)
         for i in range(5):
             m = Message(chat_id=-3001, user_id=1, message_id=i)
-            m.timestamp = datetime.datetime(2026, 4, 21, 12, 0, 0)
+            m.timestamp = recent
             session.add(m)
         await session.commit()
 

--- a/tests/webapi/test_suggestions.py
+++ b/tests/webapi/test_suggestions.py
@@ -1,0 +1,261 @@
+"""Tests for /api/suggestions — mechanical setup-gap detection."""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING
+
+import pytest
+from app.core.config import settings
+from app.core.time import utc_now
+from app.db.models import Channel, ChannelSource, Chat, Message
+from app.webapi.main import app
+from httpx import ASGITransport, AsyncClient
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def client(db_session_maker: async_sessionmaker[AsyncSession]):
+    """Wire test session to the FastAPI dep + dev-bypass auth.
+
+    Returns a factory so tests that hit the endpoint twice (orphan rule
+    needs to verify it fires only after the second chat lands) get a
+    fresh AsyncClient each call — httpx clients can't be reopened."""
+    from app.webapi.deps import get_session
+
+    async def _override_session():
+        async with db_session_maker() as s:
+            yield s
+
+    settings.admin.super_admins = [1]
+    settings.webapi.dev_bypass_auth = True
+    app.dependency_overrides[get_session] = _override_session
+    transport = ASGITransport(app=app)
+
+    def make() -> AsyncClient:
+        return AsyncClient(transport=transport, base_url="http://test")
+
+    yield make
+    app.dependency_overrides.pop(get_session, None)
+
+
+def _kinds(body: dict) -> list[str]:
+    return [item["kind"] for item in body["items"]]
+
+
+async def test_empty_db_returns_no_items(client) -> None:
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["items"] == []
+    assert "generated_at" in body
+
+
+async def test_disabled_channel_surfaces(client, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        s.add(Channel(telegram_id=-100100, name="Off Air", enabled=False))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    assert "disabled_channel" in _kinds(body)
+    item = next(i for i in body["items"] if i["kind"] == "disabled_channel")
+    assert item["target_label"] == "Off Air"
+    assert item["action_url"].startswith("/channels/")
+
+
+async def test_channel_without_sources_surfaces(client, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        s.add(Channel(telegram_id=-100200, name="Empty", enabled=True))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    assert "channel_without_sources" in _kinds(body)
+
+
+async def test_channel_with_sources_does_not_surface(client, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        ch = Channel(telegram_id=-100300, name="Stocked", enabled=True)
+        s.add(ch)
+        await s.flush()
+        s.add(ChannelSource(channel_id=ch.id, url="https://example.com/feed", source_type="rss"))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    assert "channel_without_sources" not in _kinds(body)
+
+
+async def test_channel_without_username_surfaces(client, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        s.add(Channel(telegram_id=-100400, name="No Handle", enabled=True, username=None))
+        # plus a control: enabled with username should not flag
+        s.add(Channel(telegram_id=-100401, name="Has Handle", enabled=True, username="public"))
+        await s.flush()
+        # Add a source for both so the no-sources rule doesn't trigger.
+        from sqlalchemy import select
+
+        for ch in (await s.execute(select(Channel))).scalars():
+            s.add(ChannelSource(channel_id=ch.id, url=f"https://example.com/{ch.id}", source_type="rss"))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    items = [i for i in body["items"] if i["kind"] == "channel_without_username"]
+    assert len(items) == 1
+    assert items[0]["target_label"] == "No Handle"
+
+
+async def test_unmoderated_chat_surfaces_only_after_grace(client, db_session_maker) -> None:
+    """Both is_welcome_enabled and is_captcha_enabled false AND modified_at older
+    than the grace window — only then does the rule trigger."""
+    old = utc_now() - datetime.timedelta(days=30)
+    async with db_session_maker() as s:
+        # Stale unmoderated — should flag
+        stale = Chat(id=-1, title="Stale Group", is_welcome_enabled=False, is_captcha_enabled=False)
+        stale.created_at = old
+        stale.modified_at = old
+        s.add(stale)
+        # Recently added unmoderated — within grace, should NOT flag
+        fresh = Chat(id=-2, title="Fresh Group", is_welcome_enabled=False, is_captcha_enabled=False)
+        s.add(fresh)
+        # Stale but moderated — should NOT flag
+        guarded = Chat(id=-3, title="Guarded", is_welcome_enabled=True, is_captcha_enabled=False)
+        guarded.created_at = old
+        guarded.modified_at = old
+        s.add(guarded)
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    items = [i for i in body["items"] if i["kind"] == "unmoderated_chat"]
+    labels = {i["target_label"] for i in items}
+    assert "Stale Group" in labels
+    assert "Fresh Group" not in labels
+    assert "Guarded" not in labels
+
+
+async def test_silent_chat_surfaces_when_no_recent_messages(client, db_session_maker) -> None:
+    old = utc_now() - datetime.timedelta(days=30)
+    async with db_session_maker() as s:
+        silent = Chat(id=-10, title="Silent Group")
+        silent.created_at = old
+        silent.modified_at = old
+        s.add(silent)
+        active = Chat(id=-11, title="Active Group")
+        active.created_at = old
+        active.modified_at = old
+        s.add(active)
+        await s.flush()
+        s.add(Message(chat_id=active.id, user_id=1, message_id=1, message="hi"))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    items = [i for i in body["items"] if i["kind"] == "silent_chat"]
+    labels = {i["target_label"] for i in items}
+    assert "Silent Group" in labels
+    assert "Active Group" not in labels
+
+
+async def test_orphan_chats_require_at_least_two(client, db_session_maker) -> None:
+    """A single isolated chat is fine — the rule needs >=2 to fire."""
+    async with db_session_maker() as s:
+        s.add(Chat(id=-20, title="Solo"))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    assert "orphan_chat" not in _kinds(body)
+
+    async with db_session_maker() as s:
+        s.add(Chat(id=-21, title="Also Solo"))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    items = [i for i in body["items"] if i["kind"] == "orphan_chat"]
+    assert len(items) == 2
+
+
+async def test_orphan_excludes_chats_with_relations(client, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        root = Chat(id=-30, title="Root")
+        child = Chat(id=-31, title="Child", parent_chat_id=-30)
+        s.add(root)
+        s.add(child)
+        # And one truly isolated, just to keep the rule's >=2 check from failing
+        # for orphan_chat — but since "Root" has a child it's not orphan, and
+        # "Child" has a parent, only the standalone is orphan, which is <2 → no fire.
+        s.add(Chat(id=-32, title="Loner"))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    assert "orphan_chat" not in _kinds(body)
+
+
+async def test_network_without_channel_surfaces(client, db_session_maker) -> None:
+    """Tree with >=2 chats but no Channel.review_chat_id pointing inside → fire."""
+    async with db_session_maker() as s:
+        s.add(Channel(telegram_id=-100500, name="Lonely", enabled=True, username="lonely"))
+        s.add(ChannelSource(channel_id=1, url="https://x", source_type="rss"))  # avoid no-sources noise
+        s.add(Chat(id=-40, title="Faculty Root"))
+        s.add(Chat(id=-41, title="Faculty Sub", parent_chat_id=-40))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    items = [i for i in body["items"] if i["kind"] == "network_without_channel"]
+    assert len(items) == 1
+    assert items[0]["target_label"] == "Faculty Root"
+
+
+async def test_network_with_channel_does_not_surface(client, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        s.add(Chat(id=-50, title="Wired Root"))
+        s.add(Chat(id=-51, title="Wired Sub", parent_chat_id=-50))
+        s.add(
+            Channel(
+                telegram_id=-100600,
+                name="Wired",
+                enabled=True,
+                username="wired",
+                review_chat_id=-50,
+            )
+        )
+        s.add(ChannelSource(channel_id=1, url="https://x", source_type="rss"))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    assert "network_without_channel" not in _kinds(body)
+
+
+async def test_network_rule_skips_when_no_channels_exist(client, db_session_maker) -> None:
+    async with db_session_maker() as s:
+        s.add(Chat(id=-60, title="Greenfield Root"))
+        s.add(Chat(id=-61, title="Greenfield Sub", parent_chat_id=-60))
+        await s.commit()
+
+    async with client() as c:
+        resp = await c.get("/api/suggestions")
+    body = resp.json()
+    assert "network_without_channel" not in _kinds(body)

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -499,6 +499,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/suggestions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Suggestions */
+        get: operations["list_suggestions_api_suggestions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/agent/history": {
         parameters: {
             query?: never;
@@ -1530,6 +1547,43 @@ export interface components {
             recent: components["schemas"]["SpamPingRead"][];
         };
         /**
+         * SuggestionItem
+         * @description One actionable setup-gap detected by a mechanical rule.
+         *
+         *     ``kind`` is a stable id (sibling_orphan, network_without_channel, …) that the
+         *     UI uses for icon + copy. ``severity`` drives the tone of the card. ``target_id``
+         *     is the chat / channel id the suggestion is about — the UI uses it to dedupe
+         *     when the same chat is flagged by multiple rules.
+         */
+        SuggestionItem: {
+            /** Kind */
+            kind: string;
+            /** Severity */
+            severity: string;
+            /** Title */
+            title: string;
+            /** Hint */
+            hint: string;
+            /** Target Id */
+            target_id?: number | null;
+            /** Target Label */
+            target_label?: string | null;
+            /** Action Url */
+            action_url?: string | null;
+            /** Action Label */
+            action_label?: string | null;
+        };
+        /** SuggestionsResponse */
+        SuggestionsResponse: {
+            /** Items */
+            items: components["schemas"]["SuggestionItem"][];
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+        };
+        /**
          * SystemStatus
          * @description Read-only operational status for the /settings system card.
          */
@@ -2555,6 +2609,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HomeStats"];
+                };
+            };
+        };
+    };
+    list_suggestions_api_suggestions_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuggestionsResponse"];
                 };
             };
         };

--- a/webui/src/lib/components/chat/ChatTreeNode.svelte
+++ b/webui/src/lib/components/chat/ChatTreeNode.svelte
@@ -1,50 +1,144 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import type { components } from '$lib/api/types';
+	import { ChevronDown, ChevronRight } from '@lucide/svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { untrack } from 'svelte';
 	import Self from './ChatTreeNode.svelte';
+	import { hashId, initialsFor, type EnrichedNode } from './tree';
 
-	type Node = components['schemas']['ChatNode'];
-	type Props = { node: Node; depth?: number };
-	let { node, depth = 0 }: Props = $props();
+	type Props = {
+		node: EnrichedNode;
+		expandedIds?: SvelteSet<number>;
+		query?: string;
+		defaultExpandedDepth?: number;
+	};
+	let { node, expandedIds, query = '', defaultExpandedDepth = 2 }: Props = $props();
 
-	let expanded = $state(untrack(() => depth < 2));
+	// Local fallback when the parent doesn't manage expansion (legacy uses on
+	// the dashboard preview tile). Initialised from depth so shallow trees
+	// expand by default but deep ones stay collapsed.
+	let localExpanded = $state(untrack(() => node.depth < defaultExpandedDepth));
+
+	const expanded = $derived(expandedIds ? expandedIds.has(node.id) : localExpanded);
 	const hasChildren = $derived(node.children.length > 0);
+
+	function toggle() {
+		if (expandedIds) {
+			if (expandedIds.has(node.id)) expandedIds.delete(node.id);
+			else expandedIds.add(node.id);
+		} else {
+			localExpanded = !localExpanded;
+		}
+	}
+
+	const palette = [
+		'bg-amber-100 text-amber-700',
+		'bg-emerald-100 text-emerald-700',
+		'bg-sky-100 text-sky-700',
+		'bg-violet-100 text-violet-700',
+		'bg-rose-100 text-rose-700',
+		'bg-fuchsia-100 text-fuchsia-700',
+		'bg-lime-100 text-lime-700',
+		'bg-orange-100 text-orange-700'
+	];
+	const avatarClass = $derived(palette[hashId(node.id) % palette.length]);
+	const initials = $derived(initialsFor(node.title, node.id));
+	const label = $derived(node.title ?? `#${node.id}`);
+
+	type Segment = { text: string; matched: boolean };
+	function highlight(text: string, q: string): Segment[] {
+		if (!q) return [{ text, matched: false }];
+		const lower = text.toLowerCase();
+		const needle = q.toLowerCase();
+		const segments: Segment[] = [];
+		let i = 0;
+		while (i < text.length) {
+			const hit = lower.indexOf(needle, i);
+			if (hit === -1) {
+				segments.push({ text: text.slice(i), matched: false });
+				break;
+			}
+			if (hit > i) segments.push({ text: text.slice(i, hit), matched: false });
+			segments.push({ text: text.slice(hit, hit + needle.length), matched: true });
+			i = hit + needle.length;
+		}
+		return segments;
+	}
+
+	const labelSegments = $derived(highlight(label, query));
+	const notesSegments = $derived(node.relation_notes ? highlight(node.relation_notes, query) : []);
 </script>
 
-<li class="space-y-1">
-	<div class="flex items-center gap-2 text-sm">
+<li class="space-y-0.5">
+	<div
+		class="group flex items-center gap-2 rounded-md py-1 pr-1 pl-0.5 text-sm transition-colors hover:bg-zinc-50"
+	>
 		{#if hasChildren}
 			<button
 				type="button"
-				class="w-3 text-xs text-zinc-500 hover:text-zinc-900"
+				class="flex h-5 w-5 shrink-0 items-center justify-center rounded text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700"
 				aria-label={expanded ? 'Collapse' : 'Expand'}
-				onclick={() => (expanded = !expanded)}
+				onclick={toggle}
 			>
-				{expanded ? '▾' : '▸'}
+				{#if expanded}
+					<ChevronDown class="h-3.5 w-3.5" />
+				{:else}
+					<ChevronRight class="h-3.5 w-3.5" />
+				{/if}
 			</button>
 		{:else}
-			<span class="w-3"></span>
+			<span class="h-5 w-5 shrink-0"></span>
 		{/if}
+
+		<span
+			class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold tracking-tight {avatarClass}"
+			aria-hidden="true"
+		>
+			{initials}
+		</span>
+
 		<button
 			type="button"
-			class="truncate text-zinc-800 hover:underline"
+			class="min-w-0 flex-1 truncate text-left font-medium text-zinc-800 hover:text-zinc-950 hover:underline"
 			onclick={() => goto(`/chats/${node.id}`)}
-			title={node.title ?? `#${node.id}`}
+			title={label}
 		>
-			{node.title ?? `#${node.id}`}
+			{#each labelSegments as seg}
+				{#if seg.matched}
+					<mark class="rounded bg-amber-200/70 px-0.5 text-zinc-900">{seg.text}</mark>
+				{:else}
+					{seg.text}
+				{/if}
+			{/each}
 		</button>
+
 		{#if node.relation_notes}
-			<span class="truncate text-xs text-zinc-400">· {node.relation_notes}</span>
+			<span class="hidden truncate text-xs text-zinc-400 md:inline">
+				·
+				{#each notesSegments as seg}
+					{#if seg.matched}
+						<mark class="rounded bg-amber-200/70 px-0.5 text-zinc-700">{seg.text}</mark>
+					{:else}
+						{seg.text}
+					{/if}
+				{/each}
+			</span>
 		{/if}
+
 		{#if hasChildren}
-			<span class="ml-auto text-xs text-zinc-400">{node.children.length}</span>
+			<span
+				class="ml-auto rounded-full bg-zinc-100 px-1.5 py-0.5 font-mono text-[10px] text-zinc-500 group-hover:bg-zinc-200"
+				title="{node.subtreeSize} chats including this root"
+			>
+				{node.subtreeSize}
+			</span>
 		{/if}
 	</div>
+
 	{#if expanded && hasChildren}
-		<ul class="ml-4 space-y-1 border-l border-zinc-200 pl-2">
+		<ul class="ml-3 space-y-0.5 border-l border-zinc-200 pl-3">
 			{#each node.children as child (child.id)}
-				<Self node={child} depth={depth + 1} />
+				<Self node={child} {expandedIds} {query} {defaultExpandedDepth} />
 			{/each}
 		</ul>
 	{/if}

--- a/webui/src/lib/components/chat/tree.ts
+++ b/webui/src/lib/components/chat/tree.ts
@@ -1,0 +1,116 @@
+import type { components } from '$lib/api/types';
+
+type RawNode = components['schemas']['ChatNode'];
+
+export type EnrichedNode = {
+	id: number;
+	title: string | null;
+	relation_notes: string | null | undefined;
+	depth: number;
+	subtreeSize: number; // 1 + sum of children's subtreeSize
+	children: EnrichedNode[];
+};
+
+/** Recursively annotate every node with its depth and subtree size.
+ * Subtree size includes the node itself, so leaves are 1.
+ */
+export function enrichTree(nodes: RawNode[], depth = 0): EnrichedNode[] {
+	return nodes.map((n) => {
+		const children = enrichTree(n.children, depth + 1);
+		const subtreeSize = 1 + children.reduce((acc, c) => acc + c.subtreeSize, 0);
+		return {
+			id: n.id,
+			title: n.title,
+			relation_notes: n.relation_notes,
+			depth,
+			subtreeSize,
+			children
+		};
+	});
+}
+
+export type TreeStats = {
+	total: number;
+	rootCount: number;
+	maxDepth: number; // 0 = single-node tree
+	biggestNetwork: number; // largest subtreeSize across roots
+};
+
+export function computeStats(roots: EnrichedNode[]): TreeStats {
+	let total = 0;
+	let maxDepth = 0;
+	let biggest = 0;
+	const visit = (n: EnrichedNode): void => {
+		total += 1;
+		if (n.depth > maxDepth) maxDepth = n.depth;
+		n.children.forEach(visit);
+	};
+	for (const r of roots) {
+		biggest = Math.max(biggest, r.subtreeSize);
+		visit(r);
+	}
+	return { total, rootCount: roots.length, maxDepth, biggestNetwork: biggest };
+}
+
+/** Collect every id reachable in the forest. */
+export function collectIds(roots: EnrichedNode[]): Set<number> {
+	const out = new Set<number>();
+	const visit = (n: EnrichedNode): void => {
+		out.add(n.id);
+		n.children.forEach(visit);
+	};
+	roots.forEach(visit);
+	return out;
+}
+
+/** Filter the tree to nodes whose title or relation_notes match `query`,
+ * keeping every ancestor of a match so the path is preserved. Returns a
+ * new tree (immutable). Empty query returns the input unchanged.
+ *
+ * Matching is case-insensitive substring; falsy fields are ignored.
+ */
+export function filterTree(roots: EnrichedNode[], query: string): EnrichedNode[] {
+	const q = query.trim().toLowerCase();
+	if (!q) return roots;
+
+	const matches = (n: EnrichedNode): boolean => {
+		const t = (n.title ?? '').toLowerCase();
+		const r = (n.relation_notes ?? '').toLowerCase();
+		const idStr = String(n.id);
+		return t.includes(q) || r.includes(q) || idStr.includes(q);
+	};
+
+	const walk = (nodes: EnrichedNode[]): EnrichedNode[] => {
+		const out: EnrichedNode[] = [];
+		for (const n of nodes) {
+			const filteredChildren = walk(n.children);
+			if (matches(n) || filteredChildren.length > 0) {
+				out.push({ ...n, children: filteredChildren });
+			}
+		}
+		return out;
+	};
+	return walk(roots);
+}
+
+/** Stable hash → palette index for avatar color. The exact palette lives in
+ * the Svelte component; this just produces an integer so consumers can index
+ * into whatever array they like.
+ */
+export function hashId(n: number): number {
+	// xorshift-ish; we just want consistent dispersion across small ints.
+	let x = n | 0;
+	x ^= x << 13;
+	x ^= x >>> 17;
+	x ^= x << 5;
+	return Math.abs(x);
+}
+
+export function initialsFor(title: string | null, id: number): string {
+	if (!title) return `#${String(id).slice(-2)}`;
+	const cleaned = title.trim();
+	if (!cleaned) return `#${String(id).slice(-2)}`;
+	const words = cleaned.split(/\s+/).slice(0, 2);
+	const letters = words.map((w) => w.replace(/[^\p{L}\p{N}]/gu, '').charAt(0).toUpperCase()).join('');
+	return letters || cleaned.charAt(0).toUpperCase();
+}

--- a/webui/src/lib/components/home/ActionTile.svelte
+++ b/webui/src/lib/components/home/ActionTile.svelte
@@ -4,7 +4,7 @@
 
 	type Props = {
 		title: string;
-		value: string | number;
+		value?: string | number;
 		caption?: string;
 		href?: string;
 		cta?: string;
@@ -46,7 +46,9 @@
 		{/if}
 		<div class="min-w-0 flex-1">
 			<div class="text-xs font-medium text-zinc-600">{title}</div>
-			<div class="mt-0.5 text-2xl font-semibold tracking-tight text-zinc-900">{value}</div>
+			{#if value !== undefined && value !== ''}
+				<div class="mt-0.5 text-2xl font-semibold tracking-tight text-zinc-900">{value}</div>
+			{/if}
 			{#if caption}
 				<div class="mt-0.5 text-xs text-zinc-500">{caption}</div>
 			{/if}

--- a/webui/src/lib/components/home/SuggestionsRow.svelte
+++ b/webui/src/lib/components/home/SuggestionsRow.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import ActionTile from './ActionTile.svelte';
+	import type { components } from '$lib/api/types';
+	import type { Component } from 'svelte';
+	import {
+		AtSign,
+		Inbox,
+		Lightbulb,
+		Network,
+		Power,
+		Shield,
+		Tv,
+		VolumeX
+	} from '@lucide/svelte';
+
+	type Suggestion = components['schemas']['SuggestionItem'];
+	type Tone = 'default' | 'attention' | 'success' | 'warning';
+
+	type Props = {
+		items: Suggestion[];
+		loading?: boolean;
+	};
+
+	let { items, loading = false }: Props = $props();
+
+	const iconByKind: Record<string, Component> = {
+		disabled_channel: Power,
+		channel_without_sources: Inbox,
+		channel_without_username: AtSign,
+		unmoderated_chat: Shield,
+		silent_chat: VolumeX,
+		orphan_chat: Network,
+		network_without_channel: Tv
+	};
+
+	function toneFor(severity: string): Tone {
+		if (severity === 'attention') return 'attention';
+		if (severity === 'warning') return 'warning';
+		return 'default';
+	}
+
+	function iconFor(kind: string): Component {
+		return iconByKind[kind] ?? Lightbulb;
+	}
+</script>
+
+{#if loading}
+	<p class="text-xs text-zinc-500">loading…</p>
+{:else if items.length === 0}
+	<!-- Render nothing — the parent decides whether to show the section header. -->
+{:else}
+	<div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+		{#each items as item (item.kind + ':' + (item.target_id ?? ''))}
+			<ActionTile
+				title={item.title}
+				caption={item.hint}
+				icon={iconFor(item.kind)}
+				tone={toneFor(item.severity)}
+				href={item.action_url ?? undefined}
+				cta={item.action_label ?? 'Open'}
+			/>
+		{/each}
+	</div>
+{/if}

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ChatTreeNode from '$lib/components/chat/ChatTreeNode.svelte';
+	import { enrichTree } from '$lib/components/chat/tree';
 	import BarChartH from '$lib/components/charts/BarChartH.svelte';
 	import DivergingBars from '$lib/components/charts/DivergingBars.svelte';
 	import Donut from '$lib/components/charts/Donut.svelte';
@@ -21,6 +22,7 @@
 	const suggestions = useLivePoll<Suggestions>('/api/suggestions', 60_000);
 
 	const suggestionItems = $derived(suggestions.data?.items ?? []);
+	const enrichedTree = $derived(tree.data ? enrichTree(tree.data) : []);
 
 	const totalDrafts = $derived(
 		stats.data?.drafts.reduce((acc, d) => acc + d.count, 0) ?? 0
@@ -211,12 +213,12 @@
 			<Tile title="Chat graph">
 				{#if tree.loading}
 					<p class="text-xs text-zinc-500">loading…</p>
-				{:else if !tree.data || tree.data.length === 0}
+				{:else if enrichedTree.length === 0}
 					<p class="text-xs text-zinc-500">No chats yet.</p>
 				{:else}
 					<ul class="space-y-1">
-						{#each tree.data.slice(0, 3) as root (root.id)}
-							<ChatTreeNode node={root} depth={1} />
+						{#each enrichedTree.slice(0, 3) as root (root.id)}
+							<ChatTreeNode node={root} defaultExpandedDepth={1} />
 						{/each}
 					</ul>
 					<a

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import Donut from '$lib/components/charts/Donut.svelte';
 	import ActionTile from '$lib/components/home/ActionTile.svelte';
 	import ListTile from '$lib/components/home/ListTile.svelte';
+	import SuggestionsRow from '$lib/components/home/SuggestionsRow.svelte';
 	import Tile from '$lib/components/home/Tile.svelte';
 	import SpamPingsList from '$lib/components/spam/SpamPingsList.svelte';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
@@ -13,9 +14,13 @@
 
 	type HomeStats = components['schemas']['HomeStats'];
 	type Tree = components['schemas']['ChatNode'][];
+	type Suggestions = components['schemas']['SuggestionsResponse'];
 
 	const stats = useLivePoll<HomeStats>('/api/stats/home');
 	const tree = useLivePoll<Tree>('/api/chats/graph', 120_000);
+	const suggestions = useLivePoll<Suggestions>('/api/suggestions', 60_000);
+
+	const suggestionItems = $derived(suggestions.data?.items ?? []);
 
 	const totalDrafts = $derived(
 		stats.data?.drafts.reduce((acc, d) => acc + d.count, 0) ?? 0
@@ -99,6 +104,16 @@
 			/>
 		</div>
 	</section>
+
+	<!-- Setup gaps — surfaces only when at least one rule fires. -->
+	{#if suggestionItems.length > 0}
+		<section class="space-y-2">
+			<div class="text-[10px] font-semibold tracking-wider text-zinc-400 uppercase">
+				Setup gaps
+			</div>
+			<SuggestionsRow items={suggestionItems} loading={suggestions.loading} />
+		</section>
+	{/if}
 
 	<!-- Content pipeline -->
 	<section class="space-y-2">

--- a/webui/src/routes/chats/graph/+page.svelte
+++ b/webui/src/routes/chats/graph/+page.svelte
@@ -1,26 +1,87 @@
 <script lang="ts">
 	import ChatTreeNode from '$lib/components/chat/ChatTreeNode.svelte';
+	import {
+		collectIds,
+		computeStats,
+		enrichTree,
+		filterTree,
+		type EnrichedNode
+	} from '$lib/components/chat/tree';
 	import * as Card from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
+	import { ChevronsDownUp, ChevronsUpDown, RefreshCw, Search } from '@lucide/svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 	import type { components } from '$lib/api/types';
 
 	type Tree = components['schemas']['ChatNode'][];
 	const tree = useLivePoll<Tree>('/api/chats/graph', 60_000);
 
-	const totalChats = $derived.by(() => {
-		const count = (nodes: Tree): number =>
-			nodes.reduce((acc, n) => acc + 1 + count(n.children), 0);
-		return tree.data ? count(tree.data) : 0;
+	let query = $state('');
+
+	const enrichedRoots = $derived(tree.data ? enrichTree(tree.data) : []);
+	const filteredRoots = $derived(filterTree(enrichedRoots, query));
+	const stats = $derived(computeStats(enrichedRoots));
+
+	const expandedIds = new SvelteSet<number>();
+	let seeded = false;
+
+	function seed(roots: EnrichedNode[]) {
+		const visit = (n: EnrichedNode): void => {
+			if (n.depth < 2) expandedIds.add(n.id);
+			n.children.forEach(visit);
+		};
+		roots.forEach(visit);
+	}
+
+	function expandAll() {
+		const all = collectIds(enrichedRoots);
+		for (const id of all) expandedIds.add(id);
+	}
+
+	function collapseAll() {
+		expandedIds.clear();
+	}
+
+	// While there's an active filter, expand every visible node so matches
+	// aren't hidden behind a collapsed ancestor — restore on clear.
+	let preFilterExpansion: number[] = [];
+	let filterApplied = false;
+	$effect(() => {
+		if (!seeded && enrichedRoots.length > 0) {
+			seed(enrichedRoots);
+			seeded = true;
+		}
+		const q = query.trim();
+		if (q && !filterApplied) {
+			preFilterExpansion = Array.from(expandedIds);
+			const all = collectIds(enrichedRoots);
+			for (const id of all) expandedIds.add(id);
+			filterApplied = true;
+		}
+		if (!q && filterApplied) {
+			expandedIds.clear();
+			for (const id of preFilterExpansion) expandedIds.add(id);
+			filterApplied = false;
+		}
 	});
+
+	function fmtDepth(d: number): string {
+		// stats.maxDepth is 0 for a single-node tree; humans expect levels = depth+1.
+		return enrichedRoots.length === 0 ? '—' : String(d + 1);
+	}
 </script>
 
-<div class="mx-auto max-w-3xl space-y-4 px-6 py-6">
+<div class="mx-auto max-w-4xl space-y-4 px-6 py-6">
 	<header class="flex items-baseline justify-between">
-		<h2 class="text-lg font-semibold tracking-tight">Chat graph</h2>
+		<div>
+			<h2 class="text-lg font-semibold tracking-tight">Chat graph</h2>
+			<p class="mt-0.5 text-xs text-zinc-500">
+				Hierarchical view of every managed chat. Click a node to drill into the chat detail
+				page.
+			</p>
+		</div>
 		<div class="flex items-center gap-3 text-xs text-zinc-500">
-			{#if !tree.loading && tree.data}
-				<span>{totalChats} chats</span>
-			{/if}
 			{#if tree.error}
 				<span class="text-red-600">Error: {tree.error}</span>
 			{:else if tree.lastUpdatedAt}
@@ -28,29 +89,92 @@
 			{/if}
 			<button
 				type="button"
-				class="rounded-md border border-zinc-200 px-2 py-1 text-xs font-medium hover:bg-zinc-100"
+				class="flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs font-medium hover:bg-zinc-100"
 				onclick={() => tree.refresh()}
 			>
-				Refresh
+				<RefreshCw class="h-3 w-3" />
+				<span>Refresh</span>
 			</button>
 		</div>
 	</header>
 
+	<!-- Stats strip: total chats / roots / max depth / biggest network -->
+	<div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+		<div class="rounded-lg border border-zinc-200 bg-white px-4 py-3">
+			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Chats</div>
+			<div class="mt-0.5 text-xl font-semibold tracking-tight text-zinc-900">{stats.total}</div>
+		</div>
+		<div class="rounded-lg border border-zinc-200 bg-white px-4 py-3">
+			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Networks</div>
+			<div class="mt-0.5 text-xl font-semibold tracking-tight text-zinc-900">{stats.rootCount}</div>
+		</div>
+		<div class="rounded-lg border border-zinc-200 bg-white px-4 py-3">
+			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Max depth</div>
+			<div class="mt-0.5 text-xl font-semibold tracking-tight text-zinc-900">
+				{fmtDepth(stats.maxDepth)}
+			</div>
+		</div>
+		<div class="rounded-lg border border-zinc-200 bg-white px-4 py-3">
+			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">
+				Biggest network
+			</div>
+			<div class="mt-0.5 text-xl font-semibold tracking-tight text-zinc-900">
+				{stats.biggestNetwork || '—'}
+			</div>
+		</div>
+	</div>
+
+	<!-- Toolbar: search + expand/collapse -->
+	<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+		<div class="relative max-w-sm flex-1">
+			<Search class="pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-zinc-400" />
+			<Input
+				bind:value={query}
+				placeholder="Filter by title, notes or id…"
+				class="pl-8"
+			/>
+		</div>
+		<div class="flex items-center gap-2">
+			<button
+				type="button"
+				class="flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs font-medium hover:bg-zinc-100 disabled:opacity-50"
+				disabled={enrichedRoots.length === 0}
+				onclick={expandAll}
+			>
+				<ChevronsUpDown class="h-3 w-3" />
+				<span>Expand all</span>
+			</button>
+			<button
+				type="button"
+				class="flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs font-medium hover:bg-zinc-100 disabled:opacity-50"
+				disabled={enrichedRoots.length === 0}
+				onclick={collapseAll}
+			>
+				<ChevronsDownUp class="h-3 w-3" />
+				<span>Collapse all</span>
+			</button>
+		</div>
+	</div>
+
 	<Card.Root>
 		<Card.Content class="py-4">
-			{#if tree.loading}
+			{#if tree.loading && !tree.data}
 				<p class="text-sm text-zinc-500">Loading…</p>
-			{:else if tree.error}
+			{:else if tree.error && !tree.data}
 				<p class="text-sm text-red-600">Error: {tree.error}</p>
-			{:else if !tree.data || tree.data.length === 0}
+			{:else if enrichedRoots.length === 0}
 				<p class="text-sm text-zinc-500">
-					No chats found. Set <code class="rounded bg-zinc-100 px-1 py-0.5 text-xs">parent_chat_id</code> on any
-					chat row to build the tree.
+					No chats found. Set <code class="rounded bg-zinc-100 px-1 py-0.5 text-xs">parent_chat_id</code>
+					on any chat row to build the tree.
+				</p>
+			{:else if filteredRoots.length === 0}
+				<p class="text-sm text-zinc-500">
+					No matches for <span class="font-medium text-zinc-700">"{query}"</span>.
 				</p>
 			{:else}
-				<ul class="space-y-1">
-					{#each tree.data as root (root.id)}
-						<ChatTreeNode node={root} />
+				<ul class="space-y-0.5">
+					{#each filteredRoots as root (root.id)}
+						<ChatTreeNode node={root} {expandedIds} {query} />
 					{/each}
 				</ul>
 			{/if}


### PR DESCRIPTION
## Summary

Three commits that landed locally but never pushed before PR #82 was squash-merged. Restoring them onto `main` so the work isn't lost.

- **`/api/suggestions` + Setup-gaps row** — 7 mechanical setup-gap rules (disabled channel, channel without sources, channel without username, unmoderated chat, silent chat, orphan chat, network without channel) surfacing on the dashboard between the attention bar and content pipeline. Hides itself when no rules fire.
- **Chat graph polish** — `/chats/graph` gains a search box, 4-card stats strip (Chats / Networks / Max depth / Biggest network), Expand-all / Collapse-all buttons, depth-2 default expansion seeded once, avatar circles with deterministic 8-color palette, and `<mark>` highlighting on title + relation_notes during search. Recursive `subtreeSize` pill on each branch. Polling-resilient via shared `SvelteSet<number>` state.
- **Snapshot loop title refresh** — `_refresh_stale_metadata` opportunistically syncs `Chat.title` from Telegram each tick when the row hasn't been touched for 24h+. Admin edits within the window remain authoritative.

No schema changes. Endpoints are read-only. Foundation for upcoming `webui/chat-info-sync` work (avatar fetching, manual refresh button, `last_synced_at` column).

## API additions

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/api/suggestions` | List of `SuggestionItem` (kind, severity, title, hint, action_url) |

## Test plan

- [x] `pytest tests/webapi/test_suggestions.py tests/webapi/test_snapshot_loop.py` — 17/17 pass
- [x] `ruff check app tests` clean
- [x] `ty check app tests` no new diagnostics
- [x] `svelte-check` 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)