### PR TITLE
[codex] stop deploy workflow from killing ssh session

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,6 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
             cd ~/deploy/supervisor-telegram
-            pkill -f "vite.*5173" || true
             if grep -q '^IMAGE_TAG=' .env; then
               sed -i 's|^IMAGE_TAG=.*|IMAGE_TAG=${{ github.sha }}|' .env
             else


### PR DESCRIPTION
## What changed
- removed the stale `pkill -f "vite.*5173"` command from the VPS deploy step

## Why
The main deploy workflow was exiting with status 143 before `docker compose pull` / `docker compose up` ran. The broad `pkill` pattern could match the active SSH session command itself, terminating deployment.

## Impact
Deploys on `main` can now proceed to the container update step instead of self-terminating during the remote script.

## Validation
- `git diff --check`
- repository pre-commit hooks on commit/push, including YAML validation