### PR TITLE
Put the moderator bot back, without announcing it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,7 @@ scripts/*
 !scripts/tg_accounts.py
 !scripts/tg_chats.py
 !scripts/tg_promote.py
+!scripts/tg_add_bot.py
 .claude/
 
 # Local credential drops — never tracked.

--- a/scripts/tg_add_bot.py
+++ b/scripts/tg_add_bot.py
@@ -1,0 +1,268 @@
+"""Put the moderator bot back into the chats it left, quietly.
+
+In May a middleware decided that a chat where the owner's personal account was
+not an administrator was a chat worth leaving, and the bot walked out of most of
+them. A bot cannot add itself, so this is done by the account that now
+administers those chats.
+
+    uv run python scripts/tg_add_bot.py --account work --bot @konnekt_moder_bot --chats scope.txt
+    uv run python scripts/tg_add_bot.py --account work --bot @konnekt_moder_bot --chats scope.txt --apply
+
+Without ``--apply`` nothing is sent.
+
+Quietly
+-------
+Adding someone to a group leaves a service message in it — "X added Y" — and
+thirty-five of those across the university chats is noise for several thousand
+students who did not ask to watch an administrative repair. So each addition is
+followed by deleting the notice it produced. ``--sweep`` extends that to notices
+already sitting in the chats from earlier work.
+
+That is the only reason this file reads messages at all, and it reads only
+service messages: the ones Telegram generates about membership. It never looks
+at, keeps or prints anything a person wrote.
+
+The rights the bot is given
+---------------------------
+What its own commands use, and nothing more. No ``add_admins`` — a bot that can
+appoint administrators turns a leaked token into a way to take over a chat — and
+no ``change_info``. It cannot promote, it cannot rename, and it cannot make
+itself anonymous.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import random
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tg_accounts import SESSIONS_DIR, api_credentials, session_path  # noqa: E402
+from tg_promote import MAX_TITLE, Journal, read_scope  # noqa: E402
+
+if TYPE_CHECKING:
+    from telethon import TelegramClient
+
+MIN_DELAY = 5.0
+MAX_DELAY = 15.0
+
+# How far back to look for the notice an addition just produced. It is the last
+# message in the chat unless people are talking, and a chat that busy will have
+# pushed it out of reach long before this runs.
+NOTICE_LOOKBACK = 25
+
+
+def bot_rights() -> dict[str, bool]:
+    """Moderation, and nothing that could hand the chat over.
+
+    ``invite_users`` is here because approving a join request counts as one;
+    without it the bot cannot answer the requests it exists to handle.
+    """
+    return {
+        "change_info": False,
+        "post_messages": False,
+        "edit_messages": False,
+        "delete_messages": True,
+        "ban_users": True,
+        "invite_users": True,
+        "pin_messages": True,
+        "add_admins": False,
+        "manage_call": False,
+        "anonymous": False,
+    }
+
+
+def _client(account: str, directory: Path) -> TelegramClient:
+    from telethon import TelegramClient
+
+    api_id, api_hash = api_credentials()
+    path = session_path(account, directory=directory)
+    if not path.exists():
+        raise SystemExit(f"no session for {account!r} at {path}")
+    return TelegramClient(str(path.with_suffix("")), api_id, api_hash)
+
+
+def announces(message: Any, watched: set[int]) -> bool:
+    """Whether this is a membership notice about one of the accounts we care about.
+
+    Only service messages reach here, and only their action is examined — who
+    arrived, never what anybody said.
+    """
+    from telethon.tl.types import (
+        MessageActionChatAddUser,
+        MessageActionChatJoinedByLink,
+        MessageService,
+    )
+
+    if not isinstance(message, MessageService):
+        return False
+    action = message.action
+    if isinstance(action, MessageActionChatAddUser):
+        return any(int(user) in watched for user in action.users)
+    if isinstance(action, MessageActionChatJoinedByLink):
+        sender = message.from_id
+        return bool(sender and int(getattr(sender, "user_id", 0)) in watched)
+    return False
+
+
+async def clear_notices(client: TelegramClient, chat_id: int, watched: set[int], *, limit: int) -> int:
+    """Delete the membership notices about the watched accounts. Returns how many."""
+    from telethon.tl.types import MessageService
+
+    doomed = []
+    async for message in client.iter_messages(chat_id, limit=limit):
+        # The filter runs before anything else touches the message, so a normal
+        # message is never examined beyond its type.
+        if isinstance(message, MessageService) and announces(message, watched):
+            doomed.append(message.id)
+
+    if doomed:
+        await client.delete_messages(chat_id, doomed)
+    return len(doomed)
+
+
+async def add_bot(client: TelegramClient, chat_id: int, bot: Any, title: str) -> None:
+    import contextlib
+
+    from telethon.errors import UserAlreadyParticipantError
+    from telethon.tl import functions
+
+    # Present but not an admin is a normal state to find a bot in, and the
+    # invitation is what fails then rather than the promotion.
+    with contextlib.suppress(UserAlreadyParticipantError):
+        await client(functions.channels.InviteToChannelRequest(channel=chat_id, users=[bot]))
+    await client.edit_admin(chat_id, bot, title=title[:MAX_TITLE], **bot_rights())
+
+
+async def run(
+    *,
+    account: str,
+    bot: str,
+    scope: list[Any],
+    title: str,
+    directory: Path,
+    journal_path: Path | None,
+    apply: bool,
+    sweep: bool,
+    min_delay: float,
+    max_delay: float,
+) -> int:
+    from telethon.errors import FloodWaitError, PeerFloodError, UserNotParticipantError
+
+    client = _client(account, directory)
+    await client.start()  # type: ignore[func-returns-value]
+    journal = Journal(journal_path)
+
+    me = await client.get_me()
+    bot_entity = await client.get_entity(bot)
+    watched = {int(bot_entity.id), int(me.id)}
+
+    print(f"acting as {me.username or me.first_name} (id {me.id})")
+    print(f"adding {getattr(bot_entity, 'username', None) or bot_entity.id} to {len(scope)} chats")
+    print("mode:   " + ("APPLY" if apply else "plan only (pass --apply to act)"))
+    print()
+
+    added = skipped = failed = notices = 0
+    try:
+        for entry in scope:
+            label = f"{entry.chat_id:>15} {entry.title[:36]:<38}"
+            if journal.already(entry.chat_id):
+                print(f"{label} done earlier")
+                skipped += 1
+                continue
+
+            try:
+                permissions = await client.get_permissions(entry.chat_id, bot_entity)
+                present = True
+                is_admin = bool(permissions.is_admin)
+            except UserNotParticipantError:
+                present, is_admin = False, False
+            except Exception as err:  # noqa: BLE001 — reported per chat
+                print(f"{label} cannot read: {type(err).__name__}")
+                failed += 1
+                continue
+
+            if is_admin and not sweep:
+                journal.record(entry.chat_id, ok=True, detail="already admin")
+                print(f"{label} already admin")
+                skipped += 1
+                continue
+
+            if not apply:
+                print(f"{label} would {'promote' if present else 'add and promote'}")
+                continue
+
+            try:
+                if not is_admin:
+                    await add_bot(client, entry.chat_id, bot_entity, title)
+                cleared = await clear_notices(client, entry.chat_id, watched, limit=NOTICE_LOOKBACK)
+            except PeerFloodError:
+                journal.record(entry.chat_id, ok=False, detail="peer_flood")
+                print(f"{label} PEER_FLOOD — stopping. Resume in a few hours with the same journal.")
+                failed += 1
+                break
+            except FloodWaitError as err:
+                journal.record(entry.chat_id, ok=False, detail=f"flood_wait {err.seconds}s")
+                print(f"{label} flood wait {err.seconds}s — stopping.")
+                failed += 1
+                break
+            except Exception as err:  # noqa: BLE001 — one chat failing must not end the rest
+                journal.record(entry.chat_id, ok=False, detail=f"{type(err).__name__}: {err}")
+                print(f"{label} failed: {type(err).__name__}")
+                failed += 1
+                continue
+
+            journal.record(entry.chat_id, ok=True)
+            added += 1
+            notices += cleared
+            print(f"{label} {'promoted' if is_admin else 'added'}{f', {cleared} notice(s) removed' if cleared else ''}")
+            await asyncio.sleep(random.uniform(min_delay, max_delay))  # noqa: S311 — pacing, not cryptography
+    finally:
+        await client.disconnect()  # type: ignore[func-returns-value]
+
+    print(f"\ndone {added}, skipped {skipped}, failed {failed}, notices removed {notices}")
+    if not apply:
+        print("nothing was changed.")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--account", default="work", help="session doing the adding")
+    parser.add_argument("--bot", required=True, help="the bot, e.g. @konnekt_moder_bot")
+    parser.add_argument("--chats", type=Path, required=True, help="file of chat ids, one per line")
+    parser.add_argument("--title", default="", help=f"admin title shown in the chat, up to {MAX_TITLE} characters")
+    parser.add_argument("--sessions-dir", type=Path, default=SESSIONS_DIR)
+    parser.add_argument("--journal", type=Path, help="JSONL file recording progress, so a run can resume")
+    parser.add_argument(
+        "--sweep",
+        action="store_true",
+        help="also visit chats where the bot is already an admin, to clear notices left there earlier",
+    )
+    parser.add_argument("--min-delay", type=float, default=MIN_DELAY)
+    parser.add_argument("--max-delay", type=float, default=MAX_DELAY)
+    parser.add_argument("--apply", action="store_true", help="actually add; without it nothing is sent")
+    args = parser.parse_args()
+
+    return asyncio.run(
+        run(
+            account=args.account,
+            bot=args.bot,
+            scope=read_scope(args.chats),
+            title=args.title,
+            directory=args.sessions_dir,
+            journal_path=args.journal,
+            apply=args.apply,
+            sweep=args.sweep,
+            min_delay=args.min_delay,
+            max_delay=args.max_delay,
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_tg_add_bot.py
+++ b/tests/unit/test_tg_add_bot.py
@@ -1,0 +1,135 @@
+"""Restoring the bot writes to real chats and deletes messages, so both are pinned.
+
+Deleting is the part to be careful about. The script clears the "X added Y"
+notices its own work produces, and the way that goes wrong is deleting something
+a person wrote. So the filter is tested against the shapes it will meet, and the
+absent capabilities are read off the syntax tree.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "tg_add_bot.py"
+
+
+def _identifiers() -> set[str]:
+    tree = ast.parse(_PATH.read_text(encoding="utf-8"))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.Name):
+            names.add(node.id)
+    return names
+
+
+_NAMES = _identifiers()
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("tg_add_bot", _PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["tg_add_bot"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tg_add_bot = _load()
+telethon = pytest.importorskip("telethon")
+
+from telethon.tl.types import (  # noqa: E402
+    MessageActionChatAddUser,
+    MessageActionChatDeleteUser,
+    MessageActionChatJoinedByLink,
+    MessageService,
+)
+
+BOT = 5145935834
+WORK = 7764554261
+STRANGER = 111222333
+
+
+def _service(action) -> MessageService:
+    return MessageService(id=1, peer_id=None, date=None, action=action)
+
+
+class TestWhatItDeletes:
+    def test_it_deletes_the_notice_that_the_bot_was_added(self) -> None:
+        message = _service(MessageActionChatAddUser(users=[BOT]))
+
+        assert tg_add_bot.announces(message, {BOT, WORK}) is True
+
+    def test_it_deletes_the_notice_that_the_work_account_joined_by_link(self) -> None:
+        message = _service(MessageActionChatJoinedByLink(inviter_id=1))
+        message.from_id = SimpleNamespace(user_id=WORK)
+
+        assert tg_add_bot.announces(message, {BOT, WORK}) is True
+
+    def test_somebody_else_joining_is_left_alone(self) -> None:
+        """Students join these chats constantly. None of that is ours to remove."""
+        message = _service(MessageActionChatAddUser(users=[STRANGER]))
+
+        assert tg_add_bot.announces(message, {BOT, WORK}) is False
+
+    def test_a_departure_notice_is_left_alone(self) -> None:
+        message = _service(MessageActionChatDeleteUser(user_id=BOT))
+
+        assert tg_add_bot.announces(message, {BOT, WORK}) is False
+
+    def test_an_ordinary_message_is_never_a_candidate(self) -> None:
+        """The one that matters: what a person wrote is not touched."""
+        written = SimpleNamespace(id=7, message="кто-нибудь сдал матан?", action=None)
+
+        assert tg_add_bot.announces(written, {BOT, WORK}) is False
+
+
+class TestBotRights:
+    def test_the_bot_cannot_appoint_administrators(self) -> None:
+        """Otherwise a leaked bot token becomes a way to take over the chat."""
+        assert tg_add_bot.bot_rights()["add_admins"] is False
+
+    def test_the_bot_cannot_rename_the_chat(self) -> None:
+        assert tg_add_bot.bot_rights()["change_info"] is False
+
+    def test_the_bot_can_do_what_its_commands_need(self) -> None:
+        rights = tg_add_bot.bot_rights()
+
+        assert rights["delete_messages"] is True
+        assert rights["ban_users"] is True
+        assert rights["pin_messages"] is True
+
+    def test_the_bot_can_answer_join_requests(self) -> None:
+        """Approving one counts as inviting, which is the right it needs."""
+        assert tg_add_bot.bot_rights()["invite_users"] is True
+
+    def test_moderation_is_not_anonymous(self) -> None:
+        assert tg_add_bot.bot_rights()["anonymous"] is False
+
+
+class TestItNeverTakesAnythingAway:
+    @pytest.mark.parametrize(
+        "call",
+        ["EditCreatorRequest", "EditBannedRequest", "DeleteParticipantRequest", "LeaveChannelRequest"],
+    )
+    def test_no_call_that_removes_a_person_or_the_chat(self, call: str) -> None:
+        assert call not in _NAMES
+
+    def test_the_only_deletion_is_of_messages(self) -> None:
+        assert "delete_messages" in _NAMES
+
+
+class TestPacing:
+    def test_there_is_always_a_pause_between_writes(self) -> None:
+        assert tg_add_bot.MIN_DELAY > 0
+        assert tg_add_bot.MAX_DELAY > tg_add_bot.MIN_DELAY


### PR DESCRIPTION
The bot cannot add itself. This is done by the working account promoted in #98 — the personal account is not involved.

## Quietly

Adding someone to a group leaves a service message, and thirty-six of those across the university chats is noise for several thousand students who did not ask to watch an administrative repair. Each addition is followed by deleting the notice it produced; `--sweep` clears ones left by earlier work.

That deletion is the careful part, because the way it goes wrong is removing something a person wrote. The filter considers only service messages — Telegram's own membership notices — and only those naming the bot or the acting account. A student joining is left alone, so is a departure, so is anything with text. Each of those shapes has a test.

This is also the only reason the file reads messages at all, and it reads no message contents.

## Rights

What the bot's own commands use: delete, ban, pin, and `invite_users` — approving a join request counts as inviting. No `add_admins`, which would turn a leaked bot token into a way to take over a chat, and no `change_info`.

## Verification

- dry run from the working account over the 45-chat scope: 36 would be added, 9 already admin
- 16 unit tests, including the message filter against real Telethon action types
- ruff, ty, full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)