### PR TITLE
Count an approved join request as a membership notice

### DIFF
--- a/scripts/tg_add_bot.py
+++ b/scripts/tg_add_bot.py
@@ -95,6 +95,7 @@ def announces(message: Any, watched: set[int]) -> bool:
     from telethon.tl.types import (
         MessageActionChatAddUser,
         MessageActionChatJoinedByLink,
+        MessageActionChatJoinedByRequest,
         MessageService,
     )
 
@@ -103,7 +104,7 @@ def announces(message: Any, watched: set[int]) -> bool:
     action = message.action
     if isinstance(action, MessageActionChatAddUser):
         return any(int(user) in watched for user in action.users)
-    if isinstance(action, MessageActionChatJoinedByLink):
+    if isinstance(action, MessageActionChatJoinedByLink | MessageActionChatJoinedByRequest):
         sender = message.from_id
         return bool(sender and int(getattr(sender, "user_id", 0)) in watched)
     return False

--- a/scripts/tg_tidy.py
+++ b/scripts/tg_tidy.py
@@ -58,14 +58,26 @@ DEFAULT_LOOKBACK = 3000
 
 
 def membership_actions() -> tuple[type, ...]:
-    """Notices about who is in the chat."""
+    """Notices about who is in the chat.
+
+    ``JoinedByRequest`` is the one that matters most here and the easiest to
+    miss. A chat with join approval turned on — which is most of these — records
+    every approved applicant that way rather than as an addition, so leaving it
+    out would clear a handful of notices and leave the actual pile untouched.
+    """
     from telethon.tl.types import (
         MessageActionChatAddUser,
         MessageActionChatDeleteUser,
         MessageActionChatJoinedByLink,
+        MessageActionChatJoinedByRequest,
     )
 
-    return (MessageActionChatAddUser, MessageActionChatDeleteUser, MessageActionChatJoinedByLink)
+    return (
+        MessageActionChatAddUser,
+        MessageActionChatDeleteUser,
+        MessageActionChatJoinedByLink,
+        MessageActionChatJoinedByRequest,
+    )
 
 
 def chat_change_actions() -> tuple[type, ...]:

--- a/tests/unit/test_tg_add_bot.py
+++ b/tests/unit/test_tg_add_bot.py
@@ -133,3 +133,28 @@ class TestPacing:
     def test_there_is_always_a_pause_between_writes(self) -> None:
         assert tg_add_bot.MIN_DELAY > 0
         assert tg_add_bot.MAX_DELAY > tg_add_bot.MIN_DELAY
+
+
+class TestApprovedJoinRequests:
+    """The notice a chat with join approval produces, and the easy one to miss.
+
+    Most of these chats vet applicants, so an approved join is recorded as
+    `JoinedByRequest` rather than as an addition. A filter without it clears a
+    handful of notices and leaves the actual pile in place.
+    """
+
+    def test_an_approved_join_by_the_bot_is_a_notice(self) -> None:
+        from telethon.tl.types import MessageActionChatJoinedByRequest
+
+        message = _service(MessageActionChatJoinedByRequest())
+        message.from_id = SimpleNamespace(user_id=BOT)
+
+        assert tg_add_bot.announces(message, {BOT, WORK}) is True
+
+    def test_a_student_approved_into_the_chat_is_left_alone(self) -> None:
+        from telethon.tl.types import MessageActionChatJoinedByRequest
+
+        message = _service(MessageActionChatJoinedByRequest())
+        message.from_id = SimpleNamespace(user_id=STRANGER)
+
+        assert tg_add_bot.announces(message, {BOT, WORK}) is False


### PR DESCRIPTION
Caught by sampling one chat before deleting anything in it. Of its last 1200 messages the filter matched **three** and left **eighty**:

```
WOULD DELETE: {AddUser: 2, DeleteUser: 1}
WOULD KEEP  : {NoneType: 1117, JoinedByRequest: 80}
```

`MessageActionChatJoinedByRequest` is what Telegram records when a chat with join approval admits somebody. That is most of these chats, and therefore most of the pile. The cleanup would have run, reported success, and changed nothing anybody would notice.

After the fix, same chat:

```
WOULD DELETE: {JoinedByRequest: 80, AddUser: 2, DeleteUser: 1}
WOULD KEEP  : {NoneType: 1117}
```

Every remaining message is one a person wrote.

## The bot needs no change

The Bot API folds an approved join into `new_chat_members`, which the handler merged in #100 already matches. Checked rather than assumed: 535 such service messages are in the database, and the three most recent carry both `new_chat_members` and `new_chat_member`.

## Verification

- two new tests: the bot's own approved join is a notice, a student's is not
- 18 tests on the script, ruff/ty/full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)