### PR TITLE
Find the chats in scope, and appoint the second account across them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,8 @@ scripts/*
 !scripts/env_to_github.sh
 !scripts/adopt_existing_db.py
 !scripts/tg_accounts.py
+!scripts/tg_chats.py
+!scripts/tg_promote.py
 .claude/
 
 # Local credential drops — never tracked.

--- a/docs/deployment/telegram-accounts.md
+++ b/docs/deployment/telegram-accounts.md
@@ -59,10 +59,39 @@ its settings — Telegram sees no difference between the file and the person.
 - The bot's own userbot session (`moderator_userbot.session`, mounted into the
   container) is a third, unrelated session. Do not point these scripts at it.
 
-## What comes next
+## Handing administration over
 
-Handing the chats over is the following step, and deliberately not part of this
-one: with both accounts signed in, `work` gets promoted to administrator
-everywhere `main` can appoint admins, and the moderator bot gets invited back to
-the chats it left in May. Only then does it make sense to take anything away
-from `main`.
+Which chats are in scope comes from the account's own Telegram folders — it has
+them sorted by university already, and that sorting describes the perimeter
+better than anything this repository could infer:
+
+```bash
+uv run python scripts/tg_chats.py folders --account main
+uv run python scripts/tg_chats.py candidates --account main --bot @konnekt_moder_bot --out chats.csv
+```
+
+Discovery reads a chat list, never a chat. Private conversations are dropped
+where the folder is parsed, and the file contains no call that returns message
+contents. The personal folder is excluded by default, and exclusion beats any
+`--folder` match.
+
+Then the promotion pass, over a scope file of chat ids:
+
+```bash
+uv run python scripts/tg_promote.py --account main --target @work --chats scope.txt            # plan
+uv run python scripts/tg_promote.py --account main --target @work --chats scope.txt --apply
+```
+
+It grants every administrator right, including `add_admins` — the second account
+has to be able to invite the bot back and to hand over in turn. It never
+transfers ownership, and it never demotes, removes or leaves anything: the
+personal account keeps what it has until a person removes it by hand.
+
+Pacing is the part that matters. Telegram reads a burst of membership changes as
+spam and limits the account doing the appointing — the one that owns the chats.
+Delays between writes are randomised, a flood wait is obeyed rather than retried
+through, and `PEER_FLOOD` stops the run. Pass `--journal` so a stopped run
+resumes instead of starting over.
+
+Only once the second account is verified to work does it make sense to take
+anything away from the first.

--- a/scripts/tg_chats.py
+++ b/scripts/tg_chats.py
@@ -1,0 +1,316 @@
+"""List the group chats an account is in, arranged by its Telegram folders.
+
+The step before handing administration over: knowing which chats are in scope.
+The account that owns them has them sorted into folders already — universities,
+dormitories, and so on — and that sorting is a better description of scope than
+anything this repository could infer, so it is read rather than guessed at.
+
+    uv run python scripts/tg_chats.py folders --account main
+    uv run python scripts/tg_chats.py candidates --account main --folder студ --bot @konnekt_moder_bot
+
+`folders` shows what folders exist and how many groups are in each. `candidates`
+lists the groups themselves, with whether this account can appoint admins there
+and, when a bot is named, whether that bot is present.
+
+Private conversations are never touched
+---------------------------------------
+This reads a chat list, not chats. Groups and supergroups are the only thing it
+keeps: a peer that is a user is dropped at the point it is read, before it is
+looked up, printed or counted. Nothing here calls any method that returns
+message contents — the whole file has no way to fetch a message, which is a
+stronger guarantee than a rule about not printing them.
+
+What it reports per chat is what an administrator sees in the chat's own
+settings: title, id, member count, and who holds which rights.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tg_accounts import SESSIONS_DIR, api_credentials, session_path  # noqa: E402
+
+if TYPE_CHECKING:
+    from telethon import TelegramClient
+
+# Telegram's own name for chats that are in no folder.
+UNFILED = "(no folder)"
+
+
+@dataclass
+class Group:
+    """One group chat, as its administrators see it in the chat's settings."""
+
+    id: int
+    title: str
+    kind: str
+    members: int | None
+    i_am_admin: bool
+    i_can_appoint: bool
+    bot_status: str = ""
+    folders: list[str] | None = None
+
+    def row(self) -> list[str]:
+        return [
+            str(self.id),
+            self.title,
+            self.kind,
+            "" if self.members is None else str(self.members),
+            "admin" if self.i_am_admin else "member",
+            "yes" if self.i_can_appoint else "no",
+            self.bot_status,
+            ", ".join(self.folders or []),
+        ]
+
+
+HEADER = ["chat_id", "title", "kind", "members", "my_standing", "can_appoint_admins", "bot", "folders"]
+
+
+def _client(account: str, directory: Path) -> TelegramClient:
+    from telethon import TelegramClient
+
+    api_id, api_hash = api_credentials()
+    path = session_path(account, directory=directory)
+    if not path.exists():
+        raise SystemExit(f"no session for {account!r} at {path} — run `tg_accounts.py login {account}` first")
+    return TelegramClient(str(path.with_suffix("")), api_id, api_hash)
+
+
+def _folder_title(raw: Any) -> str:
+    """Folder titles became rich text in a later layer; both shapes appear."""
+    return getattr(raw, "text", None) or str(raw)
+
+
+def _peer_id(peer: Any) -> int | None:
+    """The chat id behind a folder entry, or None when the entry is a person.
+
+    This is where private conversations leave the program. A folder can hold
+    users as well as groups, and the ones that are users are dropped here —
+    before any lookup, so their identity is never resolved at all.
+    """
+    if hasattr(peer, "channel_id"):
+        return int(peer.channel_id)
+    if hasattr(peer, "chat_id"):
+        return int(peer.chat_id)
+    return None
+
+
+async def read_folders(client: TelegramClient) -> dict[int, list[str]]:
+    """Which folders each group belongs to, keyed by chat id.
+
+    A chat can sit in several folders, so this is a list rather than a label.
+    """
+    from telethon.tl import functions
+
+    result = await client(functions.messages.GetDialogFiltersRequest())
+    filters = getattr(result, "filters", result)
+
+    membership: dict[int, list[str]] = {}
+    for entry in filters:
+        peers = getattr(entry, "include_peers", None)
+        if not peers:  # the default "All chats" pseudo-folder has none
+            continue
+        title = _folder_title(getattr(entry, "title", "?"))
+        for peer in peers:
+            chat_id = _peer_id(peer)
+            if chat_id is not None:
+                membership.setdefault(chat_id, []).append(title)
+    return membership
+
+
+async def read_groups(client: TelegramClient, folders: dict[int, list[str]]) -> list[Group]:
+    """Every group and supergroup the account is in.
+
+    `iter_dialogs` is the only way to enumerate them, and it returns private
+    conversations too. Those are discarded on sight: the loop below keeps a
+    title and an id from group entities and nothing else from anything.
+    """
+    from telethon.tl.types import Channel, Chat
+
+    groups: list[Group] = []
+    async for dialog in client.iter_dialogs():
+        entity = dialog.entity
+        is_supergroup = isinstance(entity, Channel) and entity.megagroup
+        is_basic_group = isinstance(entity, Chat)
+        if not (is_supergroup or is_basic_group):
+            continue
+
+        mine = await standing(client, entity)
+        groups.append(
+            Group(
+                id=int(entity.id),
+                title=getattr(entity, "title", "") or "",
+                kind="supergroup" if is_supergroup else "group",
+                members=getattr(entity, "participants_count", None),
+                i_am_admin=mine[0],
+                i_can_appoint=mine[1],
+                folders=folders.get(int(entity.id), []),
+            )
+        )
+    return groups
+
+
+async def standing(client: TelegramClient, chat: Any) -> tuple[bool, bool]:
+    """Whether we are an admin there, and whether we may appoint others.
+
+    The second half is the one that matters: a chat where this account cannot
+    appoint admins is a chat the handover cannot touch, and finding that out now
+    is better than failing on it halfway through.
+    """
+    try:
+        permissions = await client.get_permissions(chat, "me")
+    except Exception:  # noqa: BLE001 — reported as "not an admin", never fatal
+        return False, False
+    is_admin = bool(permissions.is_admin or permissions.is_creator)
+    can_appoint = bool(permissions.is_creator or getattr(permissions, "add_admins", False))
+    return is_admin, can_appoint
+
+
+async def check_bot(client: TelegramClient, groups: list[Group], bot: str) -> None:
+    """Fill in where the bot already is, so the rollout knows what is left."""
+    from telethon.errors import UserNotParticipantError
+
+    entity = await client.get_entity(bot)
+    for group in groups:
+        try:
+            permissions = await client.get_permissions(group.id, entity)
+        except UserNotParticipantError:
+            group.bot_status = "absent"
+        except Exception:  # noqa: BLE001 — an unreadable member list is not a failure
+            group.bot_status = "unknown"
+        else:
+            group.bot_status = "admin" if permissions.is_admin else "member"
+
+
+def matches(group: Group, needle: str | None, excluded: list[str] | None = None) -> bool:
+    """Whether this group is in scope.
+
+    Exclusion wins over inclusion. The account keeps a personal folder, and a
+    group filed there is out of scope however well it matches something else —
+    a rule the program follows is worth more than one an operator has to
+    remember while reading a list of sixty chats.
+    """
+    folders = group.folders or []
+    for skip in excluded or []:
+        lowered = skip.casefold()
+        if any(lowered in folder.casefold() for folder in folders):
+            return False
+    if not needle:
+        return True
+    lowered = needle.casefold()
+    return any(lowered in folder.casefold() for folder in folders)
+
+
+async def run_folders(account: str, directory: Path) -> int:
+    client = _client(account, directory)
+    await client.start()  # type: ignore[func-returns-value]
+    try:
+        folders = await read_folders(client)
+        counts: dict[str, int] = {}
+        for titles in folders.values():
+            for title in titles:
+                counts[title] = counts.get(title, 0) + 1
+
+        if not counts:
+            print("this account has no folders")
+            return 0
+        width = max(len(title) for title in counts)
+        for title, count in sorted(counts.items(), key=lambda item: -item[1]):
+            print(f"{title:<{width}}  {count:>3} chats")
+        return 0
+    finally:
+        await client.disconnect()  # type: ignore[func-returns-value]
+
+
+async def run_candidates(
+    account: str,
+    directory: Path,
+    *,
+    folder: str | None,
+    exclude: list[str] | None,
+    bot: str | None,
+    out: Path | None,
+) -> int:
+    client = _client(account, directory)
+    await client.start()  # type: ignore[func-returns-value]
+    try:
+        folders = await read_folders(client)
+        groups = await read_groups(client, folders)
+        groups = [group for group in groups if matches(group, folder, exclude)]
+        groups.sort(key=lambda group: (-(group.members or 0), group.title))
+
+        if bot:
+            await check_bot(client, groups, bot)
+
+        title_width = min(44, max((len(group.title) for group in groups), default=10))
+        print(f"{'chat_id':>15}  {'members':>7}  {'me':<7} {'appoint':<8} {'bot':<8} title")
+        for group in groups:
+            print(
+                f"{group.id:>15}  {group.members or 0:>7}  "
+                f"{'admin' if group.i_am_admin else 'member':<7} "
+                f"{'yes' if group.i_can_appoint else 'NO':<8} "
+                f"{group.bot_status or '-':<8} {group.title[:title_width]}"
+            )
+        print(
+            f"\n{len(groups)} groups"
+            f"{f' in folders matching {folder!r}' if folder else ''}"
+            f", {sum(1 for g in groups if not g.i_can_appoint)} where this account cannot appoint admins"
+        )
+
+        if out:
+            with out.open("w", encoding="utf-8", newline="") as handle:
+                writer = csv.writer(handle)
+                writer.writerow(HEADER)
+                writer.writerows(group.row() for group in groups)
+            print(f"written to {out}")
+        return 0
+    finally:
+        await client.disconnect()  # type: ignore[func-returns-value]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--sessions-dir", type=Path, default=SESSIONS_DIR)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    listing = sub.add_parser("folders", help="what folders this account has, and how many groups in each")
+    listing.add_argument("--account", default="main")
+
+    candidates = sub.add_parser("candidates", help="the group chats themselves")
+    candidates.add_argument("--account", default="main")
+    candidates.add_argument("--folder", help="only folders whose name contains this, case-insensitive")
+    candidates.add_argument(
+        "--exclude-folder",
+        action="append",
+        default=["Личные"],
+        help="skip folders whose name contains this; repeatable, and it wins over --folder",
+    )
+    candidates.add_argument("--bot", help="also report whether this bot is present, e.g. @konnekt_moder_bot")
+    candidates.add_argument("--out", type=Path, help="also write the list as CSV")
+
+    args = parser.parse_args()
+
+    if args.command == "folders":
+        return asyncio.run(run_folders(args.account, args.sessions_dir))
+    return asyncio.run(
+        run_candidates(
+            args.account,
+            args.sessions_dir,
+            folder=args.folder,
+            exclude=args.exclude_folder,
+            bot=args.bot,
+            out=args.out,
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tg_promote.py
+++ b/scripts/tg_promote.py
@@ -1,0 +1,277 @@
+"""Make one account an administrator across a list of chats.
+
+The handover step: the account that owns these chats appoints a second one, so
+day-to-day management moves off the personal account. Nothing is taken away from
+anybody — see below — and ownership is never transferred.
+
+    uv run python scripts/tg_promote.py --account main --target @work_azamat --chats scope.txt
+    uv run python scripts/tg_promote.py --account main --target @work_azamat --chats scope.txt --apply
+
+Without ``--apply`` every chat is inspected and the intended action printed, and
+not a single write is sent.
+
+It never takes anything away
+---------------------------
+There is no demotion, no removal, no leaving, and no transfer of ownership here.
+The last one is deliberate and worth stating twice: ``channels.editCreator`` is
+the call that hands a chat to somebody else, it is irreversible without the new
+owner's cooperation, and this file does not contain it. The personal account
+keeps everything it has until a human removes it by hand, having seen the second
+account work.
+
+Pacing
+------
+Telegram treats a burst of membership changes from one account as spam, and the
+limit lands on the account doing the appointing — the one that owns the chats.
+So the delay between writes is randomised rather than fixed, a ``FloodWaitError``
+is obeyed rather than retried through, and a ``PeerFloodError`` stops the run
+outright: at that point the account is already flagged and continuing makes it
+worse. The journal makes stopping cheap — a later run picks up where this one
+left off.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tg_accounts import SESSIONS_DIR, api_credentials, session_path  # noqa: E402
+
+if TYPE_CHECKING:
+    from telethon import TelegramClient
+
+# Randomised so the sequence does not look mechanical. The lower bound matters
+# more than the upper one: it is what keeps a run under Telegram's radar.
+MIN_DELAY = 4.0
+MAX_DELAY = 12.0
+
+# Telegram truncates an admin title beyond this.
+MAX_TITLE = 16
+
+
+def admin_rights() -> dict[str, bool]:
+    """Every administrator right, and nothing that transfers the chat.
+
+    ``add_admins`` is included on purpose: the point of this account is to
+    replace the personal one, and an admin who cannot appoint admins cannot
+    invite the moderator bot back or hand over in turn.
+
+    ``anonymous`` is not a right so much as a display choice, and moderation
+    that hides who performed it is worse than moderation that does not.
+    """
+    return {
+        "change_info": True,
+        "post_messages": True,
+        "edit_messages": True,
+        "delete_messages": True,
+        "ban_users": True,
+        "invite_users": True,
+        "pin_messages": True,
+        "add_admins": True,
+        "manage_call": True,
+        "anonymous": False,
+    }
+
+
+@dataclass
+class Target:
+    chat_id: int
+    title: str = ""
+
+
+def read_scope(path: Path) -> list[Target]:
+    """Chat ids to work through, one per line.
+
+    Anything after the id on a line is treated as a human-readable label, so a
+    list can be pasted straight out of a report without editing.
+    """
+    targets = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(maxsplit=1)
+        targets.append(Target(int(parts[0]), parts[1].strip() if len(parts) > 1 else ""))
+    return targets
+
+
+class Journal:
+    """Which chats are already done, so an interrupted run resumes."""
+
+    def __init__(self, path: Path | None) -> None:
+        self.path = path
+        self.done: set[int] = set()
+        if path and path.exists():
+            for line in path.read_text(encoding="utf-8").splitlines():
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("ok"):
+                    self.done.add(int(entry["chat_id"]))
+
+    def already(self, chat_id: int) -> bool:
+        return chat_id in self.done
+
+    def record(self, chat_id: int, *, ok: bool, detail: str = "") -> None:
+        if ok:
+            self.done.add(chat_id)
+        if not self.path:
+            return
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"chat_id": chat_id, "ok": ok, "detail": detail}, ensure_ascii=False) + "\n")
+
+
+def _client(account: str, directory: Path) -> TelegramClient:
+    from telethon import TelegramClient
+
+    api_id, api_hash = api_credentials()
+    path = session_path(account, directory=directory)
+    if not path.exists():
+        raise SystemExit(f"no session for {account!r} at {path}")
+    return TelegramClient(str(path.with_suffix("")), api_id, api_hash)
+
+
+async def already_admin(client: TelegramClient, chat_id: int, user: Any) -> bool:
+    from telethon.errors import UserNotParticipantError
+
+    try:
+        permissions = await client.get_permissions(chat_id, user)
+    except UserNotParticipantError:
+        return False
+    except Exception:  # noqa: BLE001 — treated as "not yet", the promotion will say why
+        return False
+    return bool(permissions.is_admin)
+
+
+async def promote(client: TelegramClient, chat_id: int, user: Any, title: str) -> None:
+    """Appoint the account. Adds it to the chat first if Telegram insists.
+
+    Supergroups accept an administrator who is not yet a member and add them in
+    the same step; the older group type does not, and asks for the invitation to
+    happen first.
+    """
+    from telethon.errors import UserNotParticipantError
+    from telethon.tl import functions
+
+    try:
+        await client.edit_admin(chat_id, user, title=title[:MAX_TITLE], **admin_rights())
+    except UserNotParticipantError:
+        await client(functions.channels.InviteToChannelRequest(channel=chat_id, users=[user]))
+        await asyncio.sleep(random.uniform(MIN_DELAY, MAX_DELAY))  # noqa: S311 — pacing, not cryptography
+        await client.edit_admin(chat_id, user, title=title[:MAX_TITLE], **admin_rights())
+
+
+async def run(
+    *,
+    account: str,
+    target: str,
+    scope: list[Target],
+    title: str,
+    directory: Path,
+    journal_path: Path | None,
+    apply: bool,
+    min_delay: float,
+    max_delay: float,
+) -> int:
+    from telethon.errors import FloodWaitError, PeerFloodError
+
+    client = _client(account, directory)
+    await client.start()  # type: ignore[func-returns-value]
+    journal = Journal(journal_path)
+
+    me = await client.get_me()
+    user = await client.get_entity(target)
+    print(f"acting as {me.username or me.first_name} (id {me.id})")
+    print(f"appointing {getattr(user, 'username', None) or user.id} in {len(scope)} chats")
+    print("mode:      " + ("APPLY" if apply else "plan only (pass --apply to act)"))
+    print()
+
+    promoted = skipped = failed = 0
+    try:
+        for entry in scope:
+            label = f"{entry.chat_id:>12} {entry.title[:38]:<40}"
+            if journal.already(entry.chat_id):
+                print(f"{label} done earlier")
+                skipped += 1
+                continue
+            if await already_admin(client, entry.chat_id, user):
+                journal.record(entry.chat_id, ok=True, detail="already admin")
+                print(f"{label} already admin")
+                skipped += 1
+                continue
+            if not apply:
+                print(f"{label} would promote")
+                continue
+
+            try:
+                await promote(client, entry.chat_id, user, title)
+            except PeerFloodError:
+                # Already flagged. Continuing is how a temporary limit becomes a
+                # long one, so the run ends here and the journal keeps the place.
+                journal.record(entry.chat_id, ok=False, detail="peer_flood")
+                print(f"{label} PEER_FLOOD — stopping. Resume in a few hours with the same journal.")
+                failed += 1
+                break
+            except FloodWaitError as err:
+                journal.record(entry.chat_id, ok=False, detail=f"flood_wait {err.seconds}s")
+                print(f"{label} flood wait {err.seconds}s — stopping. Resume after that.")
+                failed += 1
+                break
+            except Exception as err:  # noqa: BLE001 — one chat failing must not end the rest
+                journal.record(entry.chat_id, ok=False, detail=f"{type(err).__name__}: {err}")
+                print(f"{label} failed: {type(err).__name__}")
+                failed += 1
+                continue
+
+            journal.record(entry.chat_id, ok=True)
+            promoted += 1
+            print(f"{label} promoted")
+            await asyncio.sleep(random.uniform(min_delay, max_delay))  # noqa: S311 — pacing, not cryptography
+    finally:
+        await client.disconnect()  # type: ignore[func-returns-value]
+
+    print(f"\npromoted {promoted}, skipped {skipped}, failed {failed}")
+    if not apply:
+        print("nothing was changed.")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--account", default="main", help="session doing the appointing")
+    parser.add_argument("--target", required=True, help="account to promote, e.g. @work_azamat")
+    parser.add_argument("--chats", type=Path, required=True, help="file of chat ids, one per line")
+    parser.add_argument("--title", default="", help=f"admin title shown in the chat, up to {MAX_TITLE} characters")
+    parser.add_argument("--sessions-dir", type=Path, default=SESSIONS_DIR)
+    parser.add_argument("--journal", type=Path, help="JSONL file recording progress, so a run can resume")
+    parser.add_argument("--min-delay", type=float, default=MIN_DELAY, help="shortest pause between writes")
+    parser.add_argument("--max-delay", type=float, default=MAX_DELAY, help="longest pause between writes")
+    parser.add_argument("--apply", action="store_true", help="actually appoint; without it nothing is sent")
+    args = parser.parse_args()
+
+    return asyncio.run(
+        run(
+            account=args.account,
+            target=args.target,
+            scope=read_scope(args.chats),
+            title=args.title,
+            directory=args.sessions_dir,
+            journal_path=args.journal,
+            apply=args.apply,
+            min_delay=args.min_delay,
+            max_delay=args.max_delay,
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_tg_promote.py
+++ b/tests/unit/test_tg_promote.py
@@ -1,0 +1,131 @@
+"""The promotion pass writes to real chats, so its guarantees are pinned here.
+
+Two of them are absolute. It never transfers ownership — that call is
+irreversible without the new owner's cooperation, and the file must not contain
+it. And it never takes anything away from anybody: no demotion, no removal, no
+leaving. Both are properties of the source, so both are checked against it.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "tg_promote.py"
+
+
+def _identifiers() -> set[str]:
+    """Every name the code actually refers to.
+
+    Read from the syntax tree rather than the text, so that naming a forbidden
+    call in a docstring — to explain why it is absent — does not read as using
+    it. The prose and the program are different things and this test is about
+    the program.
+    """
+    tree = ast.parse(_PATH.read_text(encoding="utf-8"))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.Name):
+            names.add(node.id)
+    return names
+
+
+_NAMES = _identifiers()
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("tg_promote", _PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["tg_promote"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tg_promote = _load()
+
+
+class TestItNeverTakesAnythingAway:
+    def test_ownership_is_never_transferred(self) -> None:
+        """editCreator hands the chat over for good. It has no business here."""
+        assert "EditCreatorRequest" not in _NAMES
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            "EditBannedRequest",
+            "DeleteParticipantRequest",
+            "kick_participant",
+            "LeaveChannelRequest",
+            "DeleteChatUserRequest",
+        ],
+    )
+    def test_no_call_that_removes_or_demotes_appears(self, call: str) -> None:
+        assert call not in _NAMES
+
+    def test_the_only_write_is_the_promotion_and_the_invite_it_needs(self) -> None:
+        assert {"edit_admin", "InviteToChannelRequest"} <= _NAMES
+
+
+class TestRights:
+    def test_every_administrator_right_is_granted(self) -> None:
+        rights = tg_promote.admin_rights()
+
+        assert all(rights[name] for name in rights if name != "anonymous")
+
+    def test_the_account_can_appoint_further_admins(self) -> None:
+        """Without it, it could not invite the bot back or hand over in turn."""
+        assert tg_promote.admin_rights()["add_admins"] is True
+
+    def test_moderation_is_not_anonymous(self) -> None:
+        assert tg_promote.admin_rights()["anonymous"] is False
+
+
+class TestScope:
+    def test_ids_are_read_with_their_labels(self, tmp_path: Path) -> None:
+        """A scope file is pasted from a report, so it carries titles too."""
+        path = tmp_path / "scope.txt"
+        path.write_text(
+            "# universities\n1405134944 ČVUT | ЧВУТ\n\n1192822531 Karlova univerzita\n1370017010\n",
+            encoding="utf-8",
+        )
+
+        scope = tg_promote.read_scope(path)
+
+        assert [entry.chat_id for entry in scope] == [1405134944, 1192822531, 1370017010]
+        assert scope[0].title == "ČVUT | ЧВУТ"
+        assert scope[2].title == ""
+
+
+class TestJournal:
+    def test_a_resumed_run_skips_finished_chats(self, tmp_path: Path) -> None:
+        path = tmp_path / "journal.jsonl"
+        tg_promote.Journal(path).record(1405134944, ok=True)
+
+        resumed = tg_promote.Journal(path)
+
+        assert resumed.already(1405134944) is True
+        assert resumed.already(1192822531) is False
+
+    def test_a_chat_that_hit_a_flood_wait_is_tried_again(self, tmp_path: Path) -> None:
+        """Stopping on a limit must not look like having finished the chat."""
+        path = tmp_path / "journal.jsonl"
+        tg_promote.Journal(path).record(1405134944, ok=False, detail="peer_flood")
+
+        assert tg_promote.Journal(path).already(1405134944) is False
+
+
+class TestPacing:
+    def test_there_is_always_a_pause_between_writes(self) -> None:
+        """A burst of membership changes is what gets the owner's account limited."""
+        assert tg_promote.MIN_DELAY > 0
+        assert tg_promote.MAX_DELAY > tg_promote.MIN_DELAY


### PR DESCRIPTION
Step two of the handover: work out which chats are in scope, then appoint the second account across them.

## Discovery — `scripts/tg_chats.py`

Scope comes from the account's own Telegram folders. It has the chats sorted by university already, and that describes the perimeter better than anything this repository could infer — the database has been wrong since May.

```bash
uv run python scripts/tg_chats.py folders --account main
uv run python scripts/tg_chats.py candidates --account main --bot @konnekt_moder_bot --out chats.csv
```

Run against the real account it found **403 groups**, 46 filed under universities, and chats nobody here knew about: a dormitory of 885 members, a faculty group of 297.

**It reads a chat list, never a chat.** A folder entry that is a person is dropped where it is parsed — before it is looked up, printed or counted — and the file contains no call that returns message contents: no `get_messages`, no history, no download. An absent capability beats a rule about not printing things. The personal folder is excluded by default, and exclusion wins over `--folder`, so a chat filed under both is out.

## Promotion — `scripts/tg_promote.py`

```bash
uv run python scripts/tg_promote.py --account main --target @work --chats scope.txt          # plan
uv run python scripts/tg_promote.py --account main --target @work --chats scope.txt --apply
```

Grants every administrator right, `add_admins` included — an account meant to replace the personal one has to be able to invite the bot back and hand over in turn.

**What it does not do is the point.** No ownership transfer, no demotion, no removal, no leaving. Those are properties of the source rather than promises, so the tests parse the syntax tree and assert the calls are absent — which is also why the docstring can name `editCreator` while explaining that it is not there.

## Pacing

Telegram reads a burst of membership changes as spam, and the limit lands on the account doing the appointing — the one that owns the chats. Delays between writes are randomised, a `FloodWaitError` is obeyed rather than retried through, and `PeerFloodError` ends the run: at that point the account is already flagged and continuing makes it worse. The journal makes stopping cheap.

## Verification

- discovery run end to end against the live account
- promotion dry-run over the 45-chat scope: 44 would promote, 1 already admin, nothing sent
- 14 unit tests over the writing script; the read-only one has none by design
- ruff, ty and the full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
