### PR TITLE
[codex] add public catalog and harden auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,9 +66,8 @@ TELETHON_SESSION_NAME=moderator_userbot
 
 # ── Web admin UI ──
 WEBAPI_ALLOWED_ORIGINS=http://localhost:5173
-WEBAPI_AUTH_MODE=telegram            # telegram | magic_link | public
+WEBAPI_AUTH_MODE=telegram            # telegram | magic_link
 WEBAPI_PUBLIC_URL=http://localhost:5173
 WEBAPI_MAGIC_LINK_TTL_MINUTES=15
 WEBAPI_SESSION_TTL_DAYS=30
 WEBAPI_SESSION_COOKIE_SECURE=false   # true in production (HTTPS)
-WEBAPI_DEV_BYPASS_AUTH=true          # dev-only; remove for prod

--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ docker compose up -d
 uv sync --dev
 uv run alembic upgrade head
 uv run -m app.presentation.telegram
+
+# Remote web UI development on a VPS
+uv run uvicorn app.webapi.main:app --host 127.0.0.1 --port 8787
+pnpm --dir webui run dev  # serves on 0.0.0.0:5174, auth still required
 ```
 
 ## Security

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -106,9 +106,9 @@ class AdminSettings(BaseSettings):
 class WebApiSettings(BaseSettings):
     """Admin web UI / HTTP API configuration."""
 
-    auth_mode: Literal["telegram", "magic_link", "public"] = Field(
+    auth_mode: Literal["telegram", "magic_link"] = Field(
         default="telegram",
-        description="Dashboard auth mode: telegram login, bot-issued magic links, or public access.",
+        description="Admin auth mode: telegram login or bot-issued magic links.",
     )
     public_url: str = Field(
         default="",
@@ -129,10 +129,6 @@ class WebApiSettings(BaseSettings):
         description="Set Secure flag on session cookie. Disable only for local http:// dev.",
     )
     session_cookie_samesite: str = Field(default="lax", description="SameSite: lax|strict|none")
-    dev_bypass_auth: bool = Field(
-        default=False,
-        description="Dev-only: skip session validation, act as super_admins[0]. NEVER set in prod.",
-    )
 
     model_config = SettingsConfigDict(
         env_prefix="WEBAPI_",

--- a/app/webapi/deps.py
+++ b/app/webapi/deps.py
@@ -31,17 +31,14 @@ async def require_super_admin(
     Cookie name is ``settings.webapi.session_cookie_name``. Reading via
     ``request.cookies.get(name)`` keeps the name config-driven (FastAPI's
     ``Cookie(alias=...)`` would bake it into the signature at import time).
-    FastAPI injects a real Request at runtime. Production defaults to the
-    Telegram/session path; public access must be explicitly enabled.
+    FastAPI injects a real Request at runtime. Public read-only endpoints
+    live under ``/api/public`` and do not use this dependency.
     """
     from app.core.config import settings
     from app.webapi.auth import session_store
 
     if not settings.admin.super_admins:
         raise HTTPException(status_code=503, detail="No super_admin configured")
-
-    if settings.webapi.auth_mode == "public" or settings.webapi.dev_bypass_auth:
-        return settings.admin.super_admins[0]
 
     token = request.cookies.get(settings.webapi.session_cookie_name)
     if not token:

--- a/app/webapi/main.py
+++ b/app/webapi/main.py
@@ -22,6 +22,7 @@ from app.webapi.routes import (
     costs,
     health,
     posts,
+    public,
     spam,
     stats,
     suggestions,
@@ -91,6 +92,7 @@ def create_app() -> FastAPI:
     app.include_router(auth.router, prefix="/api")
     app.include_router(health.router, prefix="/api")
     app.include_router(posts.router, prefix="/api")
+    app.include_router(public.router, prefix="/api")
     app.include_router(channels.router, prefix="/api")
     app.include_router(chats.router, prefix="/api")
     app.include_router(costs.router, prefix="/api")

--- a/app/webapi/routes/admin.py
+++ b/app/webapi/routes/admin.py
@@ -84,7 +84,6 @@ async def get_system_status(
         session_ttl_days=settings.webapi.session_ttl_days,
         feature_flags=[
             FeatureFlagRead(name=f"auth_mode_{settings.webapi.auth_mode}", enabled=True),
-            FeatureFlagRead(name="dev_bypass_auth", enabled=settings.webapi.dev_bypass_auth),
             FeatureFlagRead(name="moderation_enabled", enabled=settings.moderation.enabled),
             FeatureFlagRead(name="ad_detector_enabled", enabled=settings.moderation.ad_detector_enabled),
             FeatureFlagRead(name="assistant_bot_enabled", enabled=settings.assistant.enabled),

--- a/app/webapi/routes/public.py
+++ b/app/webapi/routes/public.py
@@ -1,0 +1,54 @@
+"""Public read-only endpoints.
+
+Keep this router intentionally narrow. Public pages should consume explicit
+safe projections from here instead of reusing admin DTOs by accident.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import Channel, ChatLink
+from app.webapi.deps import get_session
+from app.webapi.schemas import PublicCatalogItem
+
+router = APIRouter(prefix="/public", tags=["public"])
+
+
+@router.get("/catalog", response_model=list[PublicCatalogItem])
+async def get_public_catalog(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> list[PublicCatalogItem]:
+    """Return only the fields that are safe to show without admin auth."""
+    chat_links = (
+        (await session.execute(select(ChatLink).order_by(ChatLink.priority.desc(), ChatLink.text))).scalars().all()
+    )
+    channels = (
+        (await session.execute(select(Channel).where(Channel.enabled.is_(True)).order_by(Channel.name))).scalars().all()
+    )
+
+    rows = [
+        *[
+            PublicCatalogItem(
+                resource_type="chat",
+                id=chat_link.id,
+                title=chat_link.text,
+                subtitle=chat_link.link,
+            )
+            for chat_link in chat_links
+        ],
+        *[
+            PublicCatalogItem(
+                resource_type="channel",
+                id=channel.id,
+                title=channel.name,
+                subtitle=f"@{channel.username}" if channel.username else None,
+            )
+            for channel in channels
+        ],
+    ]
+    return sorted(rows, key=lambda row: (row.title.lower(), row.resource_type, row.id))

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
@@ -83,6 +83,15 @@ class ChannelRead(BaseModel):
     max_posts_per_day: int
     critic_enabled: bool | None
     created_at: datetime.datetime
+
+
+class PublicCatalogItem(BaseModel):
+    """Safe public projection for the mixed chat/channel catalog."""
+
+    resource_type: Literal["chat", "channel"]
+    id: int
+    title: str
+    subtitle: str | None = None
 
 
 class ChannelSourceRead(BaseModel):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,6 @@ services:
     environment:
       PYTHONUNBUFFERED: "1"
       LOG_FILE_PATH: logs/webapi.log
-      WEBAPI_DEV_BYPASS_AUTH: "false"
     volumes:
       - bot-logs:/app/logs
     restart: unless-stopped

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ os.environ.update(
         "ADMIN_REPORT_CHAT_ID": "123456789",
         "LOG_LEVEL": "ERROR",  # Reduce logging noise in tests
         "APP_ENVIRONMENT": "test",
-        "WEBAPI_DEV_BYPASS_AUTH": "true",
     }
 )
 

--- a/tests/webapi/conftest.py
+++ b/tests/webapi/conftest.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from app.core.config import settings
+from app.webapi.main import app
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -18,3 +19,16 @@ def override_super_admins() -> Iterator[None]:
     original = list(settings.admin.super_admins)
     yield
     settings.admin.super_admins = original
+
+
+@pytest.fixture(autouse=True)
+def authenticated_super_admin() -> Iterator[None]:
+    """Most webapi tests exercise endpoint behavior, not auth mechanics."""
+    from app.webapi.deps import require_super_admin
+
+    async def _override_require_super_admin() -> int:
+        return settings.admin.super_admins[0]
+
+    app.dependency_overrides[require_super_admin] = _override_require_super_admin
+    yield
+    app.dependency_overrides.pop(require_super_admin, None)

--- a/tests/webapi/test_admin.py
+++ b/tests/webapi/test_admin.py
@@ -28,7 +28,6 @@ def client_factory(db_session_maker: async_sessionmaker[AsyncSession]):
 
     app.dependency_overrides[get_session] = _override_session
     settings.admin.super_admins = [1]
-    settings.webapi.dev_bypass_auth = True
     transport = ASGITransport(app=app)
 
     def make() -> AsyncClient:
@@ -135,7 +134,6 @@ async def test_get_system_status(client_factory) -> None:
     flag_names = {f["name"] for f in body["feature_flags"]}
     assert flag_names == {
         "auth_mode_telegram",
-        "dev_bypass_auth",
         "moderation_enabled",
         "ad_detector_enabled",
         "assistant_bot_enabled",

--- a/tests/webapi/test_auth_routes.py
+++ b/tests/webapi/test_auth_routes.py
@@ -36,13 +36,14 @@ def client_factory(db_session_maker: async_sessionmaker[AsyncSession]):
     orig_admins = list(settings.admin.super_admins)
     orig_token = settings.telegram.token
     orig_auth_mode = settings.webapi.auth_mode
-    orig_bypass = settings.webapi.dev_bypass_auth
     orig_secure = settings.webapi.session_cookie_secure
     settings.admin.super_admins = [268388996]
     settings.telegram.token = "test:bot:token"  # noqa: S105
     settings.webapi.auth_mode = "telegram"
-    settings.webapi.dev_bypass_auth = False
     settings.webapi.session_cookie_secure = False
+    from app.webapi.deps import require_super_admin
+
+    app.dependency_overrides.pop(require_super_admin, None)
     transport = ASGITransport(app=app)
 
     def make() -> AsyncClient:
@@ -53,7 +54,6 @@ def client_factory(db_session_maker: async_sessionmaker[AsyncSession]):
     settings.admin.super_admins = orig_admins
     settings.telegram.token = orig_token
     settings.webapi.auth_mode = orig_auth_mode
-    settings.webapi.dev_bypass_auth = orig_bypass
     settings.webapi.session_cookie_secure = orig_secure
 
 
@@ -116,14 +116,3 @@ async def test_magic_link_flow(client_factory, db_session_maker: async_sessionma
         me = await client.get("/api/auth/me")
         assert me.status_code == 200
         assert me.json()["user_id"] == 268388996
-
-
-async def test_public_mode_me_without_cookie(client_factory) -> None:
-    settings.webapi.auth_mode = "public"
-
-    async with client_factory() as client:
-        resp = await client.get("/api/auth/me")
-
-    assert resp.status_code == 200
-    assert resp.json()["user_id"] == 268388996
-    assert resp.json()["auth_mode"] == "public"

--- a/tests/webapi/test_channel_mutations.py
+++ b/tests/webapi/test_channel_mutations.py
@@ -33,7 +33,6 @@ def client_factory(db_session_maker: async_sessionmaker[AsyncSession], monkeypat
 
     app.dependency_overrides[get_session] = _override_session
     settings.admin.super_admins = [1]
-    settings.webapi.dev_bypass_auth = True
     transport = ASGITransport(app=app)
 
     def make() -> AsyncClient:

--- a/tests/webapi/test_chat_mutations.py
+++ b/tests/webapi/test_chat_mutations.py
@@ -31,7 +31,6 @@ def client_factory(db_session_maker: async_sessionmaker[AsyncSession]):
     app.dependency_overrides[get_session] = _override_session
     app.dependency_overrides[get_telethon] = _override_telethon
     settings.admin.super_admins = [1]
-    settings.webapi.dev_bypass_auth = True
     transport = ASGITransport(app=app)
 
     def make() -> AsyncClient:

--- a/tests/webapi/test_chat_refresh.py
+++ b/tests/webapi/test_chat_refresh.py
@@ -56,7 +56,6 @@ def client_factory(db_session_maker):
     app.dependency_overrides[get_publish_bot] = _override_publish_bot
     app.dependency_overrides[get_telethon] = _override_telethon
     settings.admin.super_admins = [1]
-    settings.webapi.dev_bypass_auth = True
     transport = ASGITransport(app=app)
 
     def make() -> AsyncClient:

--- a/tests/webapi/test_costs.py
+++ b/tests/webapi/test_costs.py
@@ -37,7 +37,6 @@ def history_client(db_session_maker: async_sessionmaker[AsyncSession]):
             yield s
 
     settings.admin.super_admins = [1]
-    settings.webapi.dev_bypass_auth = True
     app.dependency_overrides[get_session] = _override_session
     transport = ASGITransport(app=app)
     yield AsyncClient(transport=transport, base_url="http://test")

--- a/tests/webapi/test_deps.py
+++ b/tests/webapi/test_deps.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -13,26 +14,48 @@ from starlette.requests import Request as StarletteRequest
 pytestmark = pytest.mark.asyncio
 
 
-def _fake_request() -> StarletteRequest:
-    """Minimal Starlette Request for direct-call dep tests (bypass path never
-    reads cookies, so scope contents don't matter)."""
-    scope = {"type": "http", "method": "GET", "path": "/", "headers": [], "query_string": b""}
+def _fake_request(cookie: str | None = None) -> StarletteRequest:
+    """Minimal Starlette Request for direct-call dependency tests."""
+    headers = []
+    if cookie is not None:
+        headers.append((b"cookie", f"{settings.webapi.session_cookie_name}={cookie}".encode()))
+    scope = {"type": "http", "method": "GET", "path": "/", "headers": headers, "query_string": b""}
     return StarletteRequest(scope)
 
 
 def _fake_session() -> AsyncMock:
-    """Placeholder session — bypass path never touches the DB."""
+    """Placeholder session for direct-call dependency tests."""
     return AsyncMock()
 
 
-async def test_require_super_admin_returns_first_configured(override_super_admins) -> None:
-    """In dev the dep returns the first configured super_admin — enough
-    for downstream code to treat the request as authenticated."""
+async def test_require_super_admin_requires_cookie(override_super_admins) -> None:
     settings.admin.super_admins = [12345, 67890]
 
-    result = await require_super_admin(_fake_request(), _fake_session())
+    with pytest.raises(HTTPException) as exc_info:
+        await require_super_admin(_fake_request(), _fake_session())
 
-    assert result == 12345
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "not authenticated"
+
+
+async def test_require_super_admin_returns_valid_session_user(
+    monkeypatch: pytest.MonkeyPatch,
+    override_super_admins,
+) -> None:
+    settings.admin.super_admins = [12345, 67890]
+
+    async def _load_valid_session(session: AsyncMock, session_id: str) -> SimpleNamespace:
+        assert session_id == "session-token"
+        return SimpleNamespace(user_id=67890)
+
+    monkeypatch.setattr(
+        "app.webapi.auth.session_store.load_valid_session",
+        _load_valid_session,
+    )
+
+    result = await require_super_admin(_fake_request("session-token"), _fake_session())
+
+    assert result == 67890
 
 
 async def test_require_super_admin_raises_when_none_configured(override_super_admins) -> None:

--- a/tests/webapi/test_post_mutations.py
+++ b/tests/webapi/test_post_mutations.py
@@ -43,7 +43,6 @@ def client_factory(db_session_maker: async_sessionmaker[AsyncSession], monkeypat
     app.dependency_overrides[get_session] = _override_session
     app.dependency_overrides[get_publish_bot] = _override_publish_bot
     settings.admin.super_admins = [1]
-    settings.webapi.dev_bypass_auth = True
     transport = ASGITransport(app=app)
 
     def make() -> AsyncClient:

--- a/tests/webapi/test_public_catalog.py
+++ b/tests/webapi/test_public_catalog.py
@@ -1,0 +1,68 @@
+"""Tests for intentionally unauthenticated public API projections."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from app.core.config import settings
+from app.db.models import Channel, ChatLink
+from app.webapi.main import app
+from httpx import ASGITransport, AsyncClient
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def client_factory(db_session_maker: async_sessionmaker[AsyncSession]):
+    from app.webapi.deps import get_session
+
+    async def _override_get_session():
+        async with db_session_maker() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _override_get_session
+    orig_admins = list(settings.admin.super_admins)
+    settings.admin.super_admins = [1]
+    from app.webapi.deps import require_super_admin
+
+    app.dependency_overrides.pop(require_super_admin, None)
+    transport = ASGITransport(app=app)
+
+    def make() -> AsyncClient:
+        return AsyncClient(transport=transport, base_url="http://test")
+
+    yield make
+    app.dependency_overrides.pop(get_session, None)
+    settings.admin.super_admins = orig_admins
+
+
+async def test_public_catalog_is_readable_without_session(client_factory, db_session_maker) -> None:
+    async with db_session_maker() as session:
+        session.add(ChatLink(text="Public Chat", link="t.me/public_chat"))
+        session.add(Channel(telegram_id=-2001, name="Enabled Channel", username="enabled", enabled=True))
+        session.add(Channel(telegram_id=-2002, name="Disabled Channel", username="disabled", enabled=False))
+        await session.commit()
+
+    async with client_factory() as client:
+        resp = await client.get("/api/public/catalog")
+
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {"resource_type": "channel", "id": 1, "title": "Enabled Channel", "subtitle": "@enabled"},
+        {"resource_type": "chat", "id": 1, "title": "Public Chat", "subtitle": "t.me/public_chat"},
+    ]
+
+
+async def test_public_catalog_does_not_open_admin_routes(client_factory) -> None:
+    async with client_factory() as client:
+        catalog = await client.get("/api/public/catalog")
+        me = await client.get("/api/auth/me")
+        admin_channels = await client.get("/api/channels")
+
+    assert catalog.status_code == 200
+    assert me.status_code == 401
+    assert admin_channels.status_code == 401

--- a/tests/webapi/test_suggestions.py
+++ b/tests/webapi/test_suggestions.py
@@ -32,7 +32,6 @@ def client(db_session_maker: async_sessionmaker[AsyncSession]):
             yield s
 
     settings.admin.super_admins = [1]
-    settings.webapi.dev_bypass_auth = True
     app.dependency_overrides[get_session] = _override_session
     transport = ASGITransport(app=app)
 

--- a/tests/webapi/test_user_blacklist.py
+++ b/tests/webapi/test_user_blacklist.py
@@ -34,7 +34,6 @@ def client_factory(db_session_maker: async_sessionmaker[AsyncSession]):
     app.dependency_overrides[get_session] = _override_session
     app.dependency_overrides[get_publish_bot] = _override_publish_bot
     settings.admin.super_admins = [1]
-    settings.webapi.dev_bypass_auth = True
     transport = ASGITransport(app=app)
 
     def make() -> AsyncClient:

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -21,6 +21,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/magic-link": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Magic Link Login */
+        post: operations["magic_link_login_api_auth_magic_link_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/logout": {
         parameters: {
             query?: never;
@@ -277,6 +294,26 @@ export interface paths {
         post?: never;
         /** Image Clear */
         delete: operations["image_clear_api_posts__post_id__images_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/public/catalog": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Public Catalog
+         * @description Return only the fields that are safe to show without admin auth.
+         */
+        get: operations["get_public_catalog_api_public_catalog_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -804,6 +841,11 @@ export interface components {
         AuthMeResponse: {
             /** User Id */
             user_id: number;
+            /**
+             * Auth Mode
+             * @default telegram
+             */
+            auth_mode: string;
             /**
              * Is Authenticated
              * @default true
@@ -1356,6 +1398,11 @@ export interface components {
             /** Position */
             position?: number | null;
         };
+        /** MagicLinkLoginPayload */
+        MagicLinkLoginPayload: {
+            /** Token */
+            token: string;
+        };
         /** MemberSnapshotPoint */
         MemberSnapshotPoint: {
             /**
@@ -1534,6 +1581,23 @@ export interface components {
             published_at: string;
             /** Views */
             views: number;
+        };
+        /**
+         * PublicCatalogItem
+         * @description Safe public projection for the mixed chat/channel catalog.
+         */
+        PublicCatalogItem: {
+            /**
+             * Resource Type
+             * @enum {string}
+             */
+            resource_type: "chat" | "channel";
+            /** Id */
+            id: number;
+            /** Title */
+            title: string;
+            /** Subtitle */
+            subtitle?: string | null;
         };
         /**
          * ScheduledPostEntry
@@ -1746,6 +1810,39 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["TelegramLoginPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthMeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    magic_link_login_api_auth_magic_link_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MagicLinkLoginPayload"];
             };
         };
         responses: {
@@ -2222,6 +2319,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_public_catalog_api_public_catalog_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicCatalogItem"][];
                 };
             };
         };

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -12,7 +12,18 @@
 	let { children } = $props();
 
 	onMount(() => {
-		if (page.url.pathname !== '/login') void auth.refresh();
+		void auth.refresh();
+	});
+
+	const publicPath = $derived(page.url.pathname === '/catalog');
+
+	$effect(() => {
+		if (!auth.initialized || auth.me || page.url.pathname === '/login') return;
+		if (page.url.pathname === '/') {
+			void goto('/catalog');
+			return;
+		}
+		if (!publicPath) void goto('/login');
 	});
 
 	async function doLogout(): Promise<void> {
@@ -27,10 +38,32 @@
 
 {#if page.url.pathname === '/login'}
 	{@render children()}
+{:else if publicPath && !auth.me}
+	<div class="min-h-screen bg-zinc-50 text-zinc-900">
+		<header class="border-b border-zinc-200 bg-white">
+			<div class="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
+				<div class="flex items-center gap-2">
+					<div class="flex h-7 w-7 items-center justify-center rounded-md bg-zinc-900 text-sm font-semibold text-white">
+						K
+					</div>
+					<span class="text-sm font-semibold tracking-tight text-zinc-900">Konnekt</span>
+				</div>
+				<a
+					href="/login"
+					class="rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-100"
+				>
+					Admin sign in
+				</a>
+			</div>
+		</header>
+		<main>
+			{@render children()}
+		</main>
+	</div>
 {:else if !auth.initialized}
 	<div class="flex min-h-screen items-center justify-center text-sm text-zinc-400">Loading…</div>
 {:else if !auth.me}
-	<!-- apiFetch has already started navigation to /login; render nothing to avoid a flash. -->
+	<!-- The effect above has already started navigation away from this protected route. -->
 {:else}
 	<div class="flex h-screen w-screen bg-white text-zinc-900">
 		<Sidebar />

--- a/webui/src/routes/catalog/+page.svelte
+++ b/webui/src/routes/catalog/+page.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { apiFetch } from '$lib/api/client';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import ChatAvatar from '$lib/components/chat/ChatAvatar.svelte';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
-	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
+	import { auth } from '$lib/stores/auth.svelte';
 	import { CheckCircle2, Hash, MessageSquare, Network, Plus, Search, ShieldCheck, ShieldQuestion, Tv, XCircle } from '@lucide/svelte';
 	import type { components } from '$lib/api/types';
 
 	type Channel = components['schemas']['ChannelRead'];
 	type Chat = components['schemas']['ChatRead'];
+	type PublicCatalogItem = components['schemas']['PublicCatalogItem'];
 	type Filter = 'all' | 'chat' | 'channel';
 	type Resource = {
 		key: string;
@@ -25,14 +27,15 @@
 		hasPhoto?: boolean;
 	};
 
-	const chats = useLivePoll<Chat[]>('/api/chats', 60_000);
-	const channels = useLivePoll<Channel[]>('/api/channels', 60_000);
-
 	let filter = $state<Filter>('all');
 	let query = $state('');
+	let resources = $state<Resource[]>([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let lastUpdatedAt = $state<Date | null>(null);
 
-	const resources = $derived.by<Resource[]>(() => {
-		const chatRows = (chats.data ?? []).map((chat) => ({
+	function buildAdminResources(chats: Chat[], channels: Channel[]): Resource[] {
+		const chatRows = chats.map((chat) => ({
 			key: `chat:${chat.id}`,
 			type: 'chat' as const,
 			id: chat.id,
@@ -51,7 +54,7 @@
 			hasPhoto: chat.has_photo
 		}));
 
-		const channelRows = (channels.data ?? []).map((channel) => ({
+		const channelRows = channels.map((channel) => ({
 			key: `channel:${channel.id}`,
 			type: 'channel' as const,
 			id: channel.id,
@@ -69,6 +72,65 @@
 			if (title !== 0) return title;
 			return a.key.localeCompare(b.key);
 		});
+	}
+
+	function buildPublicResources(items: PublicCatalogItem[]): Resource[] {
+		return items.map((item) => ({
+			key: `${item.resource_type}:${item.id}`,
+			type: item.resource_type,
+			id: item.id,
+			title: item.title,
+			subtitle: item.subtitle ?? '',
+			status: '',
+			statusKind: 'basic',
+			metric: '',
+			identity: '',
+			path: item.resource_type === 'chat' ? `/chats/${item.id}` : `/channels/${item.id}`,
+			hasPhoto: false
+		}));
+	}
+
+	async function refreshResources(): Promise<void> {
+		loading = true;
+		error = null;
+		try {
+			if (auth.me) {
+				const [chatRes, channelRes] = await Promise.all([
+					apiFetch<Chat[]>('/api/chats'),
+					apiFetch<Channel[]>('/api/channels')
+				]);
+				if (chatRes.error) {
+					error = chatRes.error.message;
+					resources = [];
+					return;
+				}
+				if (channelRes.error) {
+					error = channelRes.error.message;
+					resources = [];
+					return;
+				}
+				resources = buildAdminResources(chatRes.data, channelRes.data);
+			} else {
+				const res = await apiFetch<PublicCatalogItem[]>('/api/public/catalog');
+				if (res.error) {
+					error = res.error.message;
+					resources = [];
+					return;
+				}
+				resources = buildPublicResources(res.data);
+			}
+			lastUpdatedAt = new Date();
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		auth.initialized;
+		auth.me;
+		void refreshResources();
+		const id = setInterval(refreshResources, 60_000);
+		return () => clearInterval(id);
 	});
 
 	const filtered = $derived.by(() => {
@@ -84,42 +146,54 @@
 	});
 
 	const summary = $derived.by(() => {
-		const chatCount = chats.data?.length ?? 0;
-		const channelCount = channels.data?.length ?? 0;
-		const enabledChannels = channels.data?.filter((channel) => channel.enabled).length ?? 0;
-		const members =
-			chats.data?.reduce((acc, chat) => acc + (chat.member_count ?? 0), 0).toLocaleString() ?? '0';
-		return { total: chatCount + channelCount, chatCount, channelCount, enabledChannels, members };
+		const chatRows = resources.filter((resource) => resource.type === 'chat');
+		const channelRows = resources.filter((resource) => resource.type === 'channel');
+		const enabledChannels = auth.me
+			? resources.filter((resource) => resource.type === 'channel' && resource.statusKind === 'enabled').length
+			: channelRows.length;
+		const members = auth.me
+			? chatRows
+					.reduce((acc, resource) => acc + Number(resource.metric.replaceAll(',', '') || 0), 0)
+					.toLocaleString()
+			: null;
+		return {
+			total: resources.length,
+			chatCount: chatRows.length,
+			channelCount: channelRows.length,
+			enabledChannels,
+			members
+		};
 	});
-
-	const loading = $derived((chats.loading && !chats.data) || (channels.loading && !channels.data));
-	const error = $derived(chats.error || channels.error);
 </script>
 
 <div class="mx-auto max-w-6xl space-y-4 px-6 py-6">
 	<header class="flex items-baseline justify-between">
 		<div>
 			<h2 class="text-lg font-semibold tracking-tight">Catalog</h2>
-			<p class="mt-0.5 text-xs text-zinc-500">Telegram resources managed by the platform.</p>
+			<p class="mt-0.5 text-xs text-zinc-500">
+				{auth.me ? 'Telegram resources managed by the platform.' : 'Public Telegram resources in the network.'}
+			</p>
 		</div>
 		<div class="flex items-center gap-2">
-			{#if chats.lastUpdatedAt || channels.lastUpdatedAt}
+			{#if lastUpdatedAt}
 				<span class="hidden text-xs text-zinc-500 md:inline">
-					Updated {(chats.lastUpdatedAt ?? channels.lastUpdatedAt)?.toLocaleTimeString()}
+					Updated {lastUpdatedAt.toLocaleTimeString()}
 				</span>
 			{/if}
-			<Button variant="outline" size="sm" href="/catalog/hierarchy">
-				<Network class="h-3.5 w-3.5" />
-				Hierarchy
-			</Button>
-			<Button size="sm" href="/channels">
-				<Plus class="h-3.5 w-3.5" />
-				New channel
-			</Button>
+			{#if auth.me}
+				<Button variant="outline" size="sm" href="/catalog/hierarchy">
+					<Network class="h-3.5 w-3.5" />
+					Hierarchy
+				</Button>
+				<Button size="sm" href="/channels">
+					<Plus class="h-3.5 w-3.5" />
+					New channel
+				</Button>
+			{/if}
 		</div>
 	</header>
 
-	<div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+	<div class="grid grid-cols-2 gap-3 {auth.me ? 'md:grid-cols-4' : 'md:grid-cols-3'}">
 		<div class="flex items-center gap-3 rounded-md border border-zinc-200 bg-white px-3 py-2.5">
 			<Hash class="h-4 w-4 text-zinc-500" />
 			<div class="min-w-0">
@@ -141,13 +215,15 @@
 				<div class="text-lg font-semibold tracking-tight text-zinc-900">{summary.channelCount}</div>
 			</div>
 		</div>
-		<div class="flex items-center gap-3 rounded-md border border-zinc-200 bg-white px-3 py-2.5">
-			<Hash class="h-4 w-4 text-zinc-500" />
-			<div class="min-w-0">
-				<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Members</div>
-				<div class="text-lg font-semibold tracking-tight text-zinc-900">{summary.members}</div>
+		{#if auth.me}
+			<div class="flex items-center gap-3 rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+				<Hash class="h-4 w-4 text-zinc-500" />
+				<div class="min-w-0">
+					<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Members</div>
+					<div class="text-lg font-semibold tracking-tight text-zinc-900">{summary.members}</div>
+				</div>
 			</div>
-		</div>
+		{/if}
 	</div>
 
 	<div class="flex flex-col gap-3 border-b border-zinc-200 pb-3 md:flex-row md:items-center md:justify-between">
@@ -183,14 +259,19 @@
 					<Table.Row class="bg-zinc-50/80">
 						<Table.Head>Name</Table.Head>
 						<Table.Head class="w-16 text-center">Type</Table.Head>
-						<Table.Head class="w-20 text-center">Status</Table.Head>
-						<Table.Head class="w-28">Metric</Table.Head>
-						<Table.Head class="w-44">Telegram ID</Table.Head>
+						{#if auth.me}
+							<Table.Head class="w-20 text-center">Status</Table.Head>
+							<Table.Head class="w-28">Metric</Table.Head>
+							<Table.Head class="w-44">Telegram ID</Table.Head>
+						{/if}
 					</Table.Row>
 				</Table.Header>
 				<Table.Body>
 					{#each filtered as resource (resource.key)}
-						<Table.Row class="cursor-pointer hover:bg-zinc-50" onclick={() => goto(resource.path)}>
+						<Table.Row
+							class="{auth.me ? 'cursor-pointer' : ''} hover:bg-zinc-50"
+							onclick={() => auth.me && goto(resource.path)}
+						>
 							<Table.Cell>
 								<div class="flex min-w-0 items-center gap-2">
 									{#if resource.type === 'chat'}
@@ -226,29 +307,31 @@
 									{/if}
 								</span>
 							</Table.Cell>
-							<Table.Cell class="text-center">
-								<span
-									class="inline-flex h-7 w-7 items-center justify-center rounded-md border border-zinc-200 bg-white {resource.statusKind === 'enabled' || resource.statusKind === 'guarded'
-										? 'text-emerald-600'
-										: resource.statusKind === 'disabled'
-											? 'text-zinc-400'
-											: 'text-zinc-500'}"
-									title={resource.status}
-									aria-label={resource.status}
-								>
-									{#if resource.statusKind === 'enabled'}
-										<CheckCircle2 class="h-3.5 w-3.5" />
-									{:else if resource.statusKind === 'disabled'}
-										<XCircle class="h-3.5 w-3.5" />
-									{:else if resource.statusKind === 'guarded'}
-										<ShieldCheck class="h-3.5 w-3.5" />
-									{:else}
-										<ShieldQuestion class="h-3.5 w-3.5" />
-									{/if}
-								</span>
-							</Table.Cell>
-							<Table.Cell class="text-sm text-zinc-700">{resource.metric}</Table.Cell>
-							<Table.Cell class="font-mono text-xs text-zinc-600">{resource.identity}</Table.Cell>
+							{#if auth.me}
+								<Table.Cell class="text-center">
+									<span
+										class="inline-flex h-7 w-7 items-center justify-center rounded-md border border-zinc-200 bg-white {resource.statusKind === 'enabled' || resource.statusKind === 'guarded'
+											? 'text-emerald-600'
+											: resource.statusKind === 'disabled'
+												? 'text-zinc-400'
+												: 'text-zinc-500'}"
+										title={resource.status}
+										aria-label={resource.status}
+									>
+										{#if resource.statusKind === 'enabled'}
+											<CheckCircle2 class="h-3.5 w-3.5" />
+										{:else if resource.statusKind === 'disabled'}
+											<XCircle class="h-3.5 w-3.5" />
+										{:else if resource.statusKind === 'guarded'}
+											<ShieldCheck class="h-3.5 w-3.5" />
+										{:else}
+											<ShieldQuestion class="h-3.5 w-3.5" />
+										{/if}
+									</span>
+								</Table.Cell>
+								<Table.Cell class="text-sm text-zinc-700">{resource.metric}</Table.Cell>
+								<Table.Cell class="font-mono text-xs text-zinc-600">{resource.identity}</Table.Cell>
+							{/if}
 						</Table.Row>
 					{/each}
 				</Table.Body>

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -1,21 +1,28 @@
 import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
-export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()],
-	server: {
-		host: '0.0.0.0',
-		port: 5173,
-		strictPort: true,
-		// Dev on a VPS: accept any Host header so you can hit the server by
-		// public IP or domain. Tighten this when auth lands.
-		allowedHosts: true,
-		proxy: {
-			'/api': {
-				target: 'http://127.0.0.1:8787',
-				changeOrigin: true
+export default defineConfig(({ mode }) => {
+	const env = loadEnv(mode, '.', 'VITE_');
+	const extraAllowedHosts = env.VITE_ALLOWED_HOSTS?.split(',')
+		.map((host: string) => host.trim())
+		.filter(Boolean);
+
+	return {
+		plugins: [tailwindcss(), sveltekit()],
+		server: {
+			host: '0.0.0.0',
+			port: 5174,
+			strictPort: true,
+			// IP hosts are allowed by Vite by default. Add owned DNS names only when
+			// needed, e.g. VITE_ALLOWED_HOSTS=dev.example.com.
+			allowedHosts: extraAllowedHosts,
+			proxy: {
+				'/api': {
+					target: 'http://127.0.0.1:8787',
+					changeOrigin: true
+				}
 			}
 		}
-	}
+	};
 });


### PR DESCRIPTION
## What changed
- add a dedicated read-only public catalog endpoint and render unauthenticated `/catalog` from that projection
- keep richer catalog/admin data behind authenticated routes
- remove the development auth bypass path so protected endpoints always require a valid session
- make remote dev exposure explicit with Vite on `0.0.0.0:5174` while keeping the backend local to `127.0.0.1:8787`

## Why
The previous setup mixed public browsing with admin-only catalog data and still retained a bypass-style auth path that is too easy to misuse once the UI is reachable remotely.

## Impact
- public users can inspect only the curated catalog fields intended for anonymous access
- admin actions remain gated by session auth
- remote development stays possible without weakening auth semantics

## Validation
- `uv run ruff check app tests`
- `uv run ruff format --check app tests`
- `uv run pytest`
- `pnpm --dir webui run check`
- `pnpm --dir webui run build`
- push hook also reran repository checks successfully