### PR TITLE
feat(webui): chat avatars + manual refresh + decoupled sync timestamp

### DIFF
--- a/alembic/versions/a8b9c0d1e2f3_add_chat_photo_and_sync.py
+++ b/alembic/versions/a8b9c0d1e2f3_add_chat_photo_and_sync.py
@@ -1,0 +1,37 @@
+"""Add chat photo_file_id + last_synced_at columns.
+
+Decouples Telethon-driven syncs from admin-driven edits:
+* ``photo_file_id`` caches the Bot API ``photo.big_file_id`` (or Telethon
+  ``photo_id`` fallback) so the UI can render avatars without re-querying
+  Telegram on every page load.
+* ``last_synced_at`` records the timestamp of the most recent metadata
+  pull from Telegram. Until now the snapshot loop's staleness check
+  piggy-backed on ``modified_at``, which also bumps when admins edit a
+  row from the web UI — so an admin save would suppress the next 24h of
+  Telegram refreshes. ``last_synced_at`` records sync-time only; admin
+  writes leave it alone.
+
+Revision ID: a8b9c0d1e2f3
+Revises: f7a8b9c0d1e2
+Create Date: 2026-04-29 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a8b9c0d1e2f3"
+down_revision: str | None = "f7a8b9c0d1e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("chats", sa.Column("photo_file_id", sa.String(), nullable=True))
+    op.add_column("chats", sa.Column("last_synced_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("chats", "last_synced_at")
+    op.drop_column("chats", "photo_file_id")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -52,6 +52,8 @@ class Chat(Base):
         index=True,
     )
     relation_notes: Mapped[str | None] = mapped_column(String, nullable=True)
+    photo_file_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    last_synced_at: Mapped[datetime.datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(DateTime, default=utc_now)
     modified_at: Mapped[datetime.datetime] = mapped_column(
         DateTime,

--- a/app/webapi/main.py
+++ b/app/webapi/main.py
@@ -50,7 +50,13 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("publish_bot_started")
     task: asyncio.Task[None] | None = None
     if telethon is not None:
-        task = asyncio.create_task(run_snapshot_loop(session_maker=session_maker, telethon=telethon))
+        task = asyncio.create_task(
+            run_snapshot_loop(
+                session_maker=session_maker,
+                telethon=telethon,
+                bot=_app.state.publish_bot,
+            )
+        )
         logger.info("snapshot_loop started")
     else:
         logger.info("snapshot_loop not started — telethon unavailable")

--- a/app/webapi/routes/chats.py
+++ b/app/webapi/routes/chats.py
@@ -11,15 +11,27 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import io
 from typing import Annotated
 
+from aiogram import Bot
+from aiogram.exceptions import TelegramBadRequest
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.logging import get_logger
 from app.core.time import utc_now
 from app.db.models import Chat, ChatMemberSnapshot, Message, SpamPing, User
-from app.webapi.deps import get_session, get_telethon_stats, require_super_admin
+from app.telethon.telethon_client import TelethonClient
+from app.webapi.deps import (
+    get_publish_bot,
+    get_session,
+    get_telethon,
+    get_telethon_stats,
+    require_super_admin,
+)
 from app.webapi.schemas import (
     ChatDetail,
     ChatNode,
@@ -30,7 +42,10 @@ from app.webapi.schemas import (
     MemberSnapshotPoint,
     SpamPingRead,
 )
+from app.webapi.services.chat_sync import fetch_chat_photo_file_id
 from app.webapi.services.telethon_stats import TelethonStatsService
+
+logger = get_logger("webapi.routes.chats")
 
 router = APIRouter(prefix="/chats", tags=["chats"])
 
@@ -68,6 +83,8 @@ async def list_chats(
             parent_chat_id=chat.parent_chat_id,
             relation_notes=chat.relation_notes,
             member_count=member_count,
+            has_photo=chat.photo_file_id is not None,
+            last_synced_at=chat.last_synced_at,
             created_at=chat.created_at,
         )
         for chat, member_count in zip(chats, member_counts, strict=True)
@@ -92,7 +109,14 @@ async def get_chat_graph(
     """
     chats = (await session.execute(select(Chat))).scalars().all()
     by_id: dict[int, ChatNode] = {
-        c.id: ChatNode(id=c.id, title=c.title, relation_notes=c.relation_notes, children=[]) for c in chats
+        c.id: ChatNode(
+            id=c.id,
+            title=c.title,
+            relation_notes=c.relation_notes,
+            has_photo=c.photo_file_id is not None,
+            children=[],
+        )
+        for c in chats
     }
     roots: list[ChatNode] = []
     for c in chats:
