### PR TITLE
[codex] strengthen product documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,141 @@
+# Supervisor Telegram Engineering Rules
+
+This file is the working contract for AI agents and developers in this
+repository. It is not a setup guide or a product brief. Use `README.md` and
+`docs/` for those.
+
+## Documentation-Driven TDD
+
+When behavior changes:
+
+1. Update the canonical documentation first.
+2. Add or update a failing test that captures the documented rule.
+3. Implement the smallest code change that makes the test pass.
+4. Refactor only after the documented behavior is protected by tests.
+
+Use this loop for product behavior, domain rules, auth/security boundaries,
+database semantics, and externally visible API or UI behavior.
+
+Do not require a documentation update for typo fixes, purely mechanical
+refactors, or internal cleanup that preserves existing contracts.
+
+Use the documentation hierarchy from `docs/README.md`:
+
+- `docs/domain/` owns current behavioral rules.
+- `docs/architecture.md` explains code structure and technical decisions.
+- `docs/testing/` defines the verification strategy.
+- `docs/project/` stores operational learnings, not canonical product rules.
+
+If implementation, tests, and canonical docs disagree, stop and reconcile the
+contract before continuing.
+
+## Core Operating Loop
+
+1. Inspect the current checkout before proposing or editing.
+2. State assumptions when they affect architecture, data, security, or delivery.
+3. Make the smallest change that fixes the real problem.
+4. Prefer red-green-refactor when behavior changes.
+5. Run the narrowest meaningful verification before claiming success.
+6. Leave the repository more consistent than you found it without expanding
+   scope silently.
+
+## Quality Bar
+
+- Fix root causes, not symptoms.
+- Do not ship code you cannot explain.
+- Do not hide uncertainty. Mark unknowns and risks explicitly.
+- Do not add abstractions until they remove real complexity, isolate an unstable
+  boundary, or serve more than one real call site.
+- Do not mix unrelated cleanup with feature work unless the cleanup is required
+  for the feature.
+- Prefer readable domain code over clever generic helpers.
+- Do not manually edit generated files when an owning tool exists.
+
+## Architecture Rules
+
+- Keep feature behavior inside the owning module: `moderation/`, `channel/`,
+  `assistant/`, `webapi/`, or `presentation/telegram/`.
+- Keep route handlers, Telegram handlers, and UI handlers thin. They should
+  orchestrate services, not duplicate business rules.
+- Reuse the existing feature-based modular style. Do not introduce interface
+  layers or entity-mapping layers unless there is a real second implementation
+  or a concrete boundary to isolate.
+- Cross-feature access should go through explicit services or repositories, not
+  incidental imports that spread ownership.
+- When a file becomes hard to review, split by responsibility before adding more
+  behavior.
+
+## Auth, Telegram, And Data Safety
+
+- Treat the admin/public boundary in the web API as a security boundary.
+- Public endpoints must be intentionally read-only and must not expose admin
+  fields by accident.
+- Admin mutations require authenticated admin sessions. Do not add auth bypass
+  paths for convenience.
+- Do not reuse production bot tokens, userbot sessions, or databases for a
+  running development instance.
+- The moderator bot uses HTML as its default parse mode. Any Telegram send/edit
+  call that supplies `entities` or `caption_entities` must pass
+  `parse_mode=None`.
+- Telethon uses a real user session. Treat write operations, scheduled messages,
+  and account-level side effects as higher-risk than ordinary bot API calls.
+- Never log secrets, bot tokens, session strings, credentials, or sensitive
+  payloads.
+
+## Database And Deployment Rules
+
+- Use PostgreSQL 18 as the supported database target.
+- Schema changes require an Alembic migration, affected code/tests, and
+  verification against PostgreSQL when behavior depends on PostgreSQL features.
+- Do not run destructive database commands on shared environments without an
+  explicit mitigation or rollback plan.
+- Keep deployment reproducible: pin concrete action/image versions, avoid stale
+  image tags, and preserve the `~/deploy/supervisor-telegram/` deployment model
+  unless the user requests a redesign.
+- CI/CD changes require syntax or configuration validation when practical.
+
+## Testing And Verification
+
+- For changed behavior, prefer a failing test first.
+- For bug fixes, reproduce the symptom before editing when feasible.
+- For refactors, prove behavior preservation with existing tests, type checks, or
+  focused characterization tests.
+- Use the narrowest lane that proves the change, then widen verification when
+  the blast radius crosses module boundaries.
+- Never claim "done", "fixed", or "clean" without fresh verification evidence.
+- Follow `docs/testing/README.md` for unit, PostgreSQL integration, E2E, and web
+  API test placement.
+
+## Agent Workflow
+
+- Manage context aggressively. Read only what is needed and summarize findings.
+- Prefer reproducible command-line workflows over click-only instructions.
+- Review generated diffs before committing.
+- Do not commit agent plans, scratchpads, handoff notes, or execution logs as
+  project documentation unless the user explicitly asks for that artifact.
+- If a task is too risky because access, rollback, or ownership is unclear, stop
+  and state the blocker.
+
+## Git Discipline
+
+- Work on a named branch for meaningful changes.
+- Commit by concern when practical.
+- Stage files explicitly and inspect `git status --short` before committing.
+- Use non-destructive git commands by default.
+- Do not amend, force-push, reset, or revert user work unless explicitly asked.
+
+## Command Reference
+
+Use the narrowest command that proves the change:
+
+```bash
+uv run ruff check app tests
+uv run ruff format --check app tests
+uv run ty check app tests
+uv run pytest tests/unit
+uv run pytest tests/integration
+uv run pytest tests/e2e
+uv run pytest tests/webapi
+pnpm --dir webui run check
+pnpm --dir webui run build
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ refactors, or internal cleanup that preserves existing contracts.
 
 Use the documentation hierarchy from `docs/README.md`:
 
+- `docs/product/` defines business intent, product scope, and the users we serve.
 - `docs/domain/` owns current behavioral rules.
 - `docs/architecture.md` explains code structure and technical decisions.
 - `docs/testing/` defines the verification strategy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Instructions for Claude Code when working on this repository.
+See [AGENTS.md](AGENTS.md) for repository instructions.
 
 ## Quick Reference
 
@@ -25,95 +25,9 @@ alembic revision --autogenerate -m "description"
 alembic upgrade head
 ```
 
