### PR TITLE
[codex] Add chat resource approval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.bak.*
 .venv
 env/
 venv/

--- a/alembic/versions/0ad1ead50003_add_chat_resource_status.py
+++ b/alembic/versions/0ad1ead50003_add_chat_resource_status.py
@@ -1,0 +1,39 @@
+"""Add operating status to chats.
+
+Revision ID: 0ad1ead50003
+Revises: 0ad1ead50002
+Create Date: 2026-06-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0ad1ead50003"
+down_revision: str | None = "0ad1ead50002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chats",
+        sa.Column(
+            "resource_status",
+            sa.String(),
+            nullable=False,
+            server_default="approved",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_chats_resource_status",
+        "chats",
+        "resource_status IN ('discovered', 'approved', 'disabled')",
+    )
+    op.alter_column("chats", "resource_status", server_default="discovered")
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_chats_resource_status", "chats", type_="check")
+    op.drop_column("chats", "resource_status")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -38,8 +38,14 @@ class Admin(Base):
 class Chat(Base):
     __tablename__ = "chats"
 
+    STATUS_DISCOVERED = "discovered"
+    STATUS_APPROVED = "approved"
+    STATUS_DISABLED = "disabled"
+    VALID_RESOURCE_STATUSES = frozenset({STATUS_DISCOVERED, STATUS_APPROVED, STATUS_DISABLED})
+
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
     title: Mapped[str | None] = mapped_column(String, nullable=True)
+    resource_status: Mapped[str] = mapped_column(String, default=STATUS_DISCOVERED, nullable=False)
     is_forum: Mapped[bool] = mapped_column(Boolean, default=False)
     welcome_message: Mapped[str | None] = mapped_column(String, nullable=True)
     time_delete: Mapped[int] = mapped_column(Integer, default=60)
@@ -77,6 +83,7 @@ class Chat(Base):
         self,
         id: int,
         title: str | None = None,
+        resource_status: str = STATUS_DISCOVERED,
         is_forum: bool = False,
         welcome_message: str | None = None,
         time_delete: int = 60,
@@ -87,6 +94,7 @@ class Chat(Base):
     ) -> None:
         self.id = id
         self.title = title
+        self.set_resource_status(resource_status)
         self.is_forum = is_forum
         self.welcome_message = welcome_message
         self.time_delete = time_delete
@@ -123,6 +131,16 @@ class Chat(Base):
     def disable_captcha(self) -> None:
         """Disable captcha"""
         self.is_captcha_enabled = False
+
+    def set_resource_status(self, status: str) -> None:
+        """Set whether the bot may actively operate in this chat."""
+        if status not in self.VALID_RESOURCE_STATUSES:
+            raise ValueError(f"Unknown chat resource status: {status}")
+        self.resource_status = status
+
+    @property
+    def is_approved(self) -> bool:
+        return self.resource_status == self.STATUS_APPROVED
 
 
 class User(Base):

--- a/app/db/repositories/chat.py
+++ b/app/db/repositories/chat.py
@@ -28,6 +28,7 @@ class ChatRepository:
         chat_model = await self._get_chat_model(chat.id)
         if chat_model:
             chat_model.title = chat.title
+            chat_model.resource_status = chat.resource_status
             chat_model.is_forum = chat.is_forum
             chat_model.welcome_message = chat.welcome_message
             chat_model.time_delete = chat.time_delete
@@ -37,6 +38,7 @@ class ChatRepository:
             chat_model = Chat(
                 id=chat.id,
                 title=chat.title,
+                resource_status=chat.resource_status,
                 is_forum=chat.is_forum,
                 welcome_message=chat.welcome_message,
                 time_delete=chat.time_delete,

--- a/app/presentation/telegram/bot.py
+++ b/app/presentation/telegram/bot.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 from app.db.session import close_db, create_session_maker, insert_chat_link
 from app.presentation.telegram.handlers import router
 from app.presentation.telegram.middlewares import (
+    ApprovedChatGateMiddleware,
     BlacklistMiddleware,
     DependenciesMiddleware,
     HistoryMiddleware,
@@ -106,6 +107,7 @@ def _setup_main_bot(
     dp.update.middleware(DependenciesMiddleware(session_pool=session_maker, bot=bot))
     dp.update.middleware(ManagedChatsMiddleware())
     dp.update.middleware(HistoryMiddleware())
+    dp.update.middleware(ApprovedChatGateMiddleware())
     dp.message.middleware(BlacklistMiddleware())
     dp.callback_query.middleware(CallbackAnswerMiddleware())
 

--- a/app/presentation/telegram/middlewares/__init__.py
+++ b/app/presentation/telegram/middlewares/__init__.py
@@ -1,11 +1,12 @@
 from .black_list import BlacklistMiddleware
 from .dependencies import DependenciesMiddleware
 from .history import HistoryMiddleware
-from .managed_chats import ManagedChatsMiddleware
+from .managed_chats import ApprovedChatGateMiddleware, ManagedChatsMiddleware
 
 __all__ = [
     "DependenciesMiddleware",
     "BlacklistMiddleware",
     "ManagedChatsMiddleware",
+    "ApprovedChatGateMiddleware",
     "HistoryMiddleware",
 ]

--- a/app/presentation/telegram/middlewares/history.py
+++ b/app/presentation/telegram/middlewares/history.py
@@ -38,6 +38,9 @@ class HistoryMiddleware(BaseMiddleware):
             except Exception as err:
                 logger.error("save_message_failed", error=str(err))
 
+            if not data.get("chat_is_approved", True):
+                return await handler(event, data)
+
             if isinstance(user, types.User):
                 try:
                     signals = await ad_detector_service.record_ad_signals(

--- a/app/presentation/telegram/middlewares/managed_chats.py
+++ b/app/presentation/telegram/middlewares/managed_chats.py
@@ -1,44 +1,23 @@
-import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
-from aiogram import BaseMiddleware, Bot, types
+from aiogram import BaseMiddleware, types
 from aiogram.types import TelegramObject
+from sqlalchemy import select
 
-from app.core.config import settings
+from app.db.models import Chat
 from app.moderation import history_service
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
-# TTL cache for chat admin checks (chat_id -> (admin_ids, expire_time))
-_admin_cache: dict[int, tuple[set[int], float]] = {}
-_CACHE_TTL = 300  # 5 minutes
-_MAX_CACHE_SIZE = 200
 
-
-def _evict_expired_cache() -> None:
-    """Remove expired entries from the admin cache."""
-    now = time.monotonic()
-    expired = [k for k, (_, ttl) in _admin_cache.items() if ttl < now]
-    for k in expired:
-        del _admin_cache[k]
-
-
-async def _is_managed_chat(bot: Bot, chat_id: int) -> bool:
-    """Check if bot's super admin is an admin in the chat (cached)."""
-    if len(_admin_cache) > _MAX_CACHE_SIZE:
-        _evict_expired_cache()
-    now = time.monotonic()
-    cached = _admin_cache.get(chat_id)
-    if cached and cached[1] > now:
-        admin_ids = cached[0]
-    else:
-        chat_admins = await bot.get_chat_administrators(chat_id)
-        admin_ids = {admin.user.id for admin in chat_admins}
-        _admin_cache[chat_id] = (admin_ids, now + _CACHE_TTL)
-
-    return any(sa in admin_ids for sa in settings.admin.super_admins)
+def _group_message(event: TelegramObject) -> types.Message | None:
+    if not isinstance(event, types.Update) or not isinstance(event.message, types.Message):
+        return None
+    if event.message.chat.type not in ["group", "supergroup"]:
+        return None
+    return event.message
 
 
 class ManagedChatsMiddleware(BaseMiddleware):
@@ -51,21 +30,33 @@ class ManagedChatsMiddleware(BaseMiddleware):
         event: TelegramObject,
         data: dict[str, Any],
     ) -> Any:
-        bot: Bot = data["bot"]
         db: AsyncSession = data["db"]
-        if (
-            isinstance(event, types.Update)
-            and isinstance(event.message, types.Message)
-            and event.message.chat.type in ["group", "supergroup"]
-        ):
-            message = event.message
-            if await _is_managed_chat(bot, message.chat.id):
-                await history_service.merge_chat(db, message.chat)
-                return await handler(event, data)
+        message = _group_message(event)
+        if message is not None:
+            await history_service.merge_chat(db, message.chat)
+            status = await db.scalar(select(Chat.resource_status).where(Chat.id == message.chat.id))
+            data["chat_resource_status"] = status or Chat.STATUS_DISCOVERED
+            data["chat_is_approved"] = status == Chat.STATUS_APPROVED
 
-            # If no super admin in chat, leave
-            await bot.leave_chat(message.chat.id)
-            # Invalidate cache for this chat
-            _admin_cache.pop(message.chat.id, None)
+        return await handler(event, data)
+
+
+class ApprovedChatGateMiddleware(BaseMiddleware):
+    """Stop active bot behavior in discovered or disabled group resources.
+
+    This middleware must run after HistoryMiddleware so passive history capture
+    still happens for resources awaiting approval.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict[str, Any],
+    ) -> Any:
+        if _group_message(event) is not None and not data.get("chat_is_approved", False):
             return None
         return await handler(event, data)

--- a/app/webapi/routes/chats.py
+++ b/app/webapi/routes/chats.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import io
-from typing import Annotated
+from typing import Annotated, cast
 
 from aiogram import Bot
 from aiogram.exceptions import TelegramBadRequest
@@ -36,6 +36,7 @@ from app.webapi.schemas import (
     ChatDetail,
     ChatNode,
     ChatRead,
+    ChatResourceStatus,
     ChatSender,
     ChatUpdate,
     HeatmapCell,
@@ -55,6 +56,10 @@ _SNAPSHOTS_LIMIT = 50
 _SPAM_PINGS_LIMIT = 30
 _RECENT_SENDERS_LOOKBACK_DAYS = 7
 _RECENT_SENDERS_LIMIT = 25
+
+
+def _resource_status(status: str) -> ChatResourceStatus:
+    return cast("ChatResourceStatus", status)
 
 
 def _build_heatmap(timestamps: list[datetime.datetime]) -> list[HeatmapCell]:
@@ -77,6 +82,7 @@ async def list_chats(
         ChatRead(
             id=chat.id,
             title=chat.title,
+            resource_status=_resource_status(chat.resource_status),
             is_forum=chat.is_forum,
             is_welcome_enabled=chat.is_welcome_enabled,
             is_captcha_enabled=chat.is_captcha_enabled,
@@ -254,6 +260,7 @@ async def get_chat(
     return ChatDetail(
         id=chat.id,
         title=chat.title,
+        resource_status=_resource_status(chat.resource_status),
         is_forum=chat.is_forum,
         is_welcome_enabled=chat.is_welcome_enabled,
         is_captcha_enabled=chat.is_captcha_enabled,
@@ -291,6 +298,10 @@ async def update_chat(
     fields = payload.model_dump(exclude_unset=True)
     if "time_delete" in fields and fields["time_delete"] is not None and fields["time_delete"] <= 0:
         raise HTTPException(status_code=422, detail="time_delete must be positive")
+    if "resource_status" in fields and fields["resource_status"] is not None:
+        status: ChatResourceStatus = fields["resource_status"]
+        if status not in Chat.VALID_RESOURCE_STATUSES:
+            raise HTTPException(status_code=422, detail="Unknown resource status")
     if "parent_chat_id" in fields and fields["parent_chat_id"] == chat_id:
         raise HTTPException(status_code=422, detail="A chat cannot be its own parent")
     if "parent_chat_id" in fields and fields["parent_chat_id"] is not None:
@@ -322,6 +333,7 @@ async def update_chat(
     return ChatRead(
         id=chat.id,
         title=chat.title,
+        resource_status=_resource_status(chat.resource_status),
         is_forum=chat.is_forum,
         is_welcome_enabled=chat.is_welcome_enabled,
         is_captcha_enabled=chat.is_captcha_enabled,
@@ -425,6 +437,7 @@ async def refresh_chat_from_telegram(
     return ChatRead(
         id=chat.id,
         title=chat.title,
+        resource_status=_resource_status(chat.resource_status),
         is_forum=chat.is_forum,
         is_welcome_enabled=chat.is_welcome_enabled,
         is_captcha_enabled=chat.is_captcha_enabled,

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -7,6 +7,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
+ChatResourceStatus = Literal["discovered", "approved", "disabled"]
+
 
 class PostRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
@@ -178,6 +180,7 @@ class ChatRead(BaseModel):
 
     id: int
     title: str | None
+    resource_status: ChatResourceStatus
     is_forum: bool
     is_welcome_enabled: bool
     is_captcha_enabled: bool
@@ -194,6 +197,7 @@ class ChatUpdate(BaseModel):
     keys present in the body are applied (``exclude_unset``)."""
 
     title: str | None = None
+    resource_status: ChatResourceStatus | None = None
     welcome_message: str | None = None
     is_welcome_enabled: bool | None = None
     is_captcha_enabled: bool | None = None

--- a/docs/domain/moderation.md
+++ b/docs/domain/moderation.md
@@ -7,6 +7,16 @@ decision layer. Human administrators remain the authority for uncertain cases.
 
 - The moderator bot owns mechanical moderation commands such as mute, ban,
   blacklist, welcome, report, and spam workflows.
+- Telegram group and supergroup resources have an explicit operating status:
+  `discovered`, `approved`, or `disabled`.
+- When the bot sees a group or supergroup that is not yet approved, it records
+  the chat, users, and messages it can observe, but it must not leave the chat
+  and must not perform public moderation actions there.
+- Public bot actions, including moderation commands, blacklist enforcement,
+  welcome/captcha behavior, spam prompts, and sponsored-ad moderator alerts, run
+  only for chats with status `approved`.
+- Administrators approve or disable discovered resources from the authenticated
+  admin web surface.
 - AI moderation may recommend or execute actions only within the supported
   moderation action set.
 - Uncertain decisions must be escalated to administrators with a bounded timeout

--- a/tests/e2e/test_agent_moderation.py
+++ b/tests/e2e/test_agent_moderation.py
@@ -28,7 +28,10 @@ from aiogram.types import (
 )
 from aiogram.utils.callback_answer import CallbackAnswerMiddleware
 from app.db.models import AgentEscalation
+from app.db.models import Chat as DbChat
+from app.db.models import Message as DbMessage
 from app.presentation.telegram.middlewares import (
+    ApprovedChatGateMiddleware,
     DependenciesMiddleware,
     HistoryMiddleware,
     ManagedChatsMiddleware,
@@ -219,8 +222,13 @@ async def dispatcher(
     dp.update.middleware(DependenciesMiddleware(session_pool=db_session_maker, bot=bot))
     dp.update.middleware(ManagedChatsMiddleware())
     dp.update.middleware(HistoryMiddleware())
+    dp.update.middleware(ApprovedChatGateMiddleware())
     dp.callback_query.middleware(CallbackAnswerMiddleware())
     dp.include_router(_build_router())
+
+    async with db_session_maker() as session:
+        await session.merge(DbChat(id=CHAT_ID, title="Test Chat", resource_status=DbChat.STATUS_APPROVED))
+        await session.commit()
 
     yield dp
 
@@ -583,19 +591,21 @@ class TestEscalationCallback:
 class TestManagedChatsMiddleware:
     """Tests for the managed chats filtering."""
 
-    async def test_unmanaged_chat_triggers_leave(
+    async def test_unapproved_chat_is_recorded_without_public_actions(
         self,
         bot: Bot,
         db_session_maker: async_sessionmaker[AsyncSession],
         fake_tg: FakeTelegramServer,
     ):
-        """Bot should leave chats where no super admin is an admin."""
+        """Bot records discovered chats but does not interact until approved."""
         UNMANAGED_CHAT_ID = -1009999999999
         fake_tg.set_chat_admins(UNMANAGED_CHAT_ID, [777777777])  # no super admin
 
         dp = Dispatcher()
         dp.update.middleware(DependenciesMiddleware(session_pool=db_session_maker, bot=bot))
         dp.update.middleware(ManagedChatsMiddleware())
+        dp.update.middleware(HistoryMiddleware())
+        dp.update.middleware(ApprovedChatGateMiddleware())
         dp.include_router(_build_router())
 
         update = Update(
@@ -612,5 +622,17 @@ class TestManagedChatsMiddleware:
         await dp.feed_update(bot, update)
 
         leave_calls = fake_tg.get_calls("leaveChat")
-        assert len(leave_calls) >= 1
-        assert int(leave_calls[0].params["chat_id"]) == UNMANAGED_CHAT_ID
+        assert leave_calls == []
+
+        async with db_session_maker() as session:
+            chat = await session.get(DbChat, UNMANAGED_CHAT_ID)
+            assert chat is not None
+            assert chat.resource_status == DbChat.STATUS_DISCOVERED
+
+            stored_message = await session.scalar(
+                select(DbMessage).where(
+                    DbMessage.chat_id == UNMANAGED_CHAT_ID,
+                    DbMessage.message_id == 1,
+                )
+            )
+            assert stored_message is not None

--- a/tests/webapi/test_chats.py
+++ b/tests/webapi/test_chats.py
@@ -55,8 +55,28 @@ async def test_list_chats_returns_all(client_factory, db_session_maker) -> None:
     assert len(body) == 2
     titles = sorted(c["title"] for c in body)
     assert titles == ["A", "B"]
+    assert {c["resource_status"] for c in body} == {"discovered"}
     # member_count is None when telethon is absent
     assert all(c["member_count"] is None for c in body)
+
+
+async def test_update_chat_resource_status(client_factory, db_session_maker) -> None:
+    chat_id = -1003
+    async with db_session_maker() as session:
+        session.add(Chat(id=chat_id, title="Pending"))
+        await session.commit()
+
+    async with client_factory() as client:
+        resp = await client.patch(f"/api/chats/{chat_id}", json={"resource_status": "approved"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["resource_status"] == "approved"
+
+    async with db_session_maker() as session:
+        chat = await session.get(Chat, chat_id)
+        assert chat is not None
+        assert chat.resource_status == "approved"
 
 
 async def test_chat_detail_heatmap_aggregates_messages(client_factory, db_session_maker) -> None:

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -1056,6 +1056,11 @@ export interface components {
             id: number;
             /** Title */
             title: string | null;
+            /**
+             * Resource Status
+             * @enum {string}
+             */
+            resource_status: "discovered" | "approved" | "disabled";
             /** Is Forum */
             is_forum: boolean;
             /** Is Welcome Enabled */
@@ -1159,6 +1164,11 @@ export interface components {
             id: number;
             /** Title */
             title: string | null;
+            /**
+             * Resource Status
+             * @enum {string}
+             */
+            resource_status: "discovered" | "approved" | "disabled";
             /** Is Forum */
             is_forum: boolean;
             /** Is Welcome Enabled */
@@ -1215,6 +1225,8 @@ export interface components {
         ChatUpdate: {
             /** Title */
             title?: string | null;
+            /** Resource Status */
+            resource_status?: ("discovered" | "approved" | "disabled") | null;
             /** Welcome Message */
             welcome_message?: string | null;
             /** Is Welcome Enabled */

--- a/webui/src/routes/catalog/+page.svelte
+++ b/webui/src/routes/catalog/+page.svelte
@@ -20,7 +20,7 @@
 		title: string;
 		subtitle: string;
 		status: string;
-		statusKind: 'enabled' | 'disabled' | 'guarded' | 'basic';
+		statusKind: 'enabled' | 'disabled' | 'guarded' | 'pending' | 'basic';
 		metric: string;
 		identity: string;
 		path: string;
@@ -41,10 +41,22 @@
 			id: chat.id,
 			title: chat.title ?? `#${chat.id}`,
 			subtitle: chat.relation_notes ?? '',
-			status: [chat.is_captcha_enabled ? 'captcha' : null, chat.is_welcome_enabled ? 'welcome' : null]
-				.filter(Boolean)
-				.join(', ') || 'basic',
-			statusKind: chat.is_captcha_enabled || chat.is_welcome_enabled ? ('guarded' as const) : ('basic' as const),
+			status:
+				chat.resource_status === 'approved'
+					? [chat.is_captcha_enabled ? 'captcha' : null, chat.is_welcome_enabled ? 'welcome' : null]
+							.filter(Boolean)
+							.join(', ') || 'approved'
+					: chat.resource_status === 'disabled'
+						? 'disabled'
+						: 'pending approval',
+			statusKind:
+				chat.resource_status === 'disabled'
+					? ('disabled' as const)
+					: chat.resource_status === 'discovered'
+						? ('pending' as const)
+						: chat.is_captcha_enabled || chat.is_welcome_enabled
+							? ('guarded' as const)
+							: ('enabled' as const),
 			metric:
 				chat.member_count === null || chat.member_count === undefined
 					? '-'
@@ -312,7 +324,9 @@
 									<span
 										class="inline-flex h-7 w-7 items-center justify-center rounded-md border border-zinc-200 bg-white {resource.statusKind === 'enabled' || resource.statusKind === 'guarded'
 											? 'text-emerald-600'
-											: resource.statusKind === 'disabled'
+											: resource.statusKind === 'pending'
+												? 'text-amber-600'
+												: resource.statusKind === 'disabled'
 												? 'text-zinc-400'
 												: 'text-zinc-500'}"
 										title={resource.status}
@@ -324,6 +338,8 @@
 											<XCircle class="h-3.5 w-3.5" />
 										{:else if resource.statusKind === 'guarded'}
 											<ShieldCheck class="h-3.5 w-3.5" />
+										{:else if resource.statusKind === 'pending'}
+											<ShieldQuestion class="h-3.5 w-3.5" />
 										{:else}
 											<ShieldQuestion class="h-3.5 w-3.5" />
 										{/if}

--- a/webui/src/routes/chats/+page.svelte
+++ b/webui/src/routes/chats/+page.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { apiFetch } from '$lib/api/client';
+	import ChatAvatar from '$lib/components/chat/ChatAvatar.svelte';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
+	import { CheckCircle2, CircleDashed, RefreshCw, Search, Shield, XCircle } from '@lucide/svelte';
+	import { toast } from 'svelte-sonner';
+	import type { components } from '$lib/api/types';
+
+	type Chat = components['schemas']['ChatRead'];
+	type ChatStatus = Chat['resource_status'];
+	type Filter = 'all' | ChatStatus;
+
+	const chats = useLivePoll<Chat[]>('/api/chats', 60_000);
+
+	let query = $state('');
+	let filter = $state<Filter>('all');
+	let busyChatId = $state<number | null>(null);
+
+	const filtered = $derived.by(() => {
+		const q = query.trim().toLowerCase();
+		return (chats.data ?? []).filter((chat) => {
+			if (filter !== 'all' && chat.resource_status !== filter) return false;
+			if (!q) return true;
+			return [chat.title ?? '', chat.relation_notes ?? '', String(chat.id), chat.resource_status]
+				.join(' ')
+				.toLowerCase()
+				.includes(q);
+		});
+	});
+
+	const counts = $derived.by(() => {
+		const rows = chats.data ?? [];
+		return {
+			all: rows.length,
+			discovered: rows.filter((chat) => chat.resource_status === 'discovered').length,
+			approved: rows.filter((chat) => chat.resource_status === 'approved').length,
+			disabled: rows.filter((chat) => chat.resource_status === 'disabled').length
+		};
+	});
+
+	function statusLabel(status: ChatStatus): string {
+		if (status === 'approved') return 'Approved';
+		if (status === 'disabled') return 'Disabled';
+		return 'Pending';
+	}
+
+	function statusTone(status: ChatStatus): 'default' | 'secondary' | 'destructive' {
+		if (status === 'approved') return 'default';
+		if (status === 'disabled') return 'secondary';
+		return 'secondary';
+	}
+
+	async function setStatus(chat: Chat, status: ChatStatus, event?: MouseEvent): Promise<void> {
+		event?.stopPropagation();
+		if (chat.resource_status === status) return;
+
+		busyChatId = chat.id;
+		const res = await apiFetch<Chat>(`/api/chats/${chat.id}`, {
+			method: 'PATCH',
+			body: JSON.stringify({ resource_status: status })
+		});
+		busyChatId = null;
+
+		if (res.error) {
+			toast.error(res.error.message);
+			return;
+		}
+
+		toast.success(`${res.data.title ?? `#${res.data.id}`} is ${statusLabel(status).toLowerCase()}`);
+		await chats.refresh();
+	}
+</script>
+
+<div class="mx-auto max-w-6xl space-y-4 px-6 py-6">
+	<header class="flex items-baseline justify-between gap-3">
+		<div>
+			<h2 class="text-lg font-semibold tracking-tight">Chats</h2>
+			<p class="mt-0.5 text-xs text-zinc-500">Approve discovered Telegram resources before the bot operates there.</p>
+		</div>
+		<div class="flex items-center gap-3 text-xs text-zinc-500">
+			{#if chats.error}
+				<span class="text-red-600">Error: {chats.error}</span>
+			{:else if chats.lastUpdatedAt}
+				<span class="hidden md:inline">Updated {chats.lastUpdatedAt.toLocaleTimeString()}</span>
+			{/if}
+			<Button variant="outline" size="sm" onclick={() => chats.refresh()}>
+				<RefreshCw class="h-3.5 w-3.5" />
+				Refresh
+			</Button>
+		</div>
+	</header>
+
+	<div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+		<div class="rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Total</div>
+			<div class="text-lg font-semibold tracking-tight text-zinc-900">{counts.all}</div>
+		</div>
+		<div class="rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Pending</div>
+			<div class="text-lg font-semibold tracking-tight text-zinc-900">{counts.discovered}</div>
+		</div>
+		<div class="rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Approved</div>
+			<div class="text-lg font-semibold tracking-tight text-zinc-900">{counts.approved}</div>
+		</div>
+		<div class="rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Disabled</div>
+			<div class="text-lg font-semibold tracking-tight text-zinc-900">{counts.disabled}</div>
+		</div>
+	</div>
+
+	<div class="flex flex-col gap-3 border-b border-zinc-200 pb-3 md:flex-row md:items-center md:justify-between">
+		<div class="flex flex-wrap items-center gap-1">
+			{#each ['all', 'discovered', 'approved', 'disabled'] as value}
+				<button
+					type="button"
+					class="rounded-md px-3 py-1.5 text-sm font-medium {filter === value
+						? 'bg-zinc-900 text-white'
+						: 'text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900'}"
+					onclick={() => (filter = value as Filter)}
+				>
+					{value === 'all' ? 'All' : statusLabel(value as ChatStatus)}
+				</button>
+			{/each}
+		</div>
+		<div class="relative w-full md:w-72">
+			<Search class="pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-zinc-400" />
+			<Input bind:value={query} placeholder="Search chats..." class="h-8 pl-8" />
+		</div>
+	</div>
+
+	<div class="overflow-hidden rounded-md border border-zinc-200 bg-white">
+		{#if chats.loading && !chats.data}
+			<p class="p-4 text-sm text-zinc-500">Loading...</p>
+		{:else if chats.error && !chats.data}
+			<p class="p-4 text-sm text-red-600">Error: {chats.error}</p>
+		{:else if filtered.length === 0}
+			<p class="p-4 text-sm text-zinc-500">No chats found.</p>
+		{:else}
+			<Table.Root>
+				<Table.Header>
+					<Table.Row class="bg-zinc-50/80">
+						<Table.Head>Name</Table.Head>
+						<Table.Head class="w-28">Status</Table.Head>
+						<Table.Head class="w-28">Members</Table.Head>
+						<Table.Head class="w-32">Features</Table.Head>
+						<Table.Head class="w-48 text-right">Actions</Table.Head>
+					</Table.Row>
+				</Table.Header>
+				<Table.Body>
+					{#each filtered as chat (chat.id)}
+						<Table.Row class="cursor-pointer hover:bg-zinc-50" onclick={() => goto(`/chats/${chat.id}`)}>
+							<Table.Cell>
+								<div class="flex min-w-0 items-center gap-2">
+									<ChatAvatar chatId={chat.id} title={chat.title} hasPhoto={chat.has_photo} size="sm" />
+									<div class="min-w-0">
+										<div class="truncate font-medium text-zinc-900">{chat.title ?? `#${chat.id}`}</div>
+										<div class="truncate font-mono text-xs text-zinc-500">{chat.id}</div>
+									</div>
+								</div>
+							</Table.Cell>
+							<Table.Cell>
+								<Badge variant={statusTone(chat.resource_status)}>
+									{#if chat.resource_status === 'approved'}
+										<CheckCircle2 class="h-3 w-3" />
+									{:else if chat.resource_status === 'disabled'}
+										<XCircle class="h-3 w-3" />
+									{:else}
+										<CircleDashed class="h-3 w-3" />
+									{/if}
+									{statusLabel(chat.resource_status)}
+								</Badge>
+							</Table.Cell>
+							<Table.Cell class="text-sm text-zinc-700">
+								{chat.member_count === null || chat.member_count === undefined ? '-' : chat.member_count.toLocaleString()}
+							</Table.Cell>
+							<Table.Cell class="text-xs text-zinc-600">
+								{[
+									chat.is_captcha_enabled ? 'captcha' : null,
+									chat.is_welcome_enabled ? 'welcome' : null
+								]
+									.filter(Boolean)
+									.join(', ') || 'basic'}
+							</Table.Cell>
+							<Table.Cell>
+								<div class="flex justify-end gap-1">
+									{#if chat.resource_status !== 'approved'}
+										<Button
+											size="sm"
+											disabled={busyChatId === chat.id}
+											onclick={(event) => setStatus(chat, 'approved', event)}
+										>
+											<Shield class="h-3.5 w-3.5" />
+											Approve
+										</Button>
+									{/if}
+									{#if chat.resource_status !== 'disabled'}
+										<Button
+											variant="outline"
+											size="sm"
+											disabled={busyChatId === chat.id}
+											onclick={(event) => setStatus(chat, 'disabled', event)}
+										>
+											Disable
+										</Button>
+									{/if}
+								</div>
+							</Table.Cell>
+						</Table.Row>
+					{/each}
+				</Table.Body>
+			</Table.Root>
+		{/if}
+	</div>
+</div>

--- a/webui/src/routes/chats/+page.ts
+++ b/webui/src/routes/chats/+page.ts
@@ -1,5 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-
-export function load() {
-	redirect(307, '/catalog');
-}

--- a/webui/src/routes/chats/[id]/+page.svelte
+++ b/webui/src/routes/chats/[id]/+page.svelte
@@ -16,6 +16,7 @@
 
 	type ChatDetail = components['schemas']['ChatDetail'];
 	type ChatRead = components['schemas']['ChatRead'];
+	type ChatStatus = ChatRead['resource_status'];
 	type UserBlockResponse = components['schemas']['UserBlockResponse'];
 
 	const chatId = page.params.id;
@@ -24,6 +25,7 @@
 	let busyUserId = $state<number | null>(null);
 	let editing = $state(false);
 	let saving = $state(false);
+	let savingStatus = $state(false);
 	let refreshing = $state(false);
 
 	async function refreshFromTelegram(): Promise<void> {
@@ -91,6 +93,27 @@
 		}
 	}
 
+	function statusLabel(status: ChatStatus): string {
+		if (status === 'approved') return 'Approved';
+		if (status === 'disabled') return 'Disabled';
+		return 'Pending';
+	}
+
+	async function setResourceStatus(status: ChatStatus): Promise<void> {
+		if (!detail.data || detail.data.resource_status === status) return;
+		savingStatus = true;
+		const res = await apiFetch<ChatRead>(`/api/chats/${chatId}`, {
+			method: 'PATCH',
+			body: JSON.stringify({ resource_status: status })
+		});
+		savingStatus = false;
+		if (res.error) toast.error(res.error.message);
+		else {
+			toast.success(`Resource is ${statusLabel(status).toLowerCase()}`);
+			await detail.refresh();
+		}
+	}
+
 	function senderLabel(s: components['schemas']['ChatSender']): string {
 		if (s.username) return `@${s.username}`;
 		const name = [s.first_name, s.last_name].filter(Boolean).join(' ').trim();
@@ -147,6 +170,7 @@
 					{/if}
 					{#if detail.data}
 						<span>· Synced from Telegram {fmtRelative(detail.data.last_synced_at)}</span>
+						<span>· {statusLabel(detail.data.resource_status)}</span>
 					{/if}
 				</div>
 			</div>
@@ -217,9 +241,27 @@
 					<div class="grid grid-cols-2 gap-2">
 						<div>Members: <strong>{detail.data.member_count ?? '—'}</strong></div>
 						<div>Forum: {detail.data.is_forum ? 'yes' : 'no'}</div>
+						<div>Status: {statusLabel(detail.data.resource_status)}</div>
 						<div>Captcha: {detail.data.is_captcha_enabled ? 'on' : 'off'}</div>
 						<div>Welcome: {detail.data.is_welcome_enabled ? 'on' : 'off'}</div>
 						<div>Auto-delete: {detail.data.time_delete}s</div>
+					</div>
+					<div class="flex flex-wrap items-center gap-2 border-t border-zinc-100 pt-3">
+						<Button
+							size="sm"
+							disabled={savingStatus || detail.data.resource_status === 'approved'}
+							onclick={() => setResourceStatus('approved')}
+						>
+							Approve resource
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={savingStatus || detail.data.resource_status === 'disabled'}
+							onclick={() => setResourceStatus('disabled')}
+						>
+							Disable
+						</Button>
 					</div>
 					{#if detail.data.welcome_message}
 						<div class="rounded-md border border-zinc-100 bg-zinc-50 p-2 text-xs text-zinc-600">


### PR DESCRIPTION
## What changed

- Adds an explicit chat resource lifecycle: `discovered`, `approved`, `disabled`.
- Stops leaving group/supergroup resources just because the configured super admin is not an admin there.
- Keeps passive chat/user/message capture for discovered resources, while active bot behavior runs only for approved chats.
- Adds admin UI controls on `/chats` and chat detail pages to approve or disable resources.
- Adds an Alembic migration and generated OpenAPI types for the new status field.
- Ignores local `.env.bak.*` files.

## Why

The bot previously treated “configured super admin is not a Telegram admin” as a reason to leave the resource. That made discovery and operating approval the same thing. This separates them so admins can review newly discovered resources from the web UI before enabling public bot actions.

## Validation

- `uv run pytest tests/webapi/test_chats.py tests/e2e/test_agent_moderation.py::TestManagedChatsMiddleware tests/e2e/test_agent_moderation.py::TestReportCommand -q`
- `uv run ruff check app tests`
- `uv run ruff format --check app tests`
- `uv run ty check app tests`
- `pnpm --dir webui run check`
- `pnpm --dir webui run build`
- `uv run alembic heads`
- pre-push hook: ruff, ruff format, ty, pytest unit + e2e