@@ -157,7 +181,14 @@ async def get_chat(
         (await session.execute(select(Chat).where(Chat.parent_chat_id == chat_id).order_by(Chat.title))).scalars().all()
     )
     children_nodes = [
-        ChatNode(id=c.id, title=c.title, relation_notes=c.relation_notes, children=[]) for c in children_rows
+        ChatNode(
+            id=c.id,
+            title=c.title,
+            relation_notes=c.relation_notes,
+            has_photo=c.photo_file_id is not None,
+            children=[],
+        )
+        for c in children_rows
     ]
 
     spam_rows = (
@@ -229,6 +260,8 @@ async def get_chat(
         parent_chat_id=chat.parent_chat_id,
         relation_notes=chat.relation_notes,
         member_count=member_count,
+        has_photo=chat.photo_file_id is not None,
+        last_synced_at=chat.last_synced_at,
         created_at=chat.created_at,
         welcome_message=chat.welcome_message,
         time_delete=chat.time_delete,
@@ -276,5 +309,110 @@ async def update_chat(
         parent_chat_id=chat.parent_chat_id,
         relation_notes=chat.relation_notes,
         member_count=member_count,
+        has_photo=chat.photo_file_id is not None,
+        last_synced_at=chat.last_synced_at,
+        created_at=chat.created_at,
+    )
+
+
+@router.get("/{chat_id}/avatar")
+async def get_chat_avatar(
+    chat_id: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    bot: Annotated[Bot, Depends(get_publish_bot)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> StreamingResponse:
+    """Stream the chat's avatar JPEG.
+
+    Reads the cached ``photo_file_id`` from the row, calls Bot API
+    ``getFile`` to resolve the file_path, then proxies ``download_file``
+    bytes back to the client. We proxy rather than 302-redirecting because
+    the Telegram file URL contains the bot token; redirecting would leak it.
+
+    Browsers cache the response for 1h via Cache-Control. Cached bytes
+    invalidate naturally when ``photo_file_id`` changes (the URL stays the
+    same but the bytes don't — we accept the staleness window since the
+    icon swap on rename is a low-impact event for an admin tool).
+    """
+    chat = (await session.execute(select(Chat).where(Chat.id == chat_id))).scalar_one_or_none()
+    if chat is None:
+        raise HTTPException(status_code=404, detail=f"Chat {chat_id} not found")
+    if chat.photo_file_id is None:
+        raise HTTPException(status_code=404, detail="No avatar cached")
+
+    try:
+        downloaded = await bot.download(chat.photo_file_id)
+    except TelegramBadRequest as e:
+        # File expired upstream — clear cache so next sync re-pulls.
+        logger.warning("avatar download failed", chat_id=chat_id, error=str(e))
+        chat.photo_file_id = None
+        await session.commit()
+        raise HTTPException(status_code=404, detail="Avatar unavailable") from None
+
+    if downloaded is None:
+        raise HTTPException(status_code=404, detail="Avatar unavailable")
+
+    payload = downloaded.read()
+    return StreamingResponse(
+        io.BytesIO(payload),
+        media_type="image/jpeg",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@router.post("/{chat_id}/refresh", response_model=ChatRead)
+async def refresh_chat_from_telegram(
+    chat_id: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    bot: Annotated[Bot, Depends(get_publish_bot)],
+    stats: Annotated[TelethonStatsService, Depends(get_telethon_stats)],
+    telethon: Annotated[TelethonClient | None, Depends(get_telethon)],
+    _admin_id: Annotated[int, Depends(require_super_admin)],
+) -> ChatRead:
+    """Synchronously pull latest title + photo from Telegram for one chat.
+
+    Manual counterpart to the hourly snapshot loop. Updates ``title`` (only
+    if upstream gave us a non-empty string), ``photo_file_id``, and bumps
+    ``last_synced_at`` to now. Member count is not refreshed here because
+    it's served live by the TelethonStatsService cache (60–300s TTL) — a
+    separate refresh would burn a Telethon RPC for marginal recency gain.
+
+    Telethon is optional; missing it just means we skip the title-sync leg
+    and the response carries whatever title was already in the DB.
+    """
+    chat = (await session.execute(select(Chat).where(Chat.id == chat_id))).scalar_one_or_none()
+    if chat is None:
+        raise HTTPException(status_code=404, detail=f"Chat {chat_id} not found")
+
+    if telethon is not None and telethon.is_available:
+        try:
+            info = await telethon.get_chat_info(chat_id)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("manual refresh: get_chat_info failed", chat_id=chat_id, error=str(e))
+        else:
+            upstream_title = getattr(info, "title", None) if info is not None else None
+            if isinstance(upstream_title, str) and upstream_title and upstream_title != chat.title:
+                chat.title = upstream_title
+
+    file_id = await fetch_chat_photo_file_id(bot=bot, chat_id=chat_id)
+    if file_id and file_id != chat.photo_file_id:
+        chat.photo_file_id = file_id
+
+    chat.last_synced_at = utc_now()
+    await session.commit()
+    await session.refresh(chat)
+
+    member_count = await stats.get_member_count(chat.id)
+    return ChatRead(
+        id=chat.id,
+        title=chat.title,
+        is_forum=chat.is_forum,
+        is_welcome_enabled=chat.is_welcome_enabled,
+        is_captcha_enabled=chat.is_captcha_enabled,
+        parent_chat_id=chat.parent_chat_id,
+        relation_notes=chat.relation_notes,
+        member_count=member_count,
+        has_photo=chat.photo_file_id is not None,
+        last_synced_at=chat.last_synced_at,
         created_at=chat.created_at,
     )

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -175,6 +175,8 @@ class ChatRead(BaseModel):
     parent_chat_id: int | None = None
     relation_notes: str | None = None
     member_count: int | None = None  # enriched from Telethon, None when unavailable
+    has_photo: bool = False
+    last_synced_at: datetime.datetime | None = None
     created_at: datetime.datetime
 
 
@@ -202,6 +204,7 @@ class ChatNode(BaseModel):
     id: int
     title: str | None
     relation_notes: str | None = None
+    has_photo: bool = False
     children: list[ChatNode] = []
 
 

--- a/app/webapi/services/chat_sync.py
+++ b/app/webapi/services/chat_sync.py
@@ -1,0 +1,46 @@
+"""Helpers for refreshing Chat metadata + photo from Telegram on demand.
+
+Two paths share these helpers:
+* The background snapshot loop (``snapshot_loop.snapshot_once``) calls
+  them on its hourly tick.
+* The manual ``POST /api/chats/{id}/refresh`` endpoint calls them when
+  the admin clicks "Refresh from Telegram" in the web UI.
+
+Title sync uses the Telethon-fed ``ChatInfo`` already in scope. Photo sync
+goes through the Bot API (``getChat`` returns ``photo.big_file_id``) — the
+moderator bot is already a member of every managed chat, so this is the
+right tool. Telethon's ``download_profile_photo`` is byte-only and would
+require a re-upload to obtain a Bot-API file_id; not worth the complexity
+for the marginal coverage of chats the bot somehow can't see.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aiogram.exceptions import TelegramBadRequest
+
+from app.core.logging import get_logger
+
+if TYPE_CHECKING:
+    from aiogram import Bot
+
+logger = get_logger("webapi.chat_sync")
+
+
+async def fetch_chat_photo_file_id(*, bot: Bot, chat_id: int) -> str | None:
+    """Bot API ``getChat`` → ``chat.photo.big_file_id``.
+
+    Returns None when the chat has no photo, the bot can't see it, or any
+    Telegram error occurs. The caller decides whether to keep the previous
+    cached file_id or NULL it out.
+    """
+    try:
+        chat = await bot.get_chat(chat_id)
+    except TelegramBadRequest as e:
+        logger.warning("get_chat failed", chat_id=chat_id, error=str(e))
+        return None
+    photo = getattr(chat, "photo", None)
+    if photo is None:
+        return None
+    return getattr(photo, "big_file_id", None)

--- a/app/webapi/snapshot_loop.py
+++ b/app/webapi/snapshot_loop.py
@@ -23,8 +23,10 @@ from sqlalchemy import select
 from app.core.logging import get_logger
 from app.core.time import utc_now
 from app.db.models import Chat, ChatMemberSnapshot
+from app.webapi.services.chat_sync import fetch_chat_photo_file_id
 
 if TYPE_CHECKING:
+    from aiogram import Bot
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
     from app.telethon.telethon_client import TelethonClient
@@ -62,16 +64,23 @@ async def snapshot_once(
     *,
     session_maker: async_sessionmaker[AsyncSession],
     telethon: TelethonClient | None,
+    bot: Bot | None = None,
 ) -> int:
     """Capture one snapshot per chat. Returns the number of snapshot rows
     written. Stale-metadata refreshes happen opportunistically and are logged
-    separately."""
+    separately.
+
+    If ``bot`` is provided and the chat is past the staleness cutoff, also
+    fetches the chat photo's file_id via Bot API. Photo fetch failures are
+    logged but do not fail the tick.
+    """
     if telethon is None or not telethon.is_available:
         logger.info("snapshot_once skipped — telethon unavailable")
         return 0
 
     written = 0
     refreshed = 0
+    photo_refreshed = 0
     now = utc_now()
     cutoff = now - datetime.timedelta(hours=METADATA_STALENESS_HOURS)
     async with session_maker() as session:
@@ -87,11 +96,22 @@ async def snapshot_once(
             if info.member_count is not None:
                 session.add(ChatMemberSnapshot(chat_id=chat.id, member_count=info.member_count))
                 written += 1
+            sync_due = chat.last_synced_at is None or chat.last_synced_at < cutoff
             if _refresh_stale_metadata(chat, info, cutoff=cutoff):
                 refreshed += 1
+            if sync_due and bot is not None:
+                file_id = await fetch_chat_photo_file_id(bot=bot, chat_id=chat.id)
+                if file_id and file_id != chat.photo_file_id:
+                    chat.photo_file_id = file_id
+                    photo_refreshed += 1
             chat.last_synced_at = now
         await session.commit()
-    logger.info("snapshot_once committed", snapshots=written, metadata_refreshed=refreshed)
+    logger.info(
+        "snapshot_once committed",
+        snapshots=written,
+        metadata_refreshed=refreshed,
+        photo_refreshed=photo_refreshed,
+    )
     return written
 
 
@@ -99,12 +119,13 @@ async def run_snapshot_loop(
     *,
     session_maker: async_sessionmaker[AsyncSession],
     telethon: TelethonClient | None,
+    bot: Bot | None = None,
     interval_seconds: int = SNAPSHOT_INTERVAL_SECONDS,
 ) -> None:
     """Forever-loop. Cancelled on app shutdown via task.cancel()."""
     while True:
         try:
-            await snapshot_once(session_maker=session_maker, telethon=telethon)
+            await snapshot_once(session_maker=session_maker, telethon=telethon, bot=bot)
         except Exception:
             logger.exception("snapshot_loop iteration failed")
         await asyncio.sleep(interval_seconds)

--- a/app/webapi/snapshot_loop.py
+++ b/app/webapi/snapshot_loop.py
@@ -6,9 +6,10 @@ no deduplication. If the process dies, we lose the in-flight tick; no
 state is corrupted because each snapshot is an independent row.
 
 Each tick also opportunistically refreshes Chat.title from Telegram for
-rows that haven't been touched in METADATA_STALENESS_HOURS — admins who
-edited a row recently keep their values, but long-untouched rows pick up
-upstream renames automatically.
+rows whose ``last_synced_at`` is older than ``METADATA_STALENESS_HOURS``.
+The staleness check uses ``last_synced_at`` (not ``modified_at``) so that
+admin edits in the web UI don't suppress Telegram syncs, and Telegram
+syncs don't masquerade as admin edits.
 """
 
 from __future__ import annotations
@@ -35,14 +36,18 @@ METADATA_STALENESS_HOURS = 24
 
 
 def _refresh_stale_metadata(chat: Chat, info: Any, *, cutoff: datetime.datetime) -> bool:
-    """Sync Chat.title from Telegram when the row's been untouched past the cutoff.
+    """Sync Chat.title from Telegram when the row's last_synced_at is past
+    the cutoff (or never set).
 
     Returns True iff the title actually changed — caller uses that to count
     refreshes for the log line. We only sync title because that's the only
     upstream-managed string surfaced in the UI; everything else (welcome,
     captcha, parent, notes) is admin-owned.
+
+    The caller bumps ``last_synced_at`` separately on every successful
+    Telegram pull, regardless of whether title actually changed.
     """
-    if chat.modified_at and chat.modified_at >= cutoff:
+    if chat.last_synced_at and chat.last_synced_at >= cutoff:
         return False
     upstream_title = getattr(info, "title", None)
     if not isinstance(upstream_title, str) or not upstream_title:
@@ -67,7 +72,8 @@ async def snapshot_once(
 
     written = 0
     refreshed = 0
-    cutoff = utc_now() - datetime.timedelta(hours=METADATA_STALENESS_HOURS)
+    now = utc_now()
+    cutoff = now - datetime.timedelta(hours=METADATA_STALENESS_HOURS)
     async with session_maker() as session:
         chats = (await session.execute(select(Chat))).scalars().all()
         for chat in chats:
@@ -83,6 +89,7 @@ async def snapshot_once(
                 written += 1
             if _refresh_stale_metadata(chat, info, cutoff=cutoff):
                 refreshed += 1
+            chat.last_synced_at = now
         await session.commit()
     logger.info("snapshot_once committed", snapshots=written, metadata_refreshed=refreshed)
     return written

--- a/tests/webapi/test_chat_refresh.py
+++ b/tests/webapi/test_chat_refresh.py
@@ -1,0 +1,164 @@
+"""Tests for POST /api/chats/{id}/refresh and GET /api/chats/{id}/avatar.
+
+The refresh endpoint exercises ``fetch_chat_photo_file_id`` (Bot API
+``getChat``) and the optional Telethon title sync. The avatar endpoint
+proxies bytes via ``Bot.download``. Both rely on a publish_bot override.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from app.core.config import settings
+from app.db.models import Chat
+from app.webapi.main import app
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+def _bot_with_photo(file_id: str) -> MagicMock:
+    """Bot mock whose get_chat returns a chat with a photo of file_id."""
+    bot = MagicMock()
+    bot.get_chat = AsyncMock(return_value=MagicMock(photo=MagicMock(big_file_id=file_id, small_file_id="small")))
+    bot.download = AsyncMock(return_value=io.BytesIO(b"\xff\xd8\xff\xe0jpegbytes"))
+    return bot
+
+
+def _bot_without_photo() -> MagicMock:
+    bot = MagicMock()
+    bot.get_chat = AsyncMock(return_value=MagicMock(photo=None))
+    bot.download = AsyncMock(return_value=None)
+    return bot
+
+
+@pytest.fixture
+def client_factory(db_session_maker):
+    from app.webapi.deps import get_publish_bot, get_session, get_telethon
+
+    bot_holder: dict[str, MagicMock] = {"bot": _bot_with_photo("photo-file-id-1")}
+    telethon_holder: dict[str, object] = {"telethon": None}
+
+    async def _override_session():
+        async with db_session_maker() as s:
+            yield s
+
+    async def _override_publish_bot():
+        return bot_holder["bot"]
+
+    async def _override_telethon():
+        return telethon_holder["telethon"]
+
+    app.dependency_overrides[get_session] = _override_session
+    app.dependency_overrides[get_publish_bot] = _override_publish_bot
+    app.dependency_overrides[get_telethon] = _override_telethon
+    settings.admin.super_admins = [1]
+    settings.webapi.dev_bypass_auth = True
+    transport = ASGITransport(app=app)
+
+    def make() -> AsyncClient:
+        return AsyncClient(transport=transport, base_url="http://test")
+
+    yield make, bot_holder, telethon_holder
+    app.dependency_overrides.pop(get_session, None)
+    app.dependency_overrides.pop(get_publish_bot, None)
+    app.dependency_overrides.pop(get_telethon, None)
+
+
+async def test_refresh_caches_photo_file_id(client_factory, db_session_maker) -> None:
+    make, _bot_holder, _telethon_holder = client_factory
+    async with db_session_maker() as s:
+        s.add(Chat(id=-7001, title="A"))
+        await s.commit()
+
+    async with make() as client:
+        resp = await client.post("/api/chats/-7001/refresh")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["has_photo"] is True
+    assert body["last_synced_at"] is not None
+
+    async with db_session_maker() as s:
+        chat = (await s.execute(select(Chat).where(Chat.id == -7001))).scalar_one()
+    assert chat.photo_file_id == "photo-file-id-1"
+    assert chat.last_synced_at is not None
+
+
+async def test_refresh_clears_photo_when_chat_has_none(client_factory, db_session_maker) -> None:
+    """Chat had a cached photo, then was un-set upstream — refresh keeps the
+    old cache (we only overwrite on positive responses; we don't actively
+    null-out, since a transient API hiccup shouldn't blow away the icon)."""
+    make, bot_holder, _telethon_holder = client_factory
+    bot_holder["bot"] = _bot_without_photo()
+    async with db_session_maker() as s:
+        chat = Chat(id=-7002, title="B")
+        chat.photo_file_id = "stale-cached-id"
+        s.add(chat)
+        await s.commit()
+
+    async with make() as client:
+        resp = await client.post("/api/chats/-7002/refresh")
+
+    assert resp.status_code == 200
+    async with db_session_maker() as s:
+        chat = (await s.execute(select(Chat).where(Chat.id == -7002))).scalar_one()
+    assert chat.photo_file_id == "stale-cached-id"
+
+
+async def test_refresh_syncs_title_via_telethon(client_factory, db_session_maker) -> None:
+    make, _bot_holder, telethon_holder = client_factory
+    tc = MagicMock()
+    tc.is_available = True
+    tc.get_chat_info = AsyncMock(return_value=MagicMock(title="Renamed Live", member_count=42))
+    telethon_holder["telethon"] = tc
+
+    async with db_session_maker() as s:
+        s.add(Chat(id=-7003, title="Old DB Title"))
+        await s.commit()
+
+    async with make() as client:
+        resp = await client.post("/api/chats/-7003/refresh")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["title"] == "Renamed Live"
+
+
+async def test_refresh_returns_404_for_unknown_chat(client_factory) -> None:
+    make, _bot_holder, _telethon_holder = client_factory
+    async with make() as client:
+        resp = await client.post("/api/chats/-9999/refresh")
+    assert resp.status_code == 404
+
+
+async def test_avatar_proxies_bytes(client_factory, db_session_maker) -> None:
+    make, _bot_holder, _telethon_holder = client_factory
+    async with db_session_maker() as s:
+        chat = Chat(id=-7004, title="C")
+        chat.photo_file_id = "photo-file-id-1"
+        s.add(chat)
+        await s.commit()
+
+    async with make() as client:
+        resp = await client.get("/api/chats/-7004/avatar")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/jpeg"
+    assert resp.headers["cache-control"] == "public, max-age=3600"
+    assert resp.content.startswith(b"\xff\xd8\xff\xe0")  # JPEG SOI marker
+
+
+async def test_avatar_returns_404_when_no_cache(client_factory, db_session_maker) -> None:
+    make, _bot_holder, _telethon_holder = client_factory
+    async with db_session_maker() as s:
+        s.add(Chat(id=-7005, title="D"))
+        await s.commit()
+
+    async with make() as client:
+        resp = await client.get("/api/chats/-7005/avatar")
+
+    assert resp.status_code == 404

--- a/tests/webapi/test_snapshot_loop.py
+++ b/tests/webapi/test_snapshot_loop.py
@@ -59,11 +59,11 @@ async def test_snapshot_once_writes_rows_for_each_chat(
 async def test_snapshot_once_refreshes_stale_chat_title(
     db_session_maker: async_sessionmaker[AsyncSession],
 ) -> None:
-    """A chat untouched for >24h picks up its current Telegram title."""
+    """A chat last synced >24h ago (or never) picks up its current Telegram title."""
     old = utc_now() - datetime.timedelta(hours=METADATA_STALENESS_HOURS + 1)
     async with db_session_maker() as session:
         stale = Chat(id=-300, title="Old Name")
-        stale.modified_at = old
+        stale.last_synced_at = old
         session.add(stale)
         await session.commit()
 
@@ -76,17 +76,20 @@ async def test_snapshot_once_refreshes_stale_chat_title(
     async with db_session_maker() as session:
         chat = (await session.execute(select(Chat).where(Chat.id == -300))).scalar_one()
     assert chat.title == "Renamed Upstream"
+    # Sync timestamp must now be recent, so the next tick won't re-refresh.
+    assert chat.last_synced_at is not None
+    assert chat.last_synced_at > utc_now() - datetime.timedelta(minutes=1)
 
 
-async def test_snapshot_once_does_not_overwrite_recent_chat(
+async def test_snapshot_once_skips_recently_synced_chat(
     db_session_maker: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Admin edited the row within the staleness window — Telethon's title
-    should NOT win, because we treat recent admin activity as authoritative."""
+    """Title sync was performed <24h ago — Telethon is queried for member
+    counts but title is NOT overwritten."""
     fresh = utc_now() - datetime.timedelta(hours=1)
     async with db_session_maker() as session:
-        chat = Chat(id=-400, title="Admin's Choice")
-        chat.modified_at = fresh
+        chat = Chat(id=-400, title="Cached Title")
+        chat.last_synced_at = fresh
         session.add(chat)
         await session.commit()
 
@@ -98,17 +101,69 @@ async def test_snapshot_once_does_not_overwrite_recent_chat(
 
     async with db_session_maker() as session:
         chat = (await session.execute(select(Chat).where(Chat.id == -400))).scalar_one()
-    assert chat.title == "Admin's Choice"
+    assert chat.title == "Cached Title"
+
+
+async def test_snapshot_once_admin_edit_does_not_block_title_sync(
+    db_session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Admin edited the row from the web UI 5 minutes ago. last_synced_at
+    is stale, so Telethon's title should still win — admin edits no longer
+    suppress upstream syncs (unlike the previous modified_at-based check)."""
+    stale_sync = utc_now() - datetime.timedelta(hours=METADATA_STALENESS_HOURS + 1)
+    fresh_admin_edit = utc_now() - datetime.timedelta(minutes=5)
+    async with db_session_maker() as session:
+        chat = Chat(id=-450, title="Old DB Title")
+        chat.last_synced_at = stale_sync
+        chat.modified_at = fresh_admin_edit
+        session.add(chat)
+        await session.commit()
+
+    tc = MagicMock()
+    tc.is_available = True
+    tc.get_chat_info = AsyncMock(return_value=MagicMock(member_count=12, title="Live Telegram"))
+
+    await snapshot_once(session_maker=db_session_maker, telethon=tc)
+
+    async with db_session_maker() as session:
+        chat = (await session.execute(select(Chat).where(Chat.id == -450))).scalar_one()
+    assert chat.title == "Live Telegram"
+
+
+async def test_snapshot_once_first_sync_for_brand_new_chat(
+    db_session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A chat with last_synced_at=NULL must be treated as stale (never synced)
+    and pick up the upstream title on the first tick."""
+    async with db_session_maker() as session:
+        chat = Chat(id=-460, title="Placeholder")
+        # last_synced_at left as NULL (default) — simulates a chat that's
+        # been added to the DB by some pathway other than the snapshot loop.
+        session.add(chat)
+        await session.commit()
+
+    tc = MagicMock()
+    tc.is_available = True
+    tc.get_chat_info = AsyncMock(return_value=MagicMock(member_count=3, title="Real Name"))
+
+    await snapshot_once(session_maker=db_session_maker, telethon=tc)
+
+    async with db_session_maker() as session:
+        chat = (await session.execute(select(Chat).where(Chat.id == -460))).scalar_one()
+    assert chat.title == "Real Name"
+    assert chat.last_synced_at is not None
 
 
 async def test_snapshot_once_skips_unchanged_title(
     db_session_maker: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Same title in DB and Telegram — no UPDATE fires, modified_at stays put."""
+    """Same title in DB and Telegram — title field is not re-assigned
+    (no UPDATE for that column), but last_synced_at is still bumped because
+    we successfully pulled fresh data from Telegram."""
     old = utc_now() - datetime.timedelta(hours=METADATA_STALENESS_HOURS + 1)
     async with db_session_maker() as session:
         chat = Chat(id=-500, title="Same Name")
-        chat.modified_at = old
+        chat.last_synced_at = old
         session.add(chat)
         await session.commit()
 
@@ -120,6 +175,8 @@ async def test_snapshot_once_skips_unchanged_title(
 
     async with db_session_maker() as session:
         chat = (await session.execute(select(Chat).where(Chat.id == -500))).scalar_one()
-    # modified_at must remain the original value because no actual UPDATE
-    # happened — the row didn't get bumped just from being inspected.
-    assert chat.modified_at < utc_now() - datetime.timedelta(hours=METADATA_STALENESS_HOURS)
+    assert chat.title == "Same Name"
+    # last_synced_at must be bumped — successful query counts as a sync
+    # even if title didn't change.
+    assert chat.last_synced_at is not None
+    assert chat.last_synced_at > utc_now() - datetime.timedelta(minutes=1)

--- a/tests/webapi/test_snapshot_loop.py
+++ b/tests/webapi/test_snapshot_loop.py
@@ -154,6 +154,53 @@ async def test_snapshot_once_first_sync_for_brand_new_chat(
     assert chat.last_synced_at is not None
 
 
+async def test_snapshot_once_caches_photo_file_id_via_bot(
+    db_session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """When a bot is supplied, snapshot_once also pulls and caches the
+    chat photo's big_file_id from Bot API getChat."""
+    async with db_session_maker() as session:
+        session.add(Chat(id=-600, title="Cap"))
+        await session.commit()
+
+    tc = MagicMock()
+    tc.is_available = True
+    tc.get_chat_info = AsyncMock(return_value=MagicMock(member_count=8, title="Cap"))
+
+    bot = MagicMock()
+    bot.get_chat = AsyncMock(return_value=MagicMock(photo=MagicMock(big_file_id="bot-photo-1", small_file_id="s")))
+
+    await snapshot_once(session_maker=db_session_maker, telethon=tc, bot=bot)
+
+    async with db_session_maker() as session:
+        chat = (await session.execute(select(Chat).where(Chat.id == -600))).scalar_one()
+    assert chat.photo_file_id == "bot-photo-1"
+
+
+async def test_snapshot_once_skips_photo_fetch_when_recently_synced(
+    db_session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A chat with last_synced_at <24h ago doesn't trigger a Bot API call,
+    saving rate-limit budget for chats that actually need it."""
+    fresh = utc_now() - datetime.timedelta(hours=1)
+    async with db_session_maker() as session:
+        chat = Chat(id=-610, title="Fresh")
+        chat.last_synced_at = fresh
+        session.add(chat)
+        await session.commit()
+
+    tc = MagicMock()
+    tc.is_available = True
+    tc.get_chat_info = AsyncMock(return_value=MagicMock(member_count=3, title="Fresh"))
+
+    bot = MagicMock()
+    bot.get_chat = AsyncMock()
+
+    await snapshot_once(session_maker=db_session_maker, telethon=tc, bot=bot)
+
+    bot.get_chat.assert_not_called()
+
+
 async def test_snapshot_once_skips_unchanged_title(
     db_session_maker: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -418,6 +418,65 @@ export interface paths {
         patch: operations["update_chat_api_chats__chat_id__patch"];
         trace?: never;
     };
+    "/api/chats/{chat_id}/avatar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Chat Avatar
+         * @description Stream the chat's avatar JPEG.
+         *
+         *     Reads the cached ``photo_file_id`` from the row, calls Bot API
+         *     ``getFile`` to resolve the file_path, then proxies ``download_file``
+         *     bytes back to the client. We proxy rather than 302-redirecting because
+         *     the Telegram file URL contains the bot token; redirecting would leak it.
+         *
+         *     Browsers cache the response for 1h via Cache-Control. Cached bytes
+         *     invalidate naturally when ``photo_file_id`` changes (the URL stays the
+         *     same but the bytes don't — we accept the staleness window since the
+         *     icon swap on rename is a low-impact event for an admin tool).
+         */
+        get: operations["get_chat_avatar_api_chats__chat_id__avatar_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chats/{chat_id}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh Chat From Telegram
+         * @description Synchronously pull latest title + photo from Telegram for one chat.
+         *
+         *     Manual counterpart to the hourly snapshot loop. Updates ``title`` (only
+         *     if upstream gave us a non-empty string), ``photo_file_id``, and bumps
+         *     ``last_synced_at`` to now. Member count is not refreshed here because
+         *     it's served live by the TelethonStatsService cache (60–300s TTL) — a
+         *     separate refresh would burn a Telethon RPC for marginal recency gain.
+         *
+         *     Telethon is optional; missing it just means we skip the title-sync leg
+         *     and the response carries whatever title was already in the DB.
+         */
+        post: operations["refresh_chat_from_telegram_api_chats__chat_id__refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/costs/session": {
         parameters: {
             query?: never;
@@ -968,6 +1027,13 @@ export interface components {
             /** Member Count */
             member_count?: number | null;
             /**
+             * Has Photo
+             * @default false
+             */
+            has_photo: boolean;
+            /** Last Synced At */
+            last_synced_at?: string | null;
+            /**
              * Created At
              * Format: date-time
              */
@@ -1032,6 +1098,11 @@ export interface components {
             /** Relation Notes */
             relation_notes?: string | null;
             /**
+             * Has Photo
+             * @default false
+             */
+            has_photo: boolean;
+            /**
              * Children
              * @default []
              */
@@ -1058,6 +1129,13 @@ export interface components {
             relation_notes?: string | null;
             /** Member Count */
             member_count?: number | null;
+            /**
+             * Has Photo
+             * @default false
+             */
+            has_photo: boolean;
+            /** Last Synced At */
+            last_synced_at?: string | null;
             /**
              * Created At
              * Format: date-time
@@ -2486,6 +2564,68 @@ export interface operations {
                 "application/json": components["schemas"]["ChatUpdate"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_chat_avatar_api_chats__chat_id__avatar_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    refresh_chat_from_telegram_api_chats__chat_id__refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {

--- a/webui/src/lib/components/chat/ChatAvatar.svelte
+++ b/webui/src/lib/components/chat/ChatAvatar.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { hashId, initialsFor } from './tree';
+
+	type Props = {
+		chatId: number;
+		title: string | null;
+		hasPhoto: boolean;
+		size?: 'xs' | 'sm' | 'md' | 'lg';
+	};
+	let { chatId, title, hasPhoto, size = 'sm' }: Props = $props();
+
+	// Lazy fallback to initials if the image fails to decode (e.g. file_id
+	// went stale before the next snapshot tick rotated it). The state flag
+	// is keyed by chatId so the component re-arms when the parent recycles
+	// it across rows.
+	let imgFailed = $state(false);
+	$effect(() => {
+		// trigger re-eval whenever chatId changes
+		void chatId;
+		imgFailed = false;
+	});
+
+	const palette = [
+		'bg-amber-100 text-amber-700',
+		'bg-emerald-100 text-emerald-700',
+		'bg-sky-100 text-sky-700',
+		'bg-violet-100 text-violet-700',
+		'bg-rose-100 text-rose-700',
+		'bg-fuchsia-100 text-fuchsia-700',
+		'bg-lime-100 text-lime-700',
+		'bg-orange-100 text-orange-700'
+	];
+	const fallbackClass = $derived(palette[hashId(chatId) % palette.length]);
+	const initials = $derived(initialsFor(title, chatId));
+
+	const dim = $derived(
+		size === 'xs'
+			? 'h-5 w-5 text-[9px]'
+			: size === 'sm'
+				? 'h-6 w-6 text-[10px]'
+				: size === 'md'
+					? 'h-8 w-8 text-xs'
+					: 'h-10 w-10 text-sm'
+	);
+	const showPhoto = $derived(hasPhoto && !imgFailed);
+</script>
+
+{#if showPhoto}
+	<img
+		src={`/api/chats/${chatId}/avatar`}
+		alt=""
+		class="{dim} shrink-0 rounded-full object-cover"
+		loading="lazy"
+		onerror={() => (imgFailed = true)}
+	/>
+{:else}
+	<span
+		class="{dim} {fallbackClass} flex shrink-0 items-center justify-center rounded-full font-semibold tracking-tight"
+		aria-hidden="true"
+	>
+		{initials}
+	</span>
+{/if}

--- a/webui/src/lib/components/chat/ChatTreeNode.svelte
+++ b/webui/src/lib/components/chat/ChatTreeNode.svelte
@@ -4,7 +4,8 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { untrack } from 'svelte';
 	import Self from './ChatTreeNode.svelte';
-	import { hashId, initialsFor, type EnrichedNode } from './tree';
+	import ChatAvatar from './ChatAvatar.svelte';
+	import { type EnrichedNode } from './tree';
 
 	type Props = {
 		node: EnrichedNode;
@@ -31,18 +32,6 @@
 		}
 	}
 
-	const palette = [
-		'bg-amber-100 text-amber-700',
-		'bg-emerald-100 text-emerald-700',
-		'bg-sky-100 text-sky-700',
-		'bg-violet-100 text-violet-700',
-		'bg-rose-100 text-rose-700',
-		'bg-fuchsia-100 text-fuchsia-700',
-		'bg-lime-100 text-lime-700',
-		'bg-orange-100 text-orange-700'
-	];
-	const avatarClass = $derived(palette[hashId(node.id) % palette.length]);
-	const initials = $derived(initialsFor(node.title, node.id));
 	const label = $derived(node.title ?? `#${node.id}`);
 
 	type Segment = { text: string; matched: boolean };
@@ -90,12 +79,8 @@
 			<span class="h-5 w-5 shrink-0"></span>
 		{/if}
 
-		<span
-			class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold tracking-tight {avatarClass}"
-			aria-hidden="true"
-		>
-			{initials}
-		</span>
+		<ChatAvatar chatId={node.id} title={node.title} hasPhoto={node.has_photo} />
+
 
 		<button
 			type="button"

--- a/webui/src/lib/components/chat/tree.ts
+++ b/webui/src/lib/components/chat/tree.ts
@@ -6,6 +6,7 @@ export type EnrichedNode = {
 	id: number;
 	title: string | null;
 	relation_notes: string | null | undefined;
+	has_photo: boolean;
 	depth: number;
 	subtreeSize: number; // 1 + sum of children's subtreeSize
 	children: EnrichedNode[];
@@ -22,6 +23,7 @@ export function enrichTree(nodes: RawNode[], depth = 0): EnrichedNode[] {
 			id: n.id,
 			title: n.title,
 			relation_notes: n.relation_notes,
+			has_photo: n.has_photo ?? false,
 			depth,
 			subtreeSize,
 			children

--- a/webui/src/routes/chats/+page.svelte
+++ b/webui/src/routes/chats/+page.svelte
@@ -2,6 +2,7 @@
 	import * as Card from '$lib/components/ui/card/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { goto } from '$app/navigation';
+	import ChatAvatar from '$lib/components/chat/ChatAvatar.svelte';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
 	import { MessagesSquare, Network, Shield, UserPlus, Users } from '@lucide/svelte';
 	import type { components } from '$lib/api/types';
@@ -107,7 +108,17 @@
 								class="cursor-pointer hover:bg-zinc-50"
 								onclick={() => goto(`/chats/${chat.id}`)}
 							>
-								<Table.Cell class="font-medium">{chat.title ?? `#${chat.id}`}</Table.Cell>
+								<Table.Cell class="font-medium">
+									<div class="flex items-center gap-2">
+										<ChatAvatar
+											chatId={chat.id}
+											title={chat.title}
+											hasPhoto={chat.has_photo}
+											size="sm"
+										/>
+										<span class="truncate">{chat.title ?? `#${chat.id}`}</span>
+									</div>
+								</Table.Cell>
 								<Table.Cell>{fmtMembers(chat.member_count)}</Table.Cell>
 								<Table.Cell>{chat.is_captcha_enabled ? 'on' : 'off'}</Table.Cell>
 								<Table.Cell>{chat.is_welcome_enabled ? 'on' : 'off'}</Table.Cell>

--- a/webui/src/routes/chats/[id]/+page.svelte
+++ b/webui/src/routes/chats/[id]/+page.svelte
@@ -3,12 +3,14 @@
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import ChatAvatar from '$lib/components/chat/ChatAvatar.svelte';
 	import HeatmapGrid from '$lib/components/chat/HeatmapGrid.svelte';
 	import Sparkline from '$lib/components/charts/Sparkline.svelte';
 	import SpamPingsList from '$lib/components/spam/SpamPingsList.svelte';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
 	import { apiFetch } from '$lib/api/client';
+	import { RefreshCw } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
 	import type { components } from '$lib/api/types';
 
@@ -22,6 +24,30 @@
 	let busyUserId = $state<number | null>(null);
 	let editing = $state(false);
 	let saving = $state(false);
+	let refreshing = $state(false);
+
+	async function refreshFromTelegram(): Promise<void> {
+		refreshing = true;
+		const res = await apiFetch<ChatRead>(`/api/chats/${chatId}/refresh`, { method: 'POST' });
+		refreshing = false;
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success(`Refreshed — title: ${res.data.title ?? '—'}`);
+			await detail.refresh();
+		}
+	}
+
+	function fmtRelative(iso: string | null | undefined): string {
+		if (!iso) return 'never synced';
+		const ageMs = Date.now() - new Date(iso).getTime();
+		const mins = Math.floor(ageMs / 60_000);
+		if (mins < 1) return 'just now';
+		if (mins < 60) return `${mins}m ago`;
+		const hours = Math.floor(mins / 60);
+		if (hours < 24) return `${hours}h ago`;
+		const days = Math.floor(hours / 24);
+		return `${days}d ago`;
+	}
 	let edit = $state({
 		title: '',
 		welcome_message: '',
@@ -101,13 +127,41 @@
 </script>
 
 <div class="mx-auto max-w-5xl space-y-4 px-6 py-6">
-	<header>
-		<h2 class="text-lg font-semibold tracking-tight">
-			{detail.data?.title ?? `Chat #${chatId}`}
-		</h2>
-		{#if detail.lastUpdatedAt}
-			<span class="text-xs text-zinc-500">Updated {detail.lastUpdatedAt.toLocaleTimeString()}</span>
-		{/if}
+	<header class="flex items-center justify-between gap-3">
+		<div class="flex min-w-0 items-center gap-3">
+			{#if detail.data}
+				<ChatAvatar
+					chatId={detail.data.id}
+					title={detail.data.title}
+					hasPhoto={detail.data.has_photo}
+					size="lg"
+				/>
+			{/if}
+			<div class="min-w-0">
+				<h2 class="truncate text-lg font-semibold tracking-tight">
+					{detail.data?.title ?? `Chat #${chatId}`}
+				</h2>
+				<div class="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-zinc-500">
+					{#if detail.lastUpdatedAt}
+						<span>Page updated {detail.lastUpdatedAt.toLocaleTimeString()}</span>
+					{/if}
+					{#if detail.data}
+						<span>· Synced from Telegram {fmtRelative(detail.data.last_synced_at)}</span>
+					{/if}
+				</div>
+			</div>
+		</div>
+		<Button
+			type="button"
+			variant="outline"
+			size="sm"
+			disabled={refreshing}
+			onclick={refreshFromTelegram}
+			class="shrink-0 gap-1.5"
+		>
+			<RefreshCw class="h-3.5 w-3.5 {refreshing ? 'animate-spin' : ''}" />
+			{refreshing ? 'Refreshing…' : 'Refresh from Telegram'}
+		</Button>
 	</header>
 
 	{#if detail.loading}


### PR DESCRIPTION
## Summary

The three optional polish items I'd previously offered, implemented in one bundled PR because they share the same migration:

1. **`Chat.last_synced_at` column** decouples Telegram syncs from admin edits. The snapshot loop's staleness check used to read `modified_at`, which also bumps when admins save changes from the web UI — meaning a 5-minute-old admin save would suppress the next 24h of upstream title syncs. The new column is bumped only by the snapshot loop / manual refresh endpoint; `modified_at` keeps its admin-edit semantics.

2. **Avatar fetching** caches the Bot API `getChat → photo.big_file_id` on `Chat.photo_file_id`. New `GET /api/chats/{id}/avatar` proxies the JPEG bytes via `Bot.download` (proxying rather than 302-redirecting because the Telegram file URL contains the bot token). Browsers cache for 1h. New `<ChatAvatar>` component renders the cached photo or falls back to the existing colored-initials chip.

3. **Manual refresh** — `POST /api/chats/{id}/refresh` is the synchronous counterpart to the hourly snapshot loop. The chat detail page header now has a "Refresh from Telegram" button + a "Synced X ago" caption.

## Schema changes

| Column | Type | Purpose |
|---|---|---|
| `chats.photo_file_id` | `String NULL` | Bot API `photo.big_file_id` cache |
| `chats.last_synced_at` | `DateTime NULL` | Last Telegram pull timestamp (sync-only, distinct from `modified_at`) |

Migration: `a8b9c0d1e2f3_add_chat_photo_and_sync.py`. Both columns are nullable so the upgrade is a metadata-only ALTER (no row backfill).

## API additions

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/api/chats/{id}/avatar` | Stream the chat's avatar JPEG (404 if no cached file_id). `Cache-Control: public, max-age=3600`. |
| `POST` | `/api/chats/{id}/refresh` | Synchronous title + photo + `last_synced_at` resync. Returns updated `ChatRead`. |
| (modified) | `ChatRead` / `ChatNode` | Now carry `has_photo: bool` and (`ChatRead` only) `last_synced_at: datetime \| None`. |

## Test plan

- [x] `pytest tests/webapi/test_snapshot_loop.py tests/webapi/test_chat_refresh.py` — 15/15 pass
- [x] `pytest tests/webapi` — 112/112 pass
- [x] `ruff check app tests` clean
- [x] `ty check app/webapi` clean
- [x] `svelte-check` 0 errors, 0 warnings
- [ ] Manual: open `/chats/[id]`, click "Refresh from Telegram" — confirm avatar appears + "Synced just now"
- [ ] Manual: rename a chat in Telegram, wait for next snapshot tick (or click refresh) — confirm title updates in UI

## Notes for future work

* `last_synced_at` could be exposed as a column on `/chats` too — currently we only render it on the detail page. Easy follow-up if the operator wants at-a-glance "last refreshed" per row.
* Avatar bytes are not stored in the DB or on disk — every `GET /avatar` round-trips to Telegram CDN via `Bot.download`. Browsers cache for 1h. If we ever feel CDN cost or latency, a per-process LRU on the file_id → bytes mapping would be a simple win.
* Telethon download fallback was deliberately left out — the moderator bot is already a member of every managed chat, so Bot API `getChat` covers the realistic surface; the marginal coverage isn't worth the complexity of re-uploading bytes through the bot to obtain a file_id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)