-## Architecture
+Use the canonical docs instead of duplicating repository guidance here:
 
-Multi-agent Telegram platform: moderator bot + assistant bot + Telethon userbot.
-Feature-based modular architecture — ORM models as domain models, no entity/interface indirection.
-Full details: [`docs/architecture.md`](docs/architecture.md).
-
-### Module Structure
-
-```
-app/
-├── core/              # Config (9 Pydantic classes), logging, DI container, enums, exceptions, tool_trace
-├── moderation/        # Moderation agent (schemas, prompts, escalation, memory, blacklist, report, services)
-├── channel/           # Content pipeline feature module
-│   ├── orchestrator.py   # Per-channel scheduling + orchestration
-│   ├── workflow.py       # Burr state machine (9 actions)
-│   ├── generator.py      # LLM screening + post generation
-│   ├── review/           # Review submodule (agent, telegram_io, service)
-│   ├── semantic_dedup.py # pgvector cosine similarity
-│   ├── sources.py        # RSS + health tracking
-│   └── http.py           # SSRF-protected HTTP client
-├── assistant/         # Conversational admin bot (PydanticAI, Claude Sonnet, 30+ tools)
-├── db/                # SQLAlchemy models, repositories, session management
-├── telethon/          # Telethon userbot client (auth, chat/message/scheduled ops)
-└── presentation/      # Telegram handlers, middlewares, utils (buttons, blacklist)
-```
-
-### Key Files
-
-- `app/core/config.py` — Pydantic settings hierarchy (9 nested config classes)
-- `app/core/enums.py` — `PostStatus`, `EscalationStatus`, `ReviewDecision` StrEnums
-- `app/core/exceptions.py` — `DomainError`, `UserNotFoundException`
-- `app/db/models.py` — 9 ORM models (including pgvector `Vector(768)` column)
-- `app/core/markdown.py` — `md_to_entities` / `md_to_entities_chunked` (telegramify-markdown)
-- `app/core/time.py` — `utc_now()` helper for naive UTC datetimes
-- `app/presentation/telegram/bot.py` — main entry, dispatcher setup
-- `app/presentation/telegram/handlers/__init__.py` — router assembly, middleware wiring
-
-### LLM Models (OpenRouter)
-
-| Role | Model | Env var override |
-|---|---|---|
-| Screening | `google/gemini-2.0-flash-001` | `CHANNEL_SCREENING_MODEL` |
-| Generation + review | `google/gemini-3.1-flash-lite-preview` | `CHANNEL_GENERATION_MODEL` |
-| Moderation | `google/gemini-3.1-flash-lite-preview` | `MODERATION_MODEL` |
-| Assistant | `anthropic/claude-sonnet-4-6` | `ASSISTANT_BOT_MODEL` |
-
-## Important Patterns
-
-### parse_mode=None with entities
-
-The moderator bot uses `DefaultBotProperties(parse_mode="HTML")`. This **silently overrides** `entities`/`caption_entities` if `parse_mode=None` is not passed. All `send_photo`/`send_message`/`edit_message` calls using entities MUST include `parse_mode=None`.
-
-### Markdown → Entities
-
-Posts use Markdown (`**bold**`, `[link](url)`) converted via `md_to_entities` from `app/core/markdown.py`. Never send raw Markdown as HTML.
-
-### Telethon Userbot
-
-Authorized session file `moderator_userbot.session` (@work_azamat). Provides: chat history, search, member lists, scheduled messages (unavailable in Bot API).
-
-### Content Pipeline Flow
-
-`fetch_sources` → `split_and_enrich_topics` → `screen_content` → `generate_post` → `send_for_review` → **HITL halt** → `publish_post` / `handle_rejection`
-
-Review agent supports multi-turn editing with per-post conversation memory (4h TTL, 200 LRU cap).
-
-### Moderation Agent
-
-Self-calibrating: injects last 5 admin corrections into system prompt. Escalates uncertain cases with inline buttons + timeout.
-
-## Testing
-
-- **640 tests**, ~27s runtime
-- Unit: SQLite in-memory
-- Integration: testcontainers PostgreSQL
-- E2E: `FakeTelegramServer` (aiohttp-based Bot API simulator)
-- Pre-commit: ruff + ty on commit, pytest on push
-
-## Environment
-
-See `.env.example` for all variables. Key ones:
-
-```bash
-MODERATOR_BOT_TOKEN=              # Moderator bot
-ADMIN_SUPER_ADMINS=123,456        # Comma-separated user IDs
-OPENROUTER_API_KEY=               # OpenRouter for all LLM calls
-BRAVE_API_KEY=                    # Brave Search API
-MODERATION_ENABLED=true           # Enable moderation agent
-ASSISTANT_BOT_TOKEN=              # Assistant bot
-ASSISTANT_BOT_ENABLED=true        # Enable assistant bot
-DB_USER= DB_PASSWORD= DB_NAME=   # PostgreSQL
-```
+- [Documentation hub](docs/README.md)
+- [Architecture](docs/architecture.md)
+- [Domain rules](docs/domain/README.md)
+- [Testing strategy](docs/testing/README.md)

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ app/
 │   ├── agent.py            # PydanticAI agent (Claude Sonnet)
 │   ├── bot.py              # Conversation management
 │   └── tools/              # 30+ tools across 5 modules
