### PR TITLE
Sign the two Telegram accounts in, keeping their sessions apart

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,8 +66,8 @@ jobs:
 
     - name: Lint + format check (ruff)
       run: |
-        uv run ruff check app tests
-        uv run ruff format --check app tests
+        uv run ruff check app tests scripts
+        uv run ruff format --check app tests scripts
 
     - name: Type check (ty)
       run: uv run ty check app tests

--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ scripts/*
 !scripts/entrypoint.sh
 !scripts/env_to_github.sh
 !scripts/adopt_existing_db.py
+!scripts/tg_accounts.py
 .claude/
 
 # Local credential drops — never tracked.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -10,3 +10,5 @@ This section covers production runtime operations and deployment contracts.
 - [The Database](database.md) - it runs beside this stack rather than in it,
   what that costs, and the one-time sequence that brought a database older than
   the migration squash under the current history.
+- [Telegram Accounts](telegram-accounts.md) - the personal and working accounts,
+  why their sessions are kept apart, and how to sign each in.

--- a/docs/deployment/telegram-accounts.md
+++ b/docs/deployment/telegram-accounts.md
@@ -1,0 +1,68 @@
+# Telegram accounts
+
+Two user accounts are involved in running these chats, and they are not
+interchangeable:
+
+- **main** — the personal account that owns the chats today.
+- **work** — the account that is to take administration over, so the personal
+  one can step back from day-to-day management.
+
+They exist as separate sessions on purpose. Telethon keeps an authorisation key
+in the session file, so one file for both accounts means whichever signed in
+last quietly replaced the other — and the failure only shows up later, as the
+wrong account doing something.
+
+## Signing in
+
+Needs an application registered at <https://my.telegram.org>; the same
+`api_id`/`api_hash` pair serves both accounts, because it identifies the
+application rather than the account.
+
+```bash
+export TELETHON_API_ID=...
+export TELETHON_API_HASH=...
+
+uv run python scripts/tg_accounts.py login main
+uv run python scripts/tg_accounts.py login work
+```
+
+Each prompts for a phone number, the code Telegram sends to that account, and a
+two-step password if one is set — so it has to be run by whoever can read the
+code. Signing in again on an account that is already authorised does nothing.
+
+## Checking
+
+```bash
+uv run python scripts/tg_accounts.py status
+```
+
+```
+main       authorised    @azamat (id 268388996)
+work       authorised    @konnekt_ops (id ...)
+```
+
+This one never prompts. It is what anything unattended runs before acting, to
+confirm it is the account it believes it is; a session that was revoked from
+Telegram's own device list shows up here as `NOT AUTHORISED` rather than as a
+confusing permission error halfway through a job.
+
+## What a session file is
+
+`.creds/sessions/<account>.session` is not a token scoped to this tool. Whoever
+holds it can read every chat and message that account can, send as it, and change
+its settings — Telegram sees no difference between the file and the person.
+
+- `.creds/` is ignored by git, and nothing there belongs in a backup that leaves
+  this machine.
+- Deleting the file only makes it unusable here. Actually revoking access means
+  ending the session from Telegram's **Devices** list.
+- The bot's own userbot session (`moderator_userbot.session`, mounted into the
+  container) is a third, unrelated session. Do not point these scripts at it.
+
+## What comes next
+
+Handing the chats over is the following step, and deliberately not part of this
+one: with both accounts signed in, `work` gets promoted to administrator
+everywhere `main` can appoint admins, and the moderator bot gets invited back to
+the chats it left in May. Only then does it make sense to take anything away
+from `main`.

--- a/scripts/adopt_existing_db.py
+++ b/scripts/adopt_existing_db.py
@@ -19,11 +19,10 @@ from __future__ import annotations
 import asyncio
 import sys
 
-from sqlalchemy import inspect
-from sqlalchemy.ext.asyncio import create_async_engine
-
 from app.db import models as _models  # noqa: F401  # register the ORM models
 from app.db.base import Base
+from sqlalchemy import inspect
+from sqlalchemy.ext.asyncio import create_async_engine
 
 INITIAL_REVISION = "fbeb70328d81"
 

--- a/scripts/tg_accounts.py
+++ b/scripts/tg_accounts.py
@@ -1,0 +1,187 @@
+"""Sign Telegram accounts in and keep their sessions apart.
+
+Two accounts are involved in running these chats: the personal one that owns
+them today, and the working one that is to take over administration. They must
+never share a session file — Telethon stores the authorisation key in it, and a
+single file for both would mean whichever logged in last silently replaced the
+other.
+
+    uv run python scripts/tg_accounts.py login main
+    uv run python scripts/tg_accounts.py login work
+    uv run python scripts/tg_accounts.py status
+
+`login` is interactive: Telegram sends a code to the account, and a second
+prompt appears if it has two-step verification. It has to be run by whoever can
+read that code. `status` is not — it only opens the stored sessions and reports
+who they belong to, which is how anything automated confirms it is acting as the
+account it thinks it is before doing anything.
+
+A session file is the account
+-----------------------------
+It is not a token scoped to this tool. Anyone holding it can read every chat and
+message that account can, send as it, and change its settings; Telegram cannot
+tell the difference. They live under `.creds/`, which this repository never
+tracks, and they belong nowhere else. Signing out from Telegram's own "active
+sessions" list is what actually revokes one — deleting the file only makes it
+unusable here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from telethon import TelegramClient
+
+# Kept beside the other credentials this machine holds, under a directory the
+# repository ignores rather than one it merely has no rule for.
+SESSIONS_DIR = Path(".creds/sessions")
+
+# Filenames become session paths, so anything that could climb out of the
+# directory or collide with a shell is refused rather than sanitised.
+ACCOUNT_NAME = re.compile(r"^[a-z][a-z0-9_-]{0,30}$")
+
+
+def session_path(name: str, *, directory: Path = SESSIONS_DIR) -> Path:
+    """Where one account's session lives. One file per account, never shared."""
+    if not ACCOUNT_NAME.match(name):
+        raise SystemExit(f"account name must match {ACCOUNT_NAME.pattern!r}, got {name!r}")
+    return directory / f"{name}.session"
+
+
+def known_accounts(directory: Path = SESSIONS_DIR) -> list[str]:
+    if not directory.exists():
+        return []
+    return sorted(path.stem for path in directory.glob("*.session"))
+
+
+def api_credentials() -> tuple[int, str]:
+    """The api_id/api_hash pair from https://my.telegram.org.
+
+    Both accounts use the same pair: it identifies the application, not the
+    account, and the deployment already names these two variables for the
+    userbot. Read from the environment so no credential is written to disk here.
+    """
+    api_id = os.environ.get("TELETHON_API_ID", "").strip()
+    api_hash = os.environ.get("TELETHON_API_HASH", "").strip()
+    if not api_id or not api_hash:
+        raise SystemExit(
+            "set TELETHON_API_ID and TELETHON_API_HASH first — create an application at https://my.telegram.org"
+        )
+    if not api_id.isdigit():
+        raise SystemExit(f"TELETHON_API_ID must be a number, got {api_id!r}")
+    return int(api_id), api_hash
+
+
+def _client(name: str, directory: Path) -> TelegramClient:
+    from telethon import TelegramClient
+
+    api_id, api_hash = api_credentials()
+    directory.mkdir(parents=True, exist_ok=True)
+    # Telethon appends .session itself, so it is handed the path without it.
+    return TelegramClient(str(session_path(name, directory=directory).with_suffix("")), api_id, api_hash)
+
+
+def _describe(me: object) -> str:
+    username = getattr(me, "username", None)
+    first = getattr(me, "first_name", "") or ""
+    last = getattr(me, "last_name", "") or ""
+    display = f"@{username}" if username else " ".join(part for part in (first, last) if part) or "?"
+    return f"{display} (id {getattr(me, 'id', '?')})"
+
+
+async def login(name: str, directory: Path) -> int:
+    """Sign one account in, or report that it already is."""
+    client = _client(name, directory)
+    path = session_path(name, directory=directory)
+    existed = path.exists()
+
+    await client.connect()
+    try:
+        if await client.is_user_authorized():
+            print(f"{name}: already signed in as {_describe(await client.get_me())}")
+            print(f"  session: {path}")
+            return 0
+
+        if existed:
+            print(f"{name}: session exists but is no longer authorised — signing in again")
+
+        # start() prompts for the phone number, the code Telegram sends, and the
+        # two-step password when one is set.
+        await client.start()  # type: ignore[func-returns-value]
+        print(f"{name}: signed in as {_describe(await client.get_me())}")
+        print(f"  session: {path}")
+        print("  this file is the account — keep it off shared machines and out of backups")
+        return 0
+    finally:
+        await client.disconnect()  # type: ignore[func-returns-value]
+
+
+async def status(names: list[str], directory: Path) -> int:
+    """Report who each stored session belongs to, without prompting for anything.
+
+    Deliberately non-interactive: this is the check an unattended run makes
+    before it acts, and a hidden prompt there would hang rather than fail.
+    """
+    if not names:
+        print(f"no sessions in {directory}/ — run `login <account>` first")
+        return 1
+
+    failures = 0
+    for name in names:
+        path = session_path(name, directory=directory)
+        if not path.exists():
+            print(f"{name:<10} missing        {path}")
+            failures += 1
+            continue
+
+        client = _client(name, directory)
+        try:
+            await client.connect()
+            if await client.is_user_authorized():
+                print(f"{name:<10} authorised    {_describe(await client.get_me())}")
+            else:
+                print(f"{name:<10} NOT AUTHORISED — sign in again, or it was revoked from Telegram")
+                failures += 1
+        except Exception as err:  # noqa: BLE001 — one broken session must not hide the others
+            print(f"{name:<10} error         {type(err).__name__}: {err}")
+            failures += 1
+        finally:
+            await client.disconnect()  # type: ignore[func-returns-value]
+
+    return 1 if failures else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--sessions-dir",
+        type=Path,
+        default=SESSIONS_DIR,
+        help=f"where session files live (default: {SESSIONS_DIR})",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    signin = sub.add_parser("login", help="sign an account in and store its session")
+    signin.add_argument("account", help="short name for this account, e.g. main or work")
+
+    check = sub.add_parser("status", help="report who each stored session belongs to")
+    check.add_argument("account", nargs="*", help="accounts to check; default is every stored session")
+
+    args = parser.parse_args()
+
+    if args.command == "login":
+        return asyncio.run(login(args.account, args.sessions_dir))
+
+    names = args.account or known_accounts(args.sessions_dir)
+    return asyncio.run(status(names, args.sessions_dir))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_tg_accounts.py
+++ b/tests/unit/test_tg_accounts.py
@@ -1,0 +1,90 @@
+"""Session files must stay one per account, and stay where they belong.
+
+Everything else in the script is Telegram I/O. What can go wrong without
+Telegram noticing is the file layout: two accounts sharing a path means the
+second login silently replaces the first, and a name that escapes the sessions
+directory means an account key written somewhere the repository does track.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "tg_accounts.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("tg_accounts", _PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["tg_accounts"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tg_accounts = _load()
+
+
+class TestSessionPaths:
+    def test_each_account_gets_its_own_file(self, tmp_path: Path) -> None:
+        """The whole point: one session per account, never shared."""
+        main = tg_accounts.session_path("main", directory=tmp_path)
+        work = tg_accounts.session_path("work", directory=tmp_path)
+
+        assert main != work
+        assert (main.parent, work.parent) == (tmp_path, tmp_path)
+
+    def test_sessions_live_under_the_ignored_credentials_directory(self) -> None:
+        """A session is the account; it must not land somewhere git tracks."""
+        assert tg_accounts.SESSIONS_DIR.parts[0] == ".creds"
+
+    @pytest.mark.parametrize("name", ["../escape", "main/../..", "Main", "", "a" * 32, "main session"])
+    def test_a_name_that_could_escape_is_refused(self, name: str, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit):
+            tg_accounts.session_path(name, directory=tmp_path)
+
+    @pytest.mark.parametrize("name", ["main", "work", "agent-2", "azamat_personal"])
+    def test_ordinary_names_are_accepted(self, name: str, tmp_path: Path) -> None:
+        assert tg_accounts.session_path(name, directory=tmp_path).name == f"{name}.session"
+
+
+class TestDiscovery:
+    def test_stored_sessions_are_listed(self, tmp_path: Path) -> None:
+        (tmp_path / "work.session").touch()
+        (tmp_path / "main.session").touch()
+        (tmp_path / "notes.txt").touch()
+
+        assert tg_accounts.known_accounts(tmp_path) == ["main", "work"]
+
+    def test_an_absent_directory_is_not_an_error(self, tmp_path: Path) -> None:
+        assert tg_accounts.known_accounts(tmp_path / "nothing-here") == []
+
+
+class TestApiCredentials:
+    def test_both_halves_are_required(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Half a pair authenticates nothing, and fails later than here."""
+        monkeypatch.setenv("TELETHON_API_ID", "12345")
+        monkeypatch.delenv("TELETHON_API_HASH", raising=False)
+
+        with pytest.raises(SystemExit):
+            tg_accounts.api_credentials()
+
+    def test_a_non_numeric_api_id_is_caught_before_telethon_sees_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TELETHON_API_ID", "not-a-number")
+        monkeypatch.setenv("TELETHON_API_HASH", "abc")
+
+        with pytest.raises(SystemExit):
+            tg_accounts.api_credentials()
+
+    def test_a_configured_pair_is_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TELETHON_API_ID", " 12345 ")
+        monkeypatch.setenv("TELETHON_API_HASH", " deadbeef ")
+
+        assert tg_accounts.api_credentials() == (12345, "deadbeef")


### PR DESCRIPTION
Step one of moving chat administration from the personal account to a working one: being able to act as each account, with their sessions kept apart.

Nothing here promotes anyone or touches a chat. That is the next step, deliberately separate — the rollout has to be right, and it is not worth writing before the accounts it runs as exist.

## What it adds

`scripts/tg_accounts.py` with two subcommands:

```bash
uv run python scripts/tg_accounts.py login main    # interactive: phone, code, 2FA
uv run python scripts/tg_accounts.py login work
uv run python scripts/tg_accounts.py status        # never prompts
```

One session file per account, under `.creds/sessions/`. Telethon stores the authorisation key in that file, so a shared one means whichever account signed in last silently replaced the other — and that shows up later as the wrong account doing something, not as an error.

Account names are validated rather than sanitised: a name that could climb out of the sessions directory would write an account key somewhere the repository tracks.

`status` is deliberately non-interactive. It is the check an unattended run makes before acting, and a session revoked from Telegram's device list reports as `NOT AUTHORISED` here rather than as a confusing permission error halfway through a job.

## Also

`scripts/` is now covered by ruff in CI. It was outside `app tests` and had drifted; these scripts are run by hand against production, which argues for more scrutiny than application code, not less.

## Verification

- 17 new unit tests over the parts that can be wrong without Telegram noticing: session paths, name validation, discovery, credential parsing
- full suite, ruff, ty green locally

## What comes next

With both accounts signed in: promote `work` to administrator everywhere `main` can appoint admins, and invite the moderator bot back to the 28 chats it left in May. Only then does removing anything from `main` make sense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
