### PR TITLE
fix(deploy): bind webui behind edge caddy

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -3,7 +3,7 @@
 
 # Written by GitHub Actions on deploy. For initial bootstrap, set any already-published image SHA.
 IMAGE_TAG=
-WEBUI_PORT=5173
+WEBUI_PORT=18083
 
 # Moderator bot
 MODERATOR_BOT_TOKEN=

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     image: ghcr.io/vsem-azamat/supervisor-telegram-webui:${IMAGE_TAG:?Set IMAGE_TAG to a published image tag}
     container_name: supervisor-telegram-webui
     ports:
-      - "${WEBUI_PORT:-5173}:80"
+      - "127.0.0.1:${WEBUI_PORT:-18083}:80"
     depends_on:
       - webapi
     restart: unless-stopped

--- a/docs/deployment/production-credentials.md
+++ b/docs/deployment/production-credentials.md
@@ -38,7 +38,9 @@ Required production values:
 - `WEBAPI_PUBLIC_URL`: public HTTPS URL of the web UI.
 - `WEBAPI_ALLOWED_ORIGINS`: the same public HTTPS origin as `WEBAPI_PUBLIC_URL`.
 - `WEBAPI_SESSION_COOKIE_SECURE=true`: required for production HTTPS sessions.
-- `WEBUI_PORT`: host port exposed by the static web UI container.
+- `WEBUI_PORT`: loopback-only host port used by the server-level edge Caddy
+  to reach the static web UI container. Production currently uses `18083`;
+  do not publish this port on `0.0.0.0`.
 
 Feature-specific production values:
 


### PR DESCRIPTION
## Summary
- bind the production web UI container to 127.0.0.1 by default
- switch production WEBUI_PORT default/template to 18083 for the shared edge Caddy topology
- document that WEBUI_PORT must not be published on 0.0.0.0 in production

## Verification
- docker run --rm -v "/home/poryadok/circuit/supervisor-telegram:/repo" -w /repo rhysd/actionlint:latest .github/workflows/deploy.yml .github/workflows/branch-test.yml .github/workflows/test.yml
- temporary .env from .env.production.example + docker compose config confirms host_ip 127.0.0.1, published 18083, target 80
- git diff --check