-├── infrastructure/         # DB models, repositories, Telethon
+├── db/                     # SQLAlchemy models, repositories, session management
+├── telethon/               # Telethon userbot client
 └── presentation/           # Telegram handlers, middlewares
 ```
 
@@ -258,3 +259,8 @@ pnpm --dir webui run dev  # serves on 0.0.0.0:5174, auth still required
 ## License
 
 MIT
+
+## Documentation
+
+Start with the [documentation hub](docs/README.md) for domain rules,
+architecture, testing strategy, and project learnings.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,36 @@
 
 > **Alpha** — actively developed, core features working in production but APIs and architecture may change.
 
-A multi-agent system that manages Telegram communities and automates content pipelines. Originally built for educational chat communities in the Czech Republic — now a general-purpose platform combining **mechanical moderation**, **AI-driven content generation**, and a **conversational admin interface**.
+A multi-agent system that helps Telegram operators keep communities useful,
+publish relevant content consistently, and spend less time on repetitive admin
+work. Originally built for educational chat communities in the Czech Republic,
+it now combines **mechanical moderation**, **AI-assisted publishing**, and a
+**conversational admin interface** in one platform.
 
 The system runs **three separate Telegram identities** working in concert: a rule-enforcing moderator bot, an LLM-powered assistant, and a Telethon userbot for Client API features unavailable to standard bots.
+
+## Product Outcomes
+
+- Keep community conversations healthier by handling routine abuse quickly and
+  escalating uncertain cases to humans.
+- Turn scattered source material into a steady publishing workflow with
+  human review where a review channel is configured.
+- Let admins manage channels, moderation, publishing, and operating visibility
+  from Telegram and authenticated web surfaces instead of stitching together
+  separate tools and manual processes.
+
+## Product Capabilities
+
+| Capability group | User value |
+|---|---|
+| **Community safety** | Routine abuse is handled quickly, while uncertain cases are escalated for human review. |
+| **Content operations** | Sources move through intake, screening, drafting, optional review, and publishing in one workflow. |
+| **Operator control** | Admins manage moderation, publishing, catalog source data, and spend visibility from coherent operating surfaces. |
+| **Learning loop** | Corrections and editorial decisions are preserved so later moderation and content output can reflect operator judgment. |
+
+See [`docs/product/`](docs/product/) for personas, jobs-to-be-done, business
+outcomes, product promises, and the separation between capabilities and
+technical enablers.
 
 ## System Architecture
 
@@ -120,7 +147,9 @@ flowchart LR
 
 ### Content Pipeline
 
-A **Burr state machine** orchestrates the full content lifecycle — from source fetching to publication — with a human-in-the-loop review step that halts execution until an admin approves.
+A **Burr state machine** orchestrates the full content lifecycle — from source
+fetching to publication. Channels with a review chat halt for human approval;
+channels without one publish directly after generation.
 
 ```mermaid
 flowchart TB
@@ -137,8 +166,10 @@ flowchart TB
     Screen --> Feedback["Load Admin Feedback<br/><i>last 20 approve/reject<br/>summarized as preferences</i>"]
     Feedback --> Generate["generate_post<br/><i>LLM + image search</i><br/><i>900 char limit</i>"]
     Generate --> Review["send_for_review<br/><i>→ Review Group</i>"]
+    Generate --> Direct["no review chat<br/><i>direct publish</i>"]
     Review --> HITL{"⏸️ HITL Halt"}
     HITL -->|"✅ Approve"| Publish["publish_post<br/><i>→ Channel</i>"]
+    Direct --> Publish
     HITL -->|"✏️ Edit"| Agent["Review Agent<br/><i>multi-turn conversation</i>"]
     Agent --> HITL
     HITL -->|"❌ Reject"| Reject["handle_rejection<br/><i>feedback stored</i>"]
@@ -148,7 +179,8 @@ flowchart TB
     style HITL fill:#ffd700,stroke:#333,color:#000
 ```
 
-**Feedback loop**: The pipeline learns from admin decisions. Before generating each post, it summarizes the last 20 approve/reject decisions into preference bullets and injects them into the generation prompt.
+**Feedback loop**: The pipeline can retain recent approve/reject decisions and
+summarize them into preference context for later generation.
 
 **Source discovery**: Periodically, Perplexity Sonar discovers new RSS feeds for each channel's topic. Each discovered URL is validated by actually fetching it and passes SSRF checks before being stored.
 
@@ -173,21 +205,6 @@ Admin: "Ban user 123456 in all chats"
 User @spammer added to global blacklist.
 Messages revoked in 3 chats.
 ```
-
-## Key Features
-
-| Area | What it does |
-|---|---|
-| **AI Moderation** | LLM-based message analysis with self-calibrating decisions, admin escalation with timeout, cross-chat risk profiles |
-| **Content Pipeline** | Automated fetch → screen → generate → review → publish with Burr state machine and HITL |
-| **Semantic Dedup** | pgvector embeddings prevent duplicate topics across a configurable time window |
-| **Conversational Review** | Multi-turn post editing through natural language in a Telegram review group |
-| **Admin Feedback Loop** | Generation learns from past approve/reject decisions |
-| **Source Management** | RSS health tracking, auto-discovery via Perplexity Sonar, SSRF-protected validation |
-| **Scheduled Publishing** | Telegram Client API (Telethon) for native scheduled messages |
-| **Mechanical Moderation** | /mute, /ban, /blacklist, welcome messages, spam detection — no LLM overhead |
-| **Cost Tracking** | Per-operation LLM cost breakdown with cache savings visibility |
-| **700+ Tests** | Unit, integration, e2e with FakeTelegramServer and testcontainers |
 
 ## Tech Stack
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,14 +6,16 @@ This directory is the documentation hub for the project.
 
 Use the docs by decision layer:
 
-1. [Domain](domain/) - current behavioral rules that code and tests must enforce.
-2. [Architecture](architecture.md) - code structure, module ownership, and
+1. [Product](product/) - intended users, jobs, outcomes, promises, and scope.
+2. [Domain](domain/) - current behavioral rules that code and tests must enforce.
+3. [Architecture](architecture.md) - code structure, module ownership, and
    technical decisions.
-3. [Testing](testing/) - test lanes, verification strategy, and test placement.
-4. [Project](project/) - operational learnings and non-canonical notes.
+4. [Testing](testing/) - test lanes, verification strategy, and test placement.
+5. [Project](project/) - operational learnings and non-canonical notes.
 
 If documents conflict, do not guess:
 
+- Product docs explain who the system serves and why it exists.
 - Domain docs decide current behavior.
 - Architecture docs explain implementation structure.
 - Testing docs explain how behavior is verified.
@@ -36,6 +38,7 @@ externally visible API or UI contracts.
 
 | Category | Description |
 | --- | --- |
+| [Product](product/) | Product framing, personas, jobs-to-be-done, outcomes, capabilities, and scope |
 | [Domain](domain/) | Canonical behavior for moderation, publishing, Telegram identities, and the admin web surface |
 | [Testing](testing/) | Test lanes and verification rules |
 | [Project](project/) | Learning log and operational notes |
@@ -44,6 +47,18 @@ externally visible API or UI contracts.
 | [Superpowers](superpowers/) | Historical specs and implementation plans |
 
 ## Quick Navigation
+
+### For Product Context
+
+1. Start with the root [README](../README.md).
+2. Read the [product overview](product/overview.md) for the canonical product
+   frame.
+3. Read the [Konnekt strategy](konnekt-strategy.md) for deployment-specific,
+   point-in-time positioning and goals.
+4. Use the [content style guide](content-style-guide.md) for Konnekt editorial
+   direction.
+5. Consult the [ČVUT chat analysis](cvut-chat-deep-analysis.md) as dated
+   audience research for the current Konnekt deployment.
 
 ### For Behavior Changes
 
@@ -55,9 +70,10 @@ externally visible API or UI contracts.
 
 1. Start with the root [README](../README.md).
 2. Read [AGENTS.md](../AGENTS.md).
-3. Read the [architecture overview](architecture.md).
-4. Review the [testing strategy](testing/).
-5. Check the [learning log](project/learning.md) for sharp edges.
+3. Read the [product overview](product/overview.md).
+4. Read the [architecture overview](architecture.md).
+5. Review the [testing strategy](testing/).
+6. Check the [learning log](project/learning.md) for sharp edges.
 
 ### For Existing Context
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,65 @@
+# Supervisor Telegram Documentation
+
+This directory is the documentation hub for the project.
+
+## Source Of Truth Hierarchy
+
+Use the docs by decision layer:
+
+1. [Domain](domain/) - current behavioral rules that code and tests must enforce.
+2. [Architecture](architecture.md) - code structure, module ownership, and
+   technical decisions.
+3. [Testing](testing/) - test lanes, verification strategy, and test placement.
+4. [Project](project/) - operational learnings and non-canonical notes.
+
+If documents conflict, do not guess:
+
+- Domain docs decide current behavior.
+- Architecture docs explain implementation structure.
+- Testing docs explain how behavior is verified.
+- Project docs record lessons and operational context, but do not override domain
+  rules.
+
+## Documentation-Driven TDD
+
+When behavior changes:
+
+1. Update the relevant domain document first.
+2. Add or update a failing test that captures the new rule.
+3. Implement the minimal code needed to pass the test.
+4. Refactor after the documented behavior is protected by tests.
+
+Use this loop for product behavior, auth boundaries, database semantics, and
+externally visible API or UI contracts.
+
+## Documentation Structure
+
+| Category | Description |
+| --- | --- |
+| [Domain](domain/) | Canonical behavior for moderation, publishing, Telegram identities, and the admin web surface |
+| [Testing](testing/) | Test lanes and verification rules |
+| [Project](project/) | Learning log and operational notes |
+| [Reviews](reviews/) | Point-in-time audits and review reports |
+| [Archive](archive/) | Historical analysis and superseded material |
+| [Superpowers](superpowers/) | Historical specs and implementation plans |
+
+## Quick Navigation
+
+### For Behavior Changes
+
+1. Read the relevant [domain document](domain/).
+2. Update that rule first if behavior is changing.
+3. Follow the [testing strategy](testing/) when choosing the first failing test.
+
+### For New Contributors
+
+1. Start with the root [README](../README.md).
+2. Read [AGENTS.md](../AGENTS.md).
+3. Read the [architecture overview](architecture.md).
+4. Review the [testing strategy](testing/).
+5. Check the [learning log](project/learning.md) for sharp edges.
+
+### For Existing Context
+
+- Historical reviews and implementation plans are useful context, but they are
+  not canonical behavior once domain docs or code have moved on.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,15 +1,19 @@
 # Architecture
 
-> Last updated: 2026-03-13
+> Last updated: 2026-05-18
 
 ## Design Philosophy
 
-**Feature-based modular architecture** — not pure DDD, not flat scripts. Each feature module groups its own models, services, and handlers. Shared infrastructure (DB, config, logging) lives in `core/` and `infrastructure/`. ORM models serve as the single data representation — no entity/model mapping layer.
+**Feature-based modular architecture** — not pure DDD, not flat scripts. Each
+feature module groups its own models, services, and handlers. Shared foundations
+live in `core/`, persistence lives in `db/`, and Telegram client access lives in
+`telethon/`. ORM models serve as the single data representation — no
+entity/model mapping layer.
 
 Key principles:
 - **ORM models are the domain models** where there's a single data source (which is most of the codebase)
 - **No abstract interfaces** unless there are multiple implementations
-- **Feature modules** (`moderation/`, `agent/channel/`, `assistant/`) own their vertical slice
+- **Feature modules** (`moderation/`, `channel/`, `assistant/`) own their vertical slice
 - **No backward-compat shims** — all migrations complete, no legacy re-export files
 
 ## Module Map
@@ -188,9 +192,4 @@ All shared enums in `app/core/enums.py`: `PostStatus`, `EscalationStatus`, `Revi
 
 ## Testing
 
-- **600+ tests**, ~20s runtime
-- **Unit**: SQLite in-memory, mocked dependencies
-- **Integration**: testcontainers PostgreSQL (real DB)
-- **E2E**: `FakeTelegramServer` (aiohttp-based Bot API simulator)
-- **Pre-commit**: ruff + ty on commit, pytest on push
-- **Factories**: `tests/factories.py` — ORM model factories (User, Chat, Admin, Message, ChatLink)
+See [Testing Strategy](testing/README.md) for the canonical verification model.

--- a/docs/content-style-guide.md
+++ b/docs/content-style-guide.md
@@ -1,5 +1,9 @@
 # Konnekt Content Style Guide
 
+> Deployment-specific editorial guidance for Konnekt. This is not the canonical
+> Supervisor Telegram product contract; use `docs/product/overview.md` for
+> durable product scope.
+
 ## Competitor Analysis (March 2026)
 
 ### @the_cesko (~5k views/post)

--- a/docs/cvut-chat-deep-analysis.md
+++ b/docs/cvut-chat-deep-analysis.md
@@ -2,6 +2,10 @@
 
 *Дата: 2026-03-11 22:40 UTC*
 
+> Deployment-specific, dated audience research for Konnekt. This is not the
+> canonical Supervisor Telegram product contract; use
+> `docs/product/overview.md` for durable product scope.
+
 Модель: google/gemini-2.5-flash-lite | Сообщений: 45,494 | Период: 2022-08 → 2026-03 | Месяцев: 44
 
 ---

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -1,0 +1,34 @@
+# Domain Ground Truth
+
+This section is the canonical behavioral reference for Supervisor Telegram.
+Use it before changing behavior, writing tests, or reviewing externally visible
+contracts.
+
+## Documents
+
+- [Moderation](moderation.md) - moderator bot behavior, escalation, and
+  blacklist rules.
+- [Content Pipeline](content-pipeline.md) - source fetching, review, publishing,
+  and scheduling rules.
+- [Admin Web](admin-web.md) - public read access, authenticated admin actions,
+  and the web surface contract.
+- [Telegram Identities](telegram-identities.md) - responsibilities of the
+  moderator bot, assistant bot, and Telethon userbot.
+
+## Rules
+
+- Domain docs own current behavior.
+- Architecture docs explain code structure, not product truth.
+- Project learnings record incidents and lessons, not the behavioral contract.
+- Historical plans and reviews are reference material only after the relevant
+  behavior has shipped.
+
+## Change Process
+
+When domain behavior changes:
+
+1. Update the relevant domain document first.
+2. Add or update a failing test that captures the new rule.
+3. Implement the minimal code needed to pass the test.
+4. Update architecture or operational docs only when the implementation shape or
+   deployment contract also changed.

--- a/docs/domain/admin-web.md
+++ b/docs/domain/admin-web.md
@@ -5,6 +5,7 @@ The web surface has a public read layer and an authenticated admin layer.
 ## Core Rules
 
 - Public visitors may access only explicitly public, read-only endpoints.
+- The current public endpoint is `GET /api/public/catalog`.
 - Public responses must expose only fields intended for anonymous viewers.
 - Administrative reads and all mutations require an authenticated admin session.
 - Authentication shortcuts or bypass flags are not valid production or remote

--- a/docs/domain/admin-web.md
+++ b/docs/domain/admin-web.md
@@ -1,0 +1,22 @@
+# Admin Web
+
+The web surface has a public read layer and an authenticated admin layer.
+
+## Core Rules
+
+- Public visitors may access only explicitly public, read-only endpoints.
+- Public responses must expose only fields intended for anonymous viewers.
+- Administrative reads and all mutations require an authenticated admin session.
+- Authentication shortcuts or bypass flags are not valid production or remote
+  development behavior.
+- Magic links are an administrator access mechanism and must be generated only
+  through trusted admin-only flows.
+
+## Tests
+
+- Anonymous access tests must prove the public projection is available and does
+  not leak admin-only fields.
+- Protected endpoint tests must prove anonymous requests are rejected.
+- Authenticated tests must prove allowed admin actions still succeed.
+- UI tests should preserve the distinction between public browsing and
+  authenticated administration.

--- a/docs/domain/content-pipeline.md
+++ b/docs/domain/content-pipeline.md
@@ -1,19 +1,27 @@
 # Content Pipeline
 
-The content pipeline turns external sources into reviewed Telegram posts with a
-human approval step before publication.
+The content pipeline turns external sources into Telegram posts. Channels with a
+review chat use a human approval step before publication; channels without one
+publish directly after generation.
 
 ## Core Flow
 
 `fetch_sources -> split_and_enrich_topics -> screen_content -> generate_post ->
-send_for_review -> publish_post | handle_rejection`
+send_for_review -> await_review -> publish_post | handle_rejection`
+
+When a channel has no review chat, `send_for_review` publishes directly and the
+workflow completes without `await_review`.
 
 ## Core Rules
 
 - Source content is fetched, normalized, and screened before post generation.
 - Duplicate or near-duplicate topics are filtered before publication decisions.
-- Generated posts require review before they are published to a channel.
+- Generated posts require review before publication when the channel has a
+  review chat configured.
+- Channels without a review chat use the direct publish path.
 - Review supports approve, reject, regenerate, edit, and schedule outcomes.
+- Administrator approve/reject decisions may be retained and summarized as
+  future generation context.
 - Scheduled Telegram publication uses the Telethon userbot because the Bot API
   does not provide the required client-level scheduling behavior.
 - Source URLs obtained from external or model-produced input must pass SSRF-safe

--- a/docs/domain/content-pipeline.md
+++ b/docs/domain/content-pipeline.md
@@ -1,0 +1,27 @@
+# Content Pipeline
+
+The content pipeline turns external sources into reviewed Telegram posts with a
+human approval step before publication.
+
+## Core Flow
+
+`fetch_sources -> split_and_enrich_topics -> screen_content -> generate_post ->
+send_for_review -> publish_post | handle_rejection`
+
+## Core Rules
+
+- Source content is fetched, normalized, and screened before post generation.
+- Duplicate or near-duplicate topics are filtered before publication decisions.
+- Generated posts require review before they are published to a channel.
+- Review supports approve, reject, regenerate, edit, and schedule outcomes.
+- Scheduled Telegram publication uses the Telethon userbot because the Bot API
+  does not provide the required client-level scheduling behavior.
+- Source URLs obtained from external or model-produced input must pass SSRF-safe
+  validation before fetching.
+
+## Tests
+
+- Pure transformations and scheduling calculations belong in unit tests.
+- Deduplication and persistence-sensitive behavior belong in PostgreSQL
+  integration tests when they depend on pgvector or database semantics.
+- End-to-end tests should cover the review workflow and observable Telegram I/O.

--- a/docs/domain/moderation.md
+++ b/docs/domain/moderation.md
@@ -1,0 +1,30 @@
+# Moderation
+
+The moderation surface combines deterministic bot commands with an AI-assisted
+decision layer. Human administrators remain the authority for uncertain cases.
+
+## Core Rules
+
+- The moderator bot owns mechanical moderation commands such as mute, ban,
+  blacklist, welcome, report, and spam workflows.
+- AI moderation may recommend or execute actions only within the supported
+  moderation action set.
+- Uncertain decisions must be escalated to administrators with a bounded timeout
+  instead of being left unresolved indefinitely.
+- Recent administrator corrections are valid moderation context and may be used
+  to calibrate later decisions.
+- Global blacklist membership applies across managed chats.
+
+## Telegram Output Rules
+
+- Moderator bot messages use HTML by default.
+- Any send or edit operation that supplies Telegram entities must pass
+  `parse_mode=None`, otherwise Telegram may ignore the explicit entities.
+
+## Tests
+
+- Local moderation rules belong in unit tests.
+- Repository and cross-chat blacklist behavior belongs in integration tests when
+  it depends on real persistence semantics.
+- End-to-end tests should cover observable Telegram workflows such as reports,
+  escalations, and admin callbacks.

--- a/docs/domain/telegram-identities.md
+++ b/docs/domain/telegram-identities.md
@@ -1,0 +1,23 @@
+# Telegram Identities
+
+Supervisor Telegram uses three Telegram identities with distinct
+responsibilities.
+
+## Identities
+
+| Identity | Responsibility |
+| --- | --- |
+| Moderator bot | Mechanical commands, moderation workflows, welcome/captcha behavior, and channel publishing through the Bot API |
+| Assistant bot | Conversational admin interface and higher-level tool orchestration |
+| Telethon userbot | Client API capabilities unavailable to bots, including history/search access and scheduled messages |
+
+## Core Rules
+
+- Keep responsibilities explicit. Do not move userbot-only behavior into bot API
+  code or vice versa.
+- Treat the Telethon session as sensitive account-level state.
+- Production and development instances must not run concurrently against the
+  same bot tokens, userbot session identity, and database unless that overlap is
+  explicitly intended and safe.
+- When one workflow crosses identities, tests and docs should state which
+  identity performs each externally visible action.

--- a/docs/konnekt-strategy.md
+++ b/docs/konnekt-strategy.md
@@ -2,6 +2,10 @@
 
 *2026-03-11 22:43 UTC*
 
+> Deployment-specific, point-in-time context for the Konnekt audience. This is
+> not the canonical Supervisor Telegram product contract; use
+> `docs/product/overview.md` for durable product scope.
+
 На основе: анализ 3 конкурентов (300 постов), 45,494 сообщений чата ČVUT (3.5 года), сравнение 3 LLM-моделей
 
 ---

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,0 +1,30 @@
+# Product Documentation
+
+This section is the canonical product and business reference for Supervisor
+Telegram.
+
+Use it to answer:
+
+- who the product is for;
+- which jobs it exists to help with;
+- which business outcomes matter;
+- which capabilities belong to the product;
+- what is explicitly in scope and out of scope;
+- which statements are product promises versus technical enablers.
+
+## Documents
+
+- [Product Overview](overview.md) - target users, jobs-to-be-done, outcomes,
+  capabilities, promises, enablers, and scope boundaries.
+
+## Relationship To Other Docs
+
+- Product docs define business intent and scope.
+- [Domain docs](../domain/) define current behavior that code and tests must
+  enforce.
+- [Architecture](../architecture.md) explains implementation structure.
+- [Testing](../testing/) explains verification strategy.
+
+When business intent changes, update the product docs first. When current
+behavior changes, update the relevant domain doc before tests and
+implementation.

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -1,0 +1,123 @@
+# Product Overview
+
+Supervisor Telegram helps teams operating Telegram communities and channels keep
+conversations healthy, publishing consistent, and operations visible while
+retaining human control over high-impact decisions.
+
+## Target Users
+
+| Persona | Primary Need |
+| --- | --- |
+| Community operator | Keep one or more Telegram communities useful, safe, and manageable as activity grows |
+| Moderator or administrator | Resolve reports, enforce rules, and handle edge cases quickly and consistently |
+| Channel editor or content manager | Turn source material into publishable posts on a reliable schedule without rebuilding the workflow by hand |
+| Operations owner | Understand managed chats, channels, public catalog state, and AI spend from authenticated operating surfaces |
+| Community member | Participate in a healthier community and receive more useful channel content; this is a beneficiary persona, not the primary operator |
+
+## Jobs To Be Done
+
+- When a Telegram community creates more moderation work than admins can handle
+  manually, help operators enforce policy consistently while escalating uncertain
+  cases to humans.
+- When a channel needs regular useful posts, help editors move from source
+  discovery to publication with less repetitive work and review where configured.
+- When admins need to run day-to-day community and channel operations, help them
+  manage workflows from familiar control surfaces instead of stitching together
+  ad hoc tools.
+- When operator judgment improves the system, preserve that feedback so later
+  moderation and content decisions can better reflect admin preferences.
+- When operators expose a public catalog, help anonymous visitors browse the
+  intended public projection without granting administrative authority.
+- When AI-backed operations cost money, help operators see spend patterns before
+  they become invisible operating risk.
+
+## Business Outcomes
+
+- Reduce repetitive moderation effort without removing human authority from
+  uncertain decisions.
+- Improve consistency of enforcement across managed chats.
+- Shorten the path from source material to publishable content.
+- Support a dependable publishing cadence with review where a review channel is
+  configured.
+- Reduce operational friction for admins managing moderation and channel work.
+- Make public catalog exposure and AI spend visible enough to operate.
+
+## Product Promises
+
+| Promise | What must stay true |
+| --- | --- |
+| Humans retain control where judgment matters | Uncertain moderation decisions escalate to admins, and generated posts enter review when the channel is configured for review |
+| Routine work becomes easier to operate | The platform reduces repeated manual steps across moderation and publishing instead of only moving them elsewhere |
+| Feedback is preserved for later use | Admin corrections and editorial decisions are stored so future moderation and content workflows can use them as context |
+| Public visibility does not imply admin authority | Public read access and authenticated administrative actions remain separate |
+| Operating cost is inspectable | AI spend is visible to operators instead of hidden inside background automation |
+
+## Product Capabilities
+
+| Capability Group | Business Meaning | Included Capabilities |
+| --- | --- | --- |
+| Community safety | Keep chats healthier with less repetitive administrator effort | Mechanical moderation, assisted moderation, reports, spam workflows, cross-chat blacklist context, escalation |
+| Content operations | Move from source material to publication predictably | Source intake, duplicate filtering, drafting, optional review, publish, schedule |
+| Operator control | Let a small team run supported workflows coherently | Conversational administration, authenticated admin surface, public catalog projection, cross-workflow visibility |
+| Learning loop | Preserve the team's actual decisions for later context | Moderation corrections and content approve/reject feedback retained for future workflows |
+| Spend visibility | Keep AI-backed work financially inspectable | Session operation/model breakdowns, daily cost history, cache savings visibility |
+
+## Technical Enablers
+
+These matter to delivery, but they are not product promises on their own. The
+current concrete choices live in [architecture](../architecture.md).
+
+| Enabler | Role |
+| --- | --- |
+| Telegram API separation | Split bot and client-level responsibilities safely |
+| LLM-assisted workflows | Support assisted decisions, drafting, and natural-language control |
+| Durable workflow orchestration | Persist and resume multi-step content flows |
+| Persistence and semantic search | Store state and support duplicate detection |
+| Source integrations | Supply candidate source material |
+| Automated verification | Keep the system maintainable as behavior changes |
+
+## In Scope
+
+- Telegram communities and channels managed by platform operators.
+- Mechanical and AI-assisted moderation workflows.
+- Content generation, editing, publishing, and scheduling, with review where a
+  review channel is configured.
+- Administrator workflows exposed through Telegram and authenticated web
+  surfaces.
+- Public read-only views only where they are intentionally exposed.
+- Cost and usage visibility for AI-backed operations.
+- Feedback from administrator decisions where it can improve later moderation or
+  content workflows.
+
+## Out Of Scope
+
+- General-purpose social media management outside Telegram.
+- Fully autonomous publishing as the default product posture for channels that
+  are configured with a review workflow.
+- Removing human authority from uncertain moderation decisions.
+- Replacing operator ownership of community policy, factual verification, or
+  editorial judgment.
+- Member-facing customer support or general chat assistance unrelated to the
+  supported moderation workflows.
+- Business systems such as advertising, payments, CRM, or subscriber
+  monetization.
+
+## Boundary With Domain Rules
+
+This document defines product intent, not executable workflow detail. Exact
+rules for moderation, content flow, Telegram identities, and admin access live in
+the [domain docs](../domain/).
+
+## Wording Risks
+
+- **"AI moderation"** can imply autonomous enforcement. Prefer **assisted
+  moderation** unless the text is explicitly about a deterministic automated
+  path.
+- **"Automated publishing"** can imply posts always go live without review.
+  Prefer **content operations** or **publishing workflow**, and state whether a
+  channel is configured for review.
+- **"General-purpose platform"** overstates the current evidence unless we can
+  name supported audiences and workflows beyond the present operating model.
+- Workflow libraries, database extensions, model routers, Telegram client
+  details, and the number of bots are enablers, not customer outcomes. Keep them
+  out of high-level product promises.

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,0 +1,9 @@
+# Project Notes
+
+Project-level notes live here when they are useful to future work but are not
+canonical domain behavior.
+
+- [Learning Log](learning.md) - recurring issues, root causes, and fixes worth
+  remembering.
+
+Use `docs/domain/` for behavior that code and tests must enforce.

--- a/docs/project/learning.md
+++ b/docs/project/learning.md
@@ -1,0 +1,36 @@
+# Learning Log
+
+A running log of issues, root causes, and fixes that are useful to remember
+while working on the project.
+
+## Telegram Entity Rendering
+
+### Explicit entities are ignored without `parse_mode=None`
+
+**Cause:** The moderator bot is configured with HTML as its default parse mode.
+That default can override explicit `entities` or `caption_entities`.
+
+**Fix:** Pass `parse_mode=None` on send/edit operations that provide Telegram
+entities.
+
+## Environment Isolation
+
+### Development and production can accidentally target the same live resources
+
+**Cause:** Bot tokens, Telethon credentials, and database settings can be copied
+between local and deployed `.env` files.
+
+**Fix:** Treat bot credentials, userbot sessions, and databases as environment
+boundaries. Do not run a development instance against production identities and
+data unless that overlap is explicitly intended.
+
+## Remote Web Development
+
+### Remote access should not rely on auth bypasses
+
+**Cause:** Exposing a development web UI from a VPS makes unauthenticated bypass
+flags tempting.
+
+**Fix:** Keep the same auth contract for remote development as for production:
+public endpoints are intentionally read-only, and admin mutations require real
+authentication.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,119 @@
+# Testing Strategy
+
+Supervisor Telegram uses separate test lanes so fast feedback stays fast while
+database and Telegram behavior can still be verified at the right boundary.
+
+## Documentation-Driven TDD
+
+For behavior changes:
+
+1. Update the relevant domain document.
+2. Add or update a failing test for the new rule.
+3. Implement the smallest code change that passes.
+4. Refactor after the behavior is documented and protected.
+
+Choose the first failing test from the narrowest lane that can prove the rule.
+
+## Test Lanes
+
+### Unit Tests
+
+Command:
+
+```bash
+uv run pytest tests/unit
+```
+
+Use for:
+
+- pure functions and formatting rules;
+- service logic with mocked external boundaries;
+- scheduling calculations and branch-heavy behavior that does not need a real
+  database.
+
+SQLite-backed fixtures are acceptable when the rule does not depend on
+PostgreSQL-specific semantics.
+
+### PostgreSQL Integration Tests
+
+Command:
+
+```bash
+uv run pytest tests/integration
+```
+
+Use for:
+
+- repository behavior;
+- Alembic-sensitive persistence paths;
+- PostgreSQL-only features such as pgvector;
+- constraints, indexes, cascades, and query behavior that SQLite cannot prove.
+
+Integration tests use the PostgreSQL 18 pgvector testcontainer image. Prefer
+this lane whenever the implementation claim depends on PostgreSQL behavior.
+
+### Telegram End-To-End Tests
+
+Command:
+
+```bash
+uv run pytest tests/e2e
+```
+
+Use for:
+
+- full moderator or review workflows;
+- Telegram callback flows;
+- assertions about Bot API requests made across the workflow.
+
+These tests use `FakeTelegramServer`. They prove local workflow behavior without
+calling real Telegram.
+
+### Web API Tests
+
+Command:
+
+```bash
+uv run pytest tests/webapi
+```
+
+Use for:
+
+- public/admin route contracts;
+- auth boundaries;
+- response projections;
+- mutation behavior exposed through FastAPI.
+
+When a web UI change only rearranges client presentation, use frontend checks in
+addition to the API tests rather than forcing the behavior into backend tests.
+
+## Test Authoring Rules
+
+- Add the smallest test that fails for the right reason.
+- Prefer unit tests first when the rule is local.
+- Use PostgreSQL integration tests for database guarantees, not broad workflow
+  coverage.
+- Use E2E tests for user-visible flows, not as the first place to encode every
+  domain rule.
+- Create only the data each test needs.
+- Mock external APIs unless the test explicitly targets the boundary itself.
+
+## Verification
+
+Use the narrowest command that proves the change, then widen when risk warrants
+it:
+
+```bash
+uv run ruff check app tests
+uv run ruff format --check app tests
+uv run ty check app tests
+uv run pytest tests/unit
+uv run pytest tests/integration
+uv run pytest tests/e2e
+uv run pytest tests/webapi
+pnpm --dir webui run check
+pnpm --dir webui run build
+```
+
+CI runs linting, formatting, typing, the full pytest suite with coverage, and
+the web UI checks.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,7 @@
 # Testing Guide
 
-This document provides guidance for testing the moderator-bot project.
+This file contains practical testing examples and fixture notes. The canonical
+test strategy lives in [`docs/testing/README.md`](../docs/testing/README.md).
 
 ## Testing Strategy
 


### PR DESCRIPTION
## What changed
- Added canonical product documentation under `docs/product/` for personas, jobs-to-be-done, outcomes, product promises, capabilities, scope, and wording risks.
- Updated README and docs navigation so product intent is described before architecture details.
- Aligned domain docs with current behavior for conditional content review/direct publish and the public catalog endpoint.
- Marked Konnekt strategy/style/audience docs as deployment-specific, point-in-time context.

## Why
The project had strong technical documentation but weaker high-level business feature framing. This gives future feature work a product source of truth before implementation detail.

## Validation
- `git diff --check`
- Pre-commit/pre-push hooks during commit and push, including ruff, ty, and pytest unit + e2e hooks.