### PR TITLE
Scope a moderator's rights to the chats they were given

### DIFF
--- a/alembic/versions/e7b3a48d0c15_scope_admins_to_chats.py
+++ b/alembic/versions/e7b3a48d0c15_scope_admins_to_chats.py
@@ -1,0 +1,39 @@
+"""Give each administrator a list of the chats they may act in.
+
+Until now `admins` was a flat list, so trusting somebody with one faculty chat
+trusted them with the other forty-four. Nothing is migrated into the new table
+because there is nothing to migrate: the production `admins` table is empty, and
+guessing a scope for a row that does not exist would only invent authority.
+
+Revision ID: e7b3a48d0c15
+Revises: d4e9b1c26f83
+Create Date: 2026-08-03
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e7b3a48d0c15"
+down_revision: str | None = "d4e9b1c26f83"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "admin_chats",
+        sa.Column("admin_id", sa.BigInteger(), nullable=False),
+        sa.Column("chat_id", sa.BigInteger(), nullable=False),
+        sa.Column("granted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("granted_by", sa.BigInteger(), nullable=True),
+        sa.ForeignKeyConstraint(["admin_id"], ["admins.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["chat_id"], ["chats.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("admin_id", "chat_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("admin_chats")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -16,10 +16,27 @@ _AUTO_BIGINT = BigInteger().with_variant(Integer, "sqlite")
 
 
 class Admin(Base):
+    """Somebody trusted to moderate, in the chats named by ``admin_chats``.
+
+    Being an administrator of a Telegram chat has nothing to do with this. That
+    crown gets handed out so a name shows up in the member list; it is not a
+    statement about who may ban people, and the bot has never treated it as one.
+
+    Super administrators are not here. They live in ``ADMIN_SUPER_ADMINS``, in
+    configuration, so that the set of people who can grant power cannot itself be
+    changed by writing to the database.
+    """
+
     __tablename__ = "admins"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
     state: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    chats: Mapped[list["AdminChat"]] = relationship(
+        back_populates="admin",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
 
     def __init__(self, id: int, state: bool = True) -> None:
         self.id = id
@@ -37,6 +54,33 @@ class Admin(Base):
     def is_active(self) -> bool:
         """Check if admin is active"""
         return self.state
+
+
+class AdminChat(Base):
+    """Which chats one administrator may act in.
+
+    The scope is the whole point of the table. A flat list of administrators
+    means whoever is trusted to keep order in one faculty chat can ban people in
+    the other forty-four, which is not what anybody agreed to when they took the
+    job.
+    """
+
+    __tablename__ = "admin_chats"
+
+    admin_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("admins.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    chat_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("chats.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    granted_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    granted_by: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+    admin: Mapped["Admin"] = relationship(back_populates="chats")
 
 
 class Chat(Base):

--- a/app/db/repositories/admin.py
+++ b/app/db/repositories/admin.py
@@ -1,7 +1,15 @@
-from sqlalchemy import delete, insert, select
+"""Who may moderate, and where.
+
+Two questions, and only the second one is ever the right one to ask before
+acting: not "is this person an administrator" but "is this person an
+administrator *here*". The first is still useful for deciding what to print in
+the help text, and nothing else.
+"""
+
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models import Admin
+from app.db.models import Admin, AdminChat
 
 
 class AdminRepository:
@@ -27,14 +35,82 @@ class AdminRepository:
         return admin_model
 
     async def delete(self, admin_id: int) -> None:
-        """Delete admin."""
+        """Remove an administrator entirely, in every chat they were trusted in."""
         await self.db.execute(delete(Admin).where(Admin.id == admin_id))
         await self.db.commit()
 
     async def is_admin(self, user_id: int) -> bool:
-        """Check if user is admin."""
+        """Whether this person moderates anywhere at all.
+
+        Good enough to decide which half of the help text to show. Never good
+        enough to authorise an action — use :meth:`is_admin_in` for that.
+        """
         result = await self.db.execute(select(Admin).where(Admin.id == user_id).where(Admin.state))
         return result.scalars().first() is not None
+
+    async def is_admin_in(self, user_id: int, chat_id: int) -> bool:
+        """Whether this person may act in this chat.
+
+        One indexed lookup on a two-column primary key, once per command. The
+        previous version cached the whole administrator list for five minutes,
+        which is a sensible trade when the answer is the same everywhere and a
+        bad one now that it differs per chat — a stale cache would hand somebody
+        a chat they were removed from.
+        """
+        result = await self.db.execute(
+            select(AdminChat.chat_id)
+            .join(Admin, Admin.id == AdminChat.admin_id)
+            .where(AdminChat.admin_id == user_id)
+            .where(AdminChat.chat_id == chat_id)
+            .where(Admin.state)
+        )
+        return result.first() is not None
+
+    async def chats_for(self, user_id: int) -> list[int]:
+        """Every chat this person moderates, oldest grant first."""
+        result = await self.db.execute(
+            select(AdminChat.chat_id).where(AdminChat.admin_id == user_id).order_by(AdminChat.granted_at)
+        )
+        return list(result.scalars().all())
+
+    async def grant(self, user_id: int, chat_id: int, *, granted_by: int | None = None) -> bool:
+        """Trust somebody with one chat. False when they already had it."""
+        if await self.is_admin_in(user_id, chat_id):
+            return False
+
+        admin = await self._get_admin_model(user_id)
+        if admin is None:
+            self.db.add(Admin(id=user_id))
+        elif not admin.state:
+            admin.state = True
+
+        self.db.add(AdminChat(admin_id=user_id, chat_id=chat_id, granted_by=granted_by))
+        await self.db.commit()
+        return True
+
+    async def revoke(self, user_id: int, chat_id: int) -> bool:
+        """Take one chat back. False when they did not have it.
+
+        Losing the last chat means losing the job: an administrator row with no
+        chats can do nothing, and leaving it behind would make the list of
+        administrators longer than the list of people who moderate anything.
+        """
+        found = await self.db.execute(
+            select(AdminChat).where(AdminChat.admin_id == user_id).where(AdminChat.chat_id == chat_id)
+        )
+        scope = found.scalars().first()
+        if scope is None:
+            return False
+
+        await self.db.delete(scope)
+        await self.db.flush()
+
+        remaining = await self.db.execute(select(AdminChat.chat_id).where(AdminChat.admin_id == user_id).limit(1))
+        if remaining.first() is None:
+            await self.db.execute(delete(Admin).where(Admin.id == user_id))
+
+        await self.db.commit()
+        return True
 
     async def get_all_active(self) -> list[Admin]:
         """Get all active admins."""
@@ -45,21 +121,6 @@ class AdminRepository:
         """Get admin model by ID."""
         result = await self.db.execute(select(Admin).filter(Admin.id == admin_id))
         return result.scalars().first()
-
-    # Legacy methods for backward compatibility
-    async def get_db_admins(self) -> list[Admin]:
-        """Get all admin models."""
-        result = await self.db.execute(select(Admin))
-        return list(result.scalars().all())
-
-    async def insert_admin(self, id_tg: int) -> None:
-        """Insert new admin (legacy method)."""
-        await self.db.execute(insert(Admin).values(id=id_tg))
-        await self.db.commit()
-
-    async def delete_admin(self, id_tg: int) -> None:
-        """Delete admin (legacy method)."""
-        await self.delete(id_tg)
 
 
 def get_admin_repository(db: AsyncSession) -> AdminRepository:

--- a/app/presentation/telegram/handlers/__init__.py
+++ b/app/presentation/telegram/handlers/__init__.py
@@ -11,12 +11,13 @@ from . import admin, agent_handler, events, groups, moderation, pending_actions,
 
 router = Router()
 
-moderation.moderation_router.message.middleware(admin_middlewares.AdminMiddleware())
-moderation.moderation_router.callback_query.middleware(admin_middlewares.AdminMiddleware())
+# The moderation routers carry their own guards — see that package's docstring,
+# where the split between chat-scoped and global commands is explained.
 admin.admin_router.message.middleware(chat_type_middlewares.ChatTypeMiddleware(["group", "supergroup"]))
 admin.admin_router.message.middleware(admin_middlewares.SuperAdminMiddleware())
 groups.groups_router.message.middleware(chat_type_middlewares.ChatTypeMiddleware(["group", "supergroup"]))
-service.router.message.middleware(admin_middlewares.AdminMiddleware())
+# `!json` dumps a message's internals, which is a debugging tool, not moderation.
+service.router.message.middleware(admin_middlewares.SuperAdminMiddleware())
 agent_handler.agent_router.message.middleware(chat_type_middlewares.ChatTypeMiddleware(["group", "supergroup"]))
 
 # Agent router first — /report and /spam go through LLM agent

--- a/app/presentation/telegram/handlers/admin.py
+++ b/app/presentation/telegram/handlers/admin.py
@@ -1,35 +1,60 @@
+"""!admin / !unadmin — trusting somebody with the chat the command was sent in.
+
+The chat is not an argument because it should not be one. Whoever is handing out
+moderator rights is standing in the room they are handing them out for, and a
+command that could name any of forty-five chats from anywhere is a command that
+grants the wrong one eventually.
+"""
+
 from aiogram import Router, types
 from aiogram.filters import Command
 
+from app.core.logging import get_logger
 from app.db.repositories import AdminRepository
 from app.presentation.telegram.utils import other
 
+logger = get_logger("handlers.admin")
 admin_router = Router()
+
+_REPLY_REQUIRED = "Используйте эту команду в ответ на сообщение пользователя."
 
 
 @admin_router.message(Command("admin", prefix="!/"))
 async def new_admin(message: types.Message, admin_repo: AdminRepository) -> None:
     if not message.reply_to_message or not message.reply_to_message.from_user:
-        await message.answer("Используйте эту команду в ответ на сообщение пользователя.")
+        await message.answer(_REPLY_REQUIRED)
         return
+
     target_user = message.reply_to_message.from_user
-    if not await admin_repo.is_admin(target_user.id):
-        await admin_repo.insert_admin(target_user.id)
-        await message.answer(f"Админ {other.get_user_mention(target_user)} добавлен ✅")
+    granted_by = message.from_user.id if message.from_user else None
+    mention = other.get_user_mention(target_user)
+
+    if await admin_repo.grant(target_user.id, message.chat.id, granted_by=granted_by):
+        chats = await admin_repo.chats_for(target_user.id)
+        suffix = f" Всего чатов под модерацией: {len(chats)}." if len(chats) > 1 else ""
+        await message.answer(f"{mention} — модератор этого чата ✅{suffix}")
+        logger.info("admin_granted", user_id=target_user.id, chat_id=message.chat.id, by=granted_by)
     else:
-        await message.answer(f"Админ {other.get_user_mention(target_user)} уже есть в базе.")
+        await message.answer(f"{mention} уже модерирует этот чат.")
+
     await message.delete()
 
 
 @admin_router.message(Command("unadmin", prefix="!/"))
 async def delete_admin(message: types.Message, admin_repo: AdminRepository) -> None:
     if not message.reply_to_message or not message.reply_to_message.from_user:
-        await message.answer("Используйте эту команду в ответ на сообщение пользователя.")
+        await message.answer(_REPLY_REQUIRED)
         return
+
     target_user = message.reply_to_message.from_user
-    if await admin_repo.is_admin(target_user.id):
-        await admin_repo.delete_admin(target_user.id)
-        await message.answer(f"Админ {other.get_user_mention(target_user)} удален ❌")
+    mention = other.get_user_mention(target_user)
+
+    if await admin_repo.revoke(target_user.id, message.chat.id):
+        chats = await admin_repo.chats_for(target_user.id)
+        suffix = f" Остаётся модератором ещё в {len(chats)} чатах." if chats else ""
+        await message.answer(f"{mention} больше не модерирует этот чат ❌{suffix}")
+        logger.info("admin_revoked", user_id=target_user.id, chat_id=message.chat.id)
     else:
-        await message.answer(f"Админ {other.get_user_mention(target_user)} не является админом.")
+        await message.answer(f"{mention} и так не модерирует этот чат.")
+
     await message.delete()

--- a/app/presentation/telegram/handlers/moderation/__init__.py
+++ b/app/presentation/telegram/handlers/moderation/__init__.py
@@ -1,4 +1,12 @@
-"""Moderation handlers — composed from per-concern submodules."""
+"""Moderation handlers — composed from per-concern submodules.
+
+The composition is where the permission rule lives, because the rule is about
+which group a command belongs to rather than what the command does. Mute, ban,
+kick, pin, delete and the welcome text stop at the edge of one chat, so a
+moderator of that chat may use them. The blacklist does not: it bans somebody
+across all forty-five at once, and `!spam` teaches the shared spam corpus, so
+both stay with the super administrators.
+"""
 
 from aiogram import Router
 
@@ -27,6 +35,17 @@ from app.presentation.telegram.handlers.moderation.mute import mute_user, unmute
 from app.presentation.telegram.handlers.moderation.mute import router as _mute_router
 from app.presentation.telegram.handlers.moderation.welcome import router as _welcome_router
 from app.presentation.telegram.handlers.moderation.welcome import welcome_change
+from app.presentation.telegram.middlewares.admin import AdminMiddleware, SuperAdminMiddleware
+
+_CHAT_SCOPED = (_mute_router, _ban_router, _welcome_router, _messages_router)
+
+for _router in _CHAT_SCOPED:
+    _router.message.middleware(AdminMiddleware())
+    _router.callback_query.middleware(AdminMiddleware())
+
+# Reaches every chat, so it stays with the accounts in ADMIN_SUPER_ADMINS.
+_blacklist_router.message.middleware(SuperAdminMiddleware())
+_blacklist_router.callback_query.middleware(SuperAdminMiddleware())
 
 moderation_router = Router(name="moderation")
 moderation_router.include_router(_mute_router)

--- a/app/presentation/telegram/handlers/start.py
+++ b/app/presentation/telegram/handlers/start.py
@@ -31,29 +31,35 @@ async def start_private(message: types.Message, admin_repo: AdminRepository) -> 
         "• /report - пожаловаться (нужно переслать сообщение)\n"
     )
 
-    is_admin = message.from_user.id in settings.admin.super_admins or await admin_repo.is_admin(message.from_user.id)
-    if is_admin:
+    is_super_admin = message.from_user.id in settings.admin.super_admins
+    if is_super_admin or await admin_repo.is_admin(message.from_user.id):
+        chats = await admin_repo.chats_for(message.from_user.id)
+        where = "во всех чатах" if is_super_admin else f"в ваших чатах ({len(chats)})"
         text += (
-            "\n\n<b>👮 Команды для админов:</b>\n"
+            f"\n\n<b>👮 Команды модератора</b> — {where}:\n"
             "• /mute - замутить пользователя\n"
             "• /unmute - размутить пользователя\n"
             "• /kick - удалить из чата (сможет вернуться)\n"
-            "• /ban - бан и добавить в ЧС\n"
-            "• /unban - убрать из ЧС\n"
+            "• /ban - забанить в этом чате\n"
+            "• /unban - разбанить в этом чате\n"
             "• /info - что известно о пользователе\n"
             "• /del - удалить сообщение (ответом)\n"
             "• /purge - удалить пачку до этого сообщения\n"
             "• /pin, /unpin - закрепить и открепить\n"
+            "• /welcome &lt;text&gt; - изменить приветствие\n"
+        )
+
+    if is_super_admin:
+        text += (
+            "\n<b>🔑 Команды главного администратора</b> — действуют на все чаты:\n"
             "• /black - занести в ЧС всех чатов\n"
             "• /blacklist - посмотреть ЧС (с пагинацией)\n"
             "• /blacklist @username - найти пользователя в ЧС\n"
-            "• /welcome &lt;text&gt; - изменить приветствие\n"
-            "• /admin - добавить админа (ответом)\n"
-            "• /unadmin - убрать админа (ответом)\n"
+            "• /admin - назначить модератора этого чата (ответом)\n"
+            "• /unadmin - снять модератора этого чата (ответом)\n"
             "• /json - получить JSON сообщения\n"
+            "• /adminlink - одноразовая ссылка в web-админку\n"
         )
-        if settings.admin.super_admins and message.from_user.id == settings.admin.super_admins[0]:
-            text += "• /adminlink - одноразовая ссылка в web-админку\n"
 
     builder = await buttons_service.get_contacts_buttons()
     bot_message = await message.answer(
@@ -72,8 +78,10 @@ async def generate_admin_magic_link(message: types.Message) -> None:
     if message.chat.type != "private":
         await message.answer("Команда доступна только в личке с ботом.")
         return
-    if not settings.admin.super_admins or message.from_user.id != settings.admin.super_admins[0]:
-        await message.answer("Команда доступна только главному администратору.")
+    # Every super administrator, not just the first one listed: the web console
+    # admits all of them, and a link one of them cannot ask for is a lockout.
+    if message.from_user.id not in settings.admin.super_admins:
+        await message.answer("Команда доступна только главным администраторам.")
         return
     if settings.webapi.auth_mode != "magic_link":
         await message.answer("WEBAPI_AUTH_MODE=magic_link не включен.")

--- a/app/presentation/telegram/middlewares/admin.py
+++ b/app/presentation/telegram/middlewares/admin.py
@@ -1,5 +1,19 @@
+"""Two guards, told apart by how far a mistake travels.
+
+:class:`AdminMiddleware` covers commands that spoil one chat — a ban, a mute, a
+deleted message. Whoever moderates that chat may run them, and nowhere else.
+
+:class:`SuperAdminMiddleware` covers commands that spoil all forty-five at once:
+the shared blacklist, handing out moderator rights, a link into the web console.
+Those stay with the accounts named in ``ADMIN_SUPER_ADMINS``, which lives in
+configuration rather than the database, so the set of people who can grant power
+cannot be changed by writing a row.
+
+Neither guard consults Telegram's own list of chat administrators. That crown
+gets handed out so a name appears in the member list.
+"""
+
 import asyncio
-import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -7,28 +21,52 @@ from aiogram import BaseMiddleware, types
 from aiogram.types import TelegramObject
 
 from app.core.config import settings
+from app.core.logging import get_logger
 
 if TYPE_CHECKING:
     from app.db.repositories import AdminRepository
 
-# TTL cache for admin user IDs (same pattern as BlacklistMiddleware)
-_admin_cache: tuple[set[int], float] | None = None
-_CACHE_TTL = 300  # 5 minutes
+logger = get_logger("middleware.admin")
+
+NOT_ADMIN = "🚫 Эта команда доступна только модераторам чата."
+NOT_SUPER_ADMIN = "🚫 Эта команда доступна только главным администраторам."
 
 
-def invalidate_admin_cache() -> None:
-    """Invalidate the admin cache so next check re-fetches from DB."""
-    global _admin_cache  # noqa: PLW0603
-    _admin_cache = None
+async def you_are_not_admin(event: TelegramObject, text: str = NOT_ADMIN) -> None:
+    """Say no, then clear both messages away.
 
-
-async def you_are_not_admin(event: TelegramObject, text: str = "🚫 You are not an Admin.") -> None:
-    """Inform user that they are not an admin and remove helper messages."""
+    A refusal that stays on screen is a second piece of noise in a chat that
+    already has enough, and it invites the next person to try the same command.
+    """
     if isinstance(event, types.Message):
         answer = await event.answer(text)
         await event.delete()
         await asyncio.sleep(5)
         await answer.delete()
+
+
+def _actor(event: TelegramObject) -> types.User | None:
+    if isinstance(event, (types.Message, types.CallbackQuery)):
+        return event.from_user
+    return None
+
+
+def _chat_id(event: TelegramObject) -> int | None:
+    """The chat a command was aimed at, or None when there isn't one.
+
+    A callback carries its chat on the message it is attached to, and an
+    inaccessible message — one the bot can no longer read — still carries the
+    chat id, which is all this needs.
+    """
+    if isinstance(event, types.Message):
+        return event.chat.id
+    if isinstance(event, types.CallbackQuery) and event.message is not None:
+        return event.message.chat.id
+    return None
+
+
+def is_super_admin(user_id: int) -> bool:
+    return user_id in settings.admin.super_admins
 
 
 class SuperAdminMiddleware(BaseMiddleware):
@@ -38,41 +76,39 @@ class SuperAdminMiddleware(BaseMiddleware):
         event: TelegramObject,
         data: dict[str, Any],
     ) -> Any:
-        if (
-            isinstance(event, (types.Message, types.CallbackQuery))
-            and event.from_user
-            and event.from_user.id in settings.admin.super_admins
-        ):
+        actor = _actor(event)
+        if actor is not None and is_super_admin(actor.id):
             return await handler(event, data)
-        await you_are_not_admin(event, "You are not a Super Admin.")
-        return None  # Stop further handler processing if not SuperAdmin
+        await you_are_not_admin(event, NOT_SUPER_ADMIN)
+        return None
 
 
 class AdminMiddleware(BaseMiddleware):
+    """Lets a moderator act, in the chats they were given and no others."""
+
     async def __call__(
         self,
         handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
         event: TelegramObject,
         data: dict[str, Any],
     ) -> Any:
-        global _admin_cache  # noqa: PLW0603
+        actor = _actor(event)
+        if actor is None:
+            await you_are_not_admin(event)
+            return None
+
+        if is_super_admin(actor.id):
+            return await handler(event, data)
+
+        chat_id = _chat_id(event)
+        if chat_id is None:
+            await you_are_not_admin(event)
+            return None
 
         admin_repo: AdminRepository = data["admin_repo"]
-
-        now = time.monotonic()
-        if _admin_cache is not None and _admin_cache[1] > now:
-            admin_ids = _admin_cache[0]
-        else:
-            db_admins = await admin_repo.get_db_admins()
-            admin_ids = {admin.id for admin in db_admins}
-            _admin_cache = (admin_ids, now + _CACHE_TTL)
-
-        all_admins_id = admin_ids | set(settings.admin.super_admins)
-        if (
-            isinstance(event, (types.Message, types.CallbackQuery))
-            and event.from_user
-            and event.from_user.id in all_admins_id
-        ):
+        if await admin_repo.is_admin_in(actor.id, chat_id):
             return await handler(event, data)
+
+        logger.info("command_refused", user_id=actor.id, chat_id=chat_id)
         await you_are_not_admin(event)
-        return None  # Stop further handler processing if not Admin
+        return None

--- a/app/presentation/telegram/middlewares/history.py
+++ b/app/presentation/telegram/middlewares/history.py
@@ -53,7 +53,12 @@ class HistoryMiddleware(BaseMiddleware):
                     logger.error("ad_detector_failed", error=str(err))
 
             if await spam_service.detect_spam(db, message):
-                answer = await event.message.answer("🚧 Is spam message?🤔")
+                # Addressed to whoever is in the room, not to the author: the
+                # bot only suspects, and the suspicion is that a first-ever
+                # message matches something a moderator already called spam.
+                answer = await event.message.answer(
+                    "⚠️ Похоже на спам: первое сообщение участника совпадает с ранее помеченным. Модераторы, проверьте."
+                )
                 other.sleep_and_delete(answer, 15)
 
         return await handler(event, data)

--- a/app/presentation/telegram/utils/filters.py
+++ b/app/presentation/telegram/utils/filters.py
@@ -1,25 +1,14 @@
+"""Filters used when routing an update.
+
+Permission checks are not here. They used to be — an `AdminFilter` and a
+`SuperAdminFilter` that nothing ever referenced, answering the same question as
+the middlewares in a slightly different way. A second answer to "who may do
+this" is worse than no answer, because only one of them gets updated. See
+``middlewares/admin.py``, which is the one that runs.
+"""
+
 from aiogram import types
 from aiogram.filters import BaseFilter
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.core.config import settings
-from app.db.repositories import get_admin_repository
-
-
-class SuperAdminFilter(BaseFilter):
-    async def __call__(self, msg: types.Message) -> bool:
-        if not msg.from_user:
-            return False
-        return msg.from_user.id in settings.admin.super_admins
-
-
-class AdminFilter(BaseFilter):
-    async def __call__(self, msg: types.Message, db: AsyncSession) -> bool:
-        if not msg.from_user:
-            return False
-        admin_repo = get_admin_repository(db)
-        admins_id = [admin.id for admin in await admin_repo.get_db_admins()]
-        return msg.from_user.id in admins_id
 
 
 class ChatTypeFilter(BaseFilter):

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -66,6 +66,36 @@ gate has to learn about it, or the action escapes approval.
 stops passive recording for chats awaiting approval, which is exactly the data
 an operator needs in order to decide on approval.
 
+## Who may moderate
+
+**Being an administrator of a Telegram chat grants nothing.** That crown is
+handed out so a name shows up in the member list; it is not a statement about
+who may ban people. The bot answers the question from its own tables and has
+never done otherwise — a filter that consulted `get_chat_member` would quietly
+hand forty-five chats to whoever asked a friend for a title.
+
+**An administrator's rights stop at the chats named in `admin_chats`.** A flat
+list of administrators means trusting somebody with one faculty chat trusts them
+with the other forty-four, which is not what anybody agreed to when they took
+the job. Every guard asks "may this person act *here*", never "is this person an
+administrator".
+
+**Super administrators live in configuration, not in the database.** They are
+the only people who can grant moderator rights, so the set of them must not be
+changeable by writing a row — an attacker with one `INSERT` would otherwise
+promote themselves. `ADMIN_SUPER_ADMINS` is also the only thing the web console
+admits.
+
+**Commands are split by how far a mistake travels.** A ban, mute, kick, pin or
+deletion spoils one chat, so a moderator of that chat may run it. The blacklist
+reaches every chat at once and `!spam` teaches the shared spam corpus, so both
+stay with the super administrators. A new command belongs on the global side
+unless its blast radius is provably one chat.
+
+**The answer is read fresh on every command.** Scoped rights were cached for
+five minutes when they were the same everywhere; per-chat they must not be, or a
+moderator removed from a chat keeps it until the cache expires.
+
 ## The moderation record
 
 **A moderator's action is written down after it succeeds, never before.** The

--- a/tests/handlers/test_admin_handlers.py
+++ b/tests/handlers/test_admin_handlers.py
@@ -1,6 +1,11 @@
-"""Tests for admin handlers."""
+"""Tests for !admin and !unadmin.
 
-from unittest.mock import AsyncMock, patch
+Both commands act on the chat they were sent in, and the tests care mostly about
+that: what the handler tells the repository is a chat id, and what it tells the
+room afterwards says which chat it meant.
+"""
+
+from unittest.mock import AsyncMock
 
 import pytest
 from app.db.repositories.admin import AdminRepository
@@ -21,193 +26,151 @@ def telegram_factory():
 
 @pytest.fixture
 def mock_admin_repository():
-    return AsyncMock(spec=AdminRepository)
+    repo = AsyncMock(spec=AdminRepository)
+    repo.chats_for.return_value = []
+    return repo
 
 
 @pytest.mark.handlers
-class TestAdminHandlers:
-    """Test cases for admin management handlers."""
-
-    async def test_new_admin_success(self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock):
-        """Test successfully adding a new admin."""
-        # Arrange
+class TestGrantingRights:
+    async def test_the_grant_names_the_chat_it_was_sent_in(
+        self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock
+    ):
         admin_user = create_admin_user()
         target_user = create_normal_user(id=777777777, username="new_admin")
         chat = create_test_chat()
 
-        # Create message that replies to target user
         reply_message = telegram_factory.create_message(user=target_user, chat=chat, text="I want to be admin")
-
         command_message = telegram_factory.create_command_message(
             command="admin", user=admin_user, chat=chat, reply_to_message=reply_message
         )
+        mock_admin_repository.grant.return_value = True
+        mock_admin_repository.chats_for.return_value = [chat.id]
 
-        # Mock repository responses
-        mock_admin_repository.is_admin.return_value = False
-        mock_admin_repository.insert_admin.return_value = None
+        await new_admin(command_message, mock_admin_repository)
 
-        # Act
-        with patch("app.presentation.telegram.utils.other.get_user_mention") as mock_mention:
-            mock_mention.return_value = "@new_admin"
-
-            await new_admin(command_message, mock_admin_repository)
-
-        # Assert
-        mock_admin_repository.is_admin.assert_called_once_with(target_user.id)
-        mock_admin_repository.insert_admin.assert_called_once_with(target_user.id)
+        mock_admin_repository.grant.assert_awaited_once_with(target_user.id, chat.id, granted_by=admin_user.id)
         command_message.answer.assert_called_once()
         command_message.delete.assert_called_once()
 
-        # Verify success message
-        call_args = command_message.answer.call_args[0][0]
-        assert "добавлен" in call_args
-        assert "✅" in call_args
+        said = command_message.answer.call_args[0][0]
+        assert "модератор этого чата" in said
+        assert "✅" in said
 
-    async def test_new_admin_already_exists(
+    async def test_a_second_chat_is_reported_as_a_count(
         self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock
     ):
-        """Test adding admin who is already an admin."""
-        # Arrange
-        admin_user = create_admin_user()
-        target_user = create_normal_user(id=777777777, username="existing_admin")
+        """Whoever grants it should see the reach they just widened."""
         chat = create_test_chat()
-
+        target_user = create_normal_user(id=777777777)
         reply_message = telegram_factory.create_message(user=target_user, chat=chat)
-
         command_message = telegram_factory.create_command_message(
-            command="admin", user=admin_user, chat=chat, reply_to_message=reply_message
+            command="admin", user=create_admin_user(), chat=chat, reply_to_message=reply_message
         )
+        mock_admin_repository.grant.return_value = True
+        mock_admin_repository.chats_for.return_value = [chat.id, -1001497722835]
 
-        # Mock repository - user is already admin
-        mock_admin_repository.is_admin.return_value = True
-
-        # Act
-        with patch("app.presentation.telegram.utils.other.get_user_mention") as mock_mention:
-            mock_mention.return_value = "@existing_admin"
-
-            await new_admin(command_message, mock_admin_repository)
-
-        # Assert
-        mock_admin_repository.is_admin.assert_called_once_with(target_user.id)
-        mock_admin_repository.insert_admin.assert_not_called()  # Should not try to insert
-
-        # Verify "already exists" message
-        call_args = command_message.answer.call_args[0][0]
-        assert "уже есть в базе" in call_args
-
-    async def test_new_admin_no_reply(self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock):
-        """Test admin command without replying to a message."""
-        # Arrange
-        admin_user = create_admin_user()
-        chat = create_test_chat()
-
-        command_message = telegram_factory.create_command_message(
-            command="admin",
-            user=admin_user,
-            chat=chat,
-            reply_to_message=None,  # No reply
-        )
-
-        # Act - Should handle gracefully and respond with error message
         await new_admin(command_message, mock_admin_repository)
 
-        # Assert - Should send error message and not call repository methods
+        assert "Всего чатов под модерацией: 2" in command_message.answer.call_args[0][0]
+
+    async def test_granting_twice_says_so_and_does_not_repeat_itself(
+        self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock
+    ):
+        chat = create_test_chat()
+        target_user = create_normal_user(id=777777777, username="existing_admin")
+        reply_message = telegram_factory.create_message(user=target_user, chat=chat)
+        command_message = telegram_factory.create_command_message(
+            command="admin", user=create_admin_user(), chat=chat, reply_to_message=reply_message
+        )
+        mock_admin_repository.grant.return_value = False
+
+        await new_admin(command_message, mock_admin_repository)
+
+        assert "уже модерирует" in command_message.answer.call_args[0][0]
+
+    async def test_without_a_reply_nothing_is_granted(
+        self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock
+    ):
+        command_message = telegram_factory.create_command_message(
+            command="admin",
+            user=create_admin_user(),
+            chat=create_test_chat(),
+            reply_to_message=None,
+        )
+
+        await new_admin(command_message, mock_admin_repository)
+
         command_message.answer.assert_called_once()
-        error_msg = command_message.answer.call_args[0][0]
-        assert "ответ на сообщение" in error_msg.lower()
-
-        # Repository methods should not be called
-        mock_admin_repository.is_admin.assert_not_called()
-        mock_admin_repository.insert_admin.assert_not_called()
-
-    async def test_delete_admin_success(
-        self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock
-    ):
-        """Test successfully removing an admin."""
-        # Arrange
-        admin_user = create_admin_user()
-        target_user = create_normal_user(id=777777777, username="admin_to_remove")
-        chat = create_test_chat()
-
-        reply_message = telegram_factory.create_message(user=target_user, chat=chat)
-
-        command_message = telegram_factory.create_command_message(
-            command="unadmin", user=admin_user, chat=chat, reply_to_message=reply_message
-        )
-
-        # Mock repository - user is currently admin
-        mock_admin_repository.is_admin.return_value = True
-        mock_admin_repository.delete_admin.return_value = None
-
-        # Act
-        with patch("app.presentation.telegram.utils.other.get_user_mention") as mock_mention:
-            mock_mention.return_value = "@admin_to_remove"
-
-            await delete_admin(command_message, mock_admin_repository)
-
-        # Assert
-        mock_admin_repository.is_admin.assert_called_once_with(target_user.id)
-        mock_admin_repository.delete_admin.assert_called_once_with(target_user.id)
-
-        # Verify success message
-        call_args = command_message.answer.call_args[0][0]
-        assert "удален" in call_args
-        assert "❌" in call_args
-
-    async def test_delete_admin_not_admin(
-        self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock
-    ):
-        """Test removing admin from user who is not an admin."""
-        # Arrange
-        admin_user = create_admin_user()
-        target_user = create_normal_user(id=777777777, username="not_admin")
-        chat = create_test_chat()
-
-        reply_message = telegram_factory.create_message(user=target_user, chat=chat)
-
-        command_message = telegram_factory.create_command_message(
-            command="unadmin", user=admin_user, chat=chat, reply_to_message=reply_message
-        )
-
-        # Mock repository - user is not admin
-        mock_admin_repository.is_admin.return_value = False
-
-        # Act
-        with patch("app.presentation.telegram.utils.other.get_user_mention") as mock_mention:
-            mock_mention.return_value = "@not_admin"
-
-            await delete_admin(command_message, mock_admin_repository)
-
-        # Assert
-        mock_admin_repository.is_admin.assert_called_once_with(target_user.id)
-        mock_admin_repository.delete_admin.assert_not_called()  # Should not try to delete
-
-        # Verify "not admin" message
-        call_args = command_message.answer.call_args[0][0]
-        assert "не является админом" in call_args
+        assert "ответ на сообщение" in command_message.answer.call_args[0][0].lower()
+        mock_admin_repository.grant.assert_not_called()
 
 
 @pytest.mark.handlers
-class TestAdminHandlerEdgeCases:
-    """Test edge cases and error conditions for admin handlers."""
-
-    async def test_admin_command_database_error(
+class TestRevokingRights:
+    async def test_the_revoke_names_the_chat_it_was_sent_in(
         self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock
     ):
-        """Test admin command when database operation fails."""
-        # Arrange
-        admin_user = create_admin_user()
-        target_user = create_normal_user()
         chat = create_test_chat()
-
+        target_user = create_normal_user(id=777777777, username="admin_to_remove")
         reply_message = telegram_factory.create_message(user=target_user, chat=chat)
         command_message = telegram_factory.create_command_message(
-            command="admin", user=admin_user, chat=chat, reply_to_message=reply_message
+            command="unadmin", user=create_admin_user(), chat=chat, reply_to_message=reply_message
         )
+        mock_admin_repository.revoke.return_value = True
 
-        # Mock database error
-        mock_admin_repository.is_admin.side_effect = Exception("Database connection failed")
+        await delete_admin(command_message, mock_admin_repository)
 
-        # Act & Assert
+        mock_admin_repository.revoke.assert_awaited_once_with(target_user.id, chat.id)
+        said = command_message.answer.call_args[0][0]
+        assert "больше не модерирует этот чат" in said
+        assert "❌" in said
+
+    async def test_remaining_chats_are_spelled_out(
+        self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock
+    ):
+        """Taking one chat back is not the same as taking the job away."""
+        chat = create_test_chat()
+        target_user = create_normal_user(id=777777777)
+        reply_message = telegram_factory.create_message(user=target_user, chat=chat)
+        command_message = telegram_factory.create_command_message(
+            command="unadmin", user=create_admin_user(), chat=chat, reply_to_message=reply_message
+        )
+        mock_admin_repository.revoke.return_value = True
+        mock_admin_repository.chats_for.return_value = [-1001497722835, -1001192822531]
+
+        await delete_admin(command_message, mock_admin_repository)
+
+        assert "ещё в 2 чатах" in command_message.answer.call_args[0][0]
+
+    async def test_revoking_from_somebody_who_never_had_it(
+        self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock
+    ):
+        chat = create_test_chat()
+        target_user = create_normal_user(id=777777777, username="not_admin")
+        reply_message = telegram_factory.create_message(user=target_user, chat=chat)
+        command_message = telegram_factory.create_command_message(
+            command="unadmin", user=create_admin_user(), chat=chat, reply_to_message=reply_message
+        )
+        mock_admin_repository.revoke.return_value = False
+
+        await delete_admin(command_message, mock_admin_repository)
+
+        assert "и так не модерирует" in command_message.answer.call_args[0][0]
+
+
+@pytest.mark.handlers
+class TestWhenTheDatabaseIsDown:
+    async def test_the_failure_is_not_swallowed(
+        self, telegram_factory: TelegramObjectFactory, mock_admin_repository: AsyncMock
+    ):
+        """A grant that silently did nothing would be worse than a visible error."""
+        chat = create_test_chat()
+        reply_message = telegram_factory.create_message(user=create_normal_user(), chat=chat)
+        command_message = telegram_factory.create_command_message(
+            command="admin", user=create_admin_user(), chat=chat, reply_to_message=reply_message
+        )
+        mock_admin_repository.grant.side_effect = Exception("Database connection failed")
+
         with pytest.raises(Exception, match="Database connection failed"):
             await new_admin(command_message, mock_admin_repository)

--- a/tests/unit/test_admin_middleware.py
+++ b/tests/unit/test_admin_middleware.py
@@ -1,163 +1,221 @@
-"""Tests for admin middlewares."""
+"""Who gets past the two guards.
+
+The interesting case is the one the old flat list could not express: a moderator
+of one chat, standing in another, being told no. Everything else here exists so
+that case cannot be made to pass by accident.
+"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiogram import types
+from app.db.models import Chat
+from app.db.repositories import AdminRepository
 from app.presentation.telegram.middlewares.admin import (
     AdminMiddleware,
     SuperAdminMiddleware,
-    invalidate_admin_cache,
     you_are_not_admin,
 )
 
+pytestmark = pytest.mark.unit
 
-def _make_message(user_id: int) -> MagicMock:
+SUPER = 111
+OTHER_SUPER = 222
+MODERATOR = 555
+STRANGER = 999
+
+HOME = -1001370017010  # ČVUT FIT
+ELSEWHERE = -1001497722835  # Strahov
+
+
+def _message(user_id: int, chat_id: int | None = HOME) -> MagicMock:
     msg = MagicMock(spec=types.Message)
     msg.from_user = MagicMock(spec=types.User)
     msg.from_user.id = user_id
+    msg.chat = MagicMock(spec=types.Chat)
+    msg.chat.id = chat_id
     msg.answer = AsyncMock(return_value=MagicMock(spec=types.Message))
     msg.answer.return_value.delete = AsyncMock()
     msg.delete = AsyncMock()
     return msg
 
 
-def _make_callback(user_id: int) -> MagicMock:
+def _callback(user_id: int, chat_id: int | None = HOME) -> MagicMock:
     cb = MagicMock(spec=types.CallbackQuery)
     cb.from_user = MagicMock(spec=types.User)
     cb.from_user.id = user_id
+    cb.message = _message(user_id, chat_id) if chat_id is not None else None
     return cb
 
 
+def _supers(*ids: int):
+    """Pin the configured super administrators for one test."""
+    patched = patch("app.presentation.telegram.middlewares.admin.settings")
+    mock = patched.start()
+    mock.admin.super_admins = list(ids)
+    return patched
+
+
+async def _seed(session, *, moderates: list[int]) -> dict:
+    for chat_id in {HOME, ELSEWHERE}:
+        session.add(Chat(id=chat_id, title=str(chat_id), resource_status=Chat.STATUS_APPROVED))
+    await session.commit()
+
+    repo = AdminRepository(session)
+    for chat_id in moderates:
+        await repo.grant(MODERATOR, chat_id, granted_by=SUPER)
+    return {"admin_repo": repo, "db": session}
+
+
 class TestSuperAdminMiddleware:
-    @pytest.fixture
-    def middleware(self):
-        return SuperAdminMiddleware()
+    async def test_a_super_admin_gets_through(self) -> None:
+        handler, msg = AsyncMock(), _message(SUPER)
+        patched = _supers(SUPER, OTHER_SUPER)
+        try:
+            await SuperAdminMiddleware()(handler, msg, {})
+        finally:
+            patched.stop()
 
-    async def test_allows_super_admin(self, middleware):
-        handler = AsyncMock()
-        msg = _make_message(111)
-        with patch("app.presentation.telegram.middlewares.admin.settings") as mock_settings:
-            mock_settings.admin.super_admins = [111, 222]
-            await middleware(handler, msg, {})
-            handler.assert_called_once_with(msg, {})
+        handler.assert_awaited_once_with(msg, {})
 
-    async def test_blocks_non_super_admin(self, middleware):
-        handler = AsyncMock()
-        msg = _make_message(999)
-        with patch("app.presentation.telegram.middlewares.admin.settings") as mock_settings:
-            mock_settings.admin.super_admins = [111]
-            with patch("app.presentation.telegram.middlewares.admin.you_are_not_admin", new_callable=AsyncMock):
-                result = await middleware(handler, msg, {})
-                handler.assert_not_called()
-                assert result is None
+    async def test_both_configured_accounts_get_through(self) -> None:
+        """Two accounts, not just the first one listed."""
+        handler, msg = AsyncMock(), _message(OTHER_SUPER)
+        patched = _supers(SUPER, OTHER_SUPER)
+        try:
+            await SuperAdminMiddleware()(handler, msg, {})
+        finally:
+            patched.stop()
 
-    async def test_allows_callback_query(self, middleware):
-        handler = AsyncMock()
-        cb = _make_callback(111)
-        with patch("app.presentation.telegram.middlewares.admin.settings") as mock_settings:
-            mock_settings.admin.super_admins = [111]
-            await middleware(handler, cb, {})
-            handler.assert_called_once()
+        handler.assert_awaited_once()
+
+    async def test_a_chat_moderator_is_not_a_super_admin(self, session) -> None:
+        """The blacklist reaches every chat, so moderating one is not enough."""
+        data = await _seed(session, moderates=[HOME])
+        handler, msg = AsyncMock(), _message(MODERATOR)
+        patched = _supers(SUPER)
+        try:
+            result = await SuperAdminMiddleware()(handler, msg, data)
+        finally:
+            patched.stop()
+
+        handler.assert_not_awaited()
+        assert result is None
+
+    async def test_a_callback_is_judged_the_same_way(self) -> None:
+        handler, cb = AsyncMock(), _callback(SUPER)
+        patched = _supers(SUPER)
+        try:
+            await SuperAdminMiddleware()(handler, cb, {})
+        finally:
+            patched.stop()
+
+        handler.assert_awaited_once()
 
 
 class TestAdminMiddleware:
-    @pytest.fixture(autouse=True)
-    def _clear_cache(self):
-        """Invalidate admin cache before each test to ensure isolation."""
-        invalidate_admin_cache()
-        yield
-        invalidate_admin_cache()
+    async def test_a_moderator_acts_in_their_own_chat(self, session) -> None:
+        data = await _seed(session, moderates=[HOME])
+        handler, msg = AsyncMock(), _message(MODERATOR, HOME)
+        patched = _supers(SUPER)
+        try:
+            await AdminMiddleware()(handler, msg, data)
+        finally:
+            patched.stop()
 
-    @pytest.fixture
-    def middleware(self):
-        return AdminMiddleware()
+        handler.assert_awaited_once_with(msg, data)
 
-    @pytest.fixture
-    def admin_repo(self):
-        return AsyncMock()
+    async def test_a_moderator_is_refused_in_a_chat_they_do_not_moderate(self, session) -> None:
+        """The reason this table exists. One chat's moderator is not the other's."""
+        data = await _seed(session, moderates=[HOME])
+        handler, msg = AsyncMock(), _message(MODERATOR, ELSEWHERE)
+        patched = _supers(SUPER)
+        try:
+            result = await AdminMiddleware()(handler, msg, data)
+        finally:
+            patched.stop()
 
-    async def test_allows_super_admin(self, middleware, admin_repo):
-        handler = AsyncMock()
-        msg = _make_message(111)
-        admin_repo.get_db_admins = AsyncMock(return_value=[])
-        with patch("app.presentation.telegram.middlewares.admin.settings") as mock_settings:
-            mock_settings.admin.super_admins = [111]
-            await middleware(handler, msg, {"admin_repo": admin_repo})
-            handler.assert_called_once()
+        handler.assert_not_awaited()
+        assert result is None
 
-    async def test_allows_db_admin(self, middleware, admin_repo):
-        handler = AsyncMock()
-        msg = _make_message(333)
-        db_admin = MagicMock()
-        db_admin.id = 333
-        admin_repo.get_db_admins = AsyncMock(return_value=[db_admin])
-        with patch("app.presentation.telegram.middlewares.admin.settings") as mock_settings:
-            mock_settings.admin.super_admins = [111]
-            await middleware(handler, msg, {"admin_repo": admin_repo})
-            handler.assert_called_once()
+    async def test_a_super_admin_acts_anywhere(self, session) -> None:
+        data = await _seed(session, moderates=[])
+        handler, msg = AsyncMock(), _message(SUPER, ELSEWHERE)
+        patched = _supers(SUPER)
+        try:
+            await AdminMiddleware()(handler, msg, data)
+        finally:
+            patched.stop()
 
-    async def test_blocks_regular_user(self, middleware, admin_repo):
-        handler = AsyncMock()
-        msg = _make_message(999)
-        admin_repo.get_db_admins = AsyncMock(return_value=[])
-        with patch("app.presentation.telegram.middlewares.admin.settings") as mock_settings:
-            mock_settings.admin.super_admins = [111]
-            with patch("app.presentation.telegram.middlewares.admin.you_are_not_admin", new_callable=AsyncMock):
-                result = await middleware(handler, msg, {"admin_repo": admin_repo})
-                handler.assert_not_called()
-                assert result is None
+        handler.assert_awaited_once()
 
-    async def test_allows_callback_query(self, middleware, admin_repo):
-        """Test that AdminMiddleware allows a CallbackQuery from a DB admin."""
-        handler = AsyncMock()
-        cb = _make_callback(333)
-        db_admin = MagicMock()
-        db_admin.id = 333
-        admin_repo.get_db_admins = AsyncMock(return_value=[db_admin])
-        with patch("app.presentation.telegram.middlewares.admin.settings") as mock_settings:
-            mock_settings.admin.super_admins = [111]
-            await middleware(handler, cb, {"admin_repo": admin_repo})
-            handler.assert_called_once_with(cb, {"admin_repo": admin_repo})
+    async def test_a_stranger_is_refused(self, session) -> None:
+        data = await _seed(session, moderates=[HOME])
+        handler, msg = AsyncMock(), _message(STRANGER, HOME)
+        patched = _supers(SUPER)
+        try:
+            result = await AdminMiddleware()(handler, msg, data)
+        finally:
+            patched.stop()
 
-    async def test_cache_prevents_double_db_call(self, middleware, admin_repo):
-        """Second call within TTL should not call get_db_admins again."""
-        handler = AsyncMock()
-        db_admin = MagicMock()
-        db_admin.id = 333
-        admin_repo.get_db_admins = AsyncMock(return_value=[db_admin])
+        handler.assert_not_awaited()
+        assert result is None
 
-        with patch("app.presentation.telegram.middlewares.admin.settings") as mock_settings:
-            mock_settings.admin.super_admins = [111]
+    async def test_a_revoked_moderator_is_refused_at_once(self, session) -> None:
+        """No cache to go stale: the answer is read fresh on every command."""
+        data = await _seed(session, moderates=[HOME])
+        repo: AdminRepository = data["admin_repo"]
+        patched = _supers(SUPER)
+        try:
+            handler, msg = AsyncMock(), _message(MODERATOR, HOME)
+            await AdminMiddleware()(handler, msg, data)
+            handler.assert_awaited_once()
 
-            # First call populates cache
-            msg1 = _make_message(333)
-            await middleware(handler, msg1, {"admin_repo": admin_repo})
+            await repo.revoke(MODERATOR, HOME)
 
-            # Second call should use cache
-            msg2 = _make_message(333)
-            await middleware(handler, msg2, {"admin_repo": admin_repo})
+            handler, msg = AsyncMock(), _message(MODERATOR, HOME)
+            await AdminMiddleware()(handler, msg, data)
+        finally:
+            patched.stop()
 
-            # get_db_admins should only have been called once (cache hit on second)
-            assert admin_repo.get_db_admins.call_count == 1
+        handler.assert_not_awaited()
+
+    async def test_a_callback_is_scoped_by_its_message(self, session) -> None:
+        data = await _seed(session, moderates=[HOME])
+        handler, cb = AsyncMock(), _callback(MODERATOR, ELSEWHERE)
+        patched = _supers(SUPER)
+        try:
+            result = await AdminMiddleware()(handler, cb, data)
+        finally:
+            patched.stop()
+
+        handler.assert_not_awaited()
+        assert result is None
+
+    async def test_a_moderator_gets_nothing_where_there_is_no_chat(self, session) -> None:
+        """A scoped right cannot be exercised somewhere the scope does not reach."""
+        data = await _seed(session, moderates=[HOME])
+        handler, cb = AsyncMock(), _callback(MODERATOR, chat_id=None)
+        patched = _supers(SUPER)
+        try:
+            result = await AdminMiddleware()(handler, cb, data)
+        finally:
+            patched.stop()
+
+        handler.assert_not_awaited()
+        assert result is None
 
 
-class TestYouAreNotAdmin:
-    async def test_sends_rejection_for_message(self):
-        msg = _make_message(999)
+class TestTheRefusal:
+    async def test_it_speaks_russian_and_clears_up_after_itself(self) -> None:
+        """Both messages go: a refusal left on screen is noise plus an invitation."""
+        msg = _message(STRANGER)
+
         with patch("app.presentation.telegram.middlewares.admin.asyncio.sleep", new_callable=AsyncMock):
             await you_are_not_admin(msg)
-            msg.answer.assert_called_once_with("\U0001f6ab You are not an Admin.")
-            msg.delete.assert_called_once()
-            msg.answer.return_value.delete.assert_called_once()
 
-    async def test_custom_text(self):
-        msg = _make_message(999)
-        with patch("app.presentation.telegram.middlewares.admin.asyncio.sleep", new_callable=AsyncMock):
-            await you_are_not_admin(msg, "Custom denial")
-            msg.answer.assert_called_once_with("Custom denial")
-
-    async def test_noop_for_non_message(self):
-        event = MagicMock(spec=types.CallbackQuery)
-        # Should not raise
-        await you_are_not_admin(event)
+        said = msg.answer.await_args.args[0]
+        assert said.isascii() is False
+        assert "Admin" not in said
+        msg.delete.assert_awaited_once()
+        msg.answer.return_value.delete.assert_awaited_once()

--- a/tests/unit/test_admin_scope.py
+++ b/tests/unit/test_admin_scope.py
@@ -1,0 +1,94 @@
+"""Granting and taking back the right to moderate one chat.
+
+The rules worth pinning down are the ones a reader would not guess: an
+administrator with no chats is not kept around, and revoking a chat somebody
+never had is not an error, just a no.
+"""
+
+import pytest
+from app.db.models import Admin, Chat
+from app.db.repositories import AdminRepository
+
+pytestmark = pytest.mark.unit
+
+MODERATOR = 555
+GRANTED_BY = 111
+
+HOME = -1001370017010  # ČVUT FIT
+ELSEWHERE = -1001497722835  # Strahov
+
+
+@pytest.fixture
+async def repo(session) -> AdminRepository:
+    for chat_id in (HOME, ELSEWHERE):
+        session.add(Chat(id=chat_id, title=str(chat_id), resource_status=Chat.STATUS_APPROVED))
+    await session.commit()
+    return AdminRepository(session)
+
+
+class TestGranting:
+    async def test_a_first_grant_creates_the_administrator(self, repo, session) -> None:
+        assert await repo.grant(MODERATOR, HOME, granted_by=GRANTED_BY) is True
+
+        assert await repo.is_admin_in(MODERATOR, HOME) is True
+        assert await session.get(Admin, MODERATOR) is not None
+
+    async def test_the_scope_does_not_leak_to_other_chats(self, repo) -> None:
+        await repo.grant(MODERATOR, HOME)
+
+        assert await repo.is_admin_in(MODERATOR, ELSEWHERE) is False
+
+    async def test_granting_twice_changes_nothing(self, repo) -> None:
+        await repo.grant(MODERATOR, HOME)
+
+        assert await repo.grant(MODERATOR, HOME) is False
+        assert await repo.chats_for(MODERATOR) == [HOME]
+
+    async def test_a_second_chat_is_added_not_swapped(self, repo) -> None:
+        await repo.grant(MODERATOR, HOME)
+        await repo.grant(MODERATOR, ELSEWHERE)
+
+        assert set(await repo.chats_for(MODERATOR)) == {HOME, ELSEWHERE}
+
+
+class TestRevoking:
+    async def test_only_the_named_chat_is_taken_back(self, repo) -> None:
+        await repo.grant(MODERATOR, HOME)
+        await repo.grant(MODERATOR, ELSEWHERE)
+
+        assert await repo.revoke(MODERATOR, HOME) is True
+
+        assert await repo.is_admin_in(MODERATOR, HOME) is False
+        assert await repo.is_admin_in(MODERATOR, ELSEWHERE) is True
+
+    async def test_losing_the_last_chat_ends_the_job(self, repo, session) -> None:
+        """Otherwise the administrator list grows names that moderate nothing."""
+        await repo.grant(MODERATOR, HOME)
+
+        await repo.revoke(MODERATOR, HOME)
+
+        assert await session.get(Admin, MODERATOR) is None
+        assert await repo.is_admin(MODERATOR) is False
+
+    async def test_revoking_what_was_never_granted_is_a_no_not_a_crash(self, repo) -> None:
+        assert await repo.revoke(MODERATOR, HOME) is False
+
+    async def test_revoking_one_chat_leaves_the_others_reachable(self, repo) -> None:
+        await repo.grant(MODERATOR, HOME)
+        await repo.grant(MODERATOR, ELSEWHERE)
+
+        await repo.revoke(MODERATOR, HOME)
+
+        assert await repo.is_admin(MODERATOR) is True
+
+
+class TestDeactivation:
+    async def test_a_deactivated_administrator_may_act_nowhere(self, repo, session) -> None:
+        """`state` is the whole-person switch; the scope rows are left alone."""
+        await repo.grant(MODERATOR, HOME)
+
+        admin = await session.get(Admin, MODERATOR)
+        admin.deactivate()
+        await session.commit()
+
+        assert await repo.is_admin_in(MODERATOR, HOME) is False

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -1,149 +1,15 @@
-"""Tests for telegram filters."""
+"""Tests for telegram filters.
 
-from unittest.mock import AsyncMock, patch
+Only routing lives here now. The permission filters this module used to hold
+were unreferenced duplicates of the admin middlewares and have been removed —
+see tests/unit/test_admin_middleware.py for the checks that actually run.
+"""
+
+from unittest.mock import AsyncMock
 
 import pytest
 from aiogram import types
-from app.presentation.telegram.utils.filters import AdminFilter, ChatTypeFilter, SuperAdminFilter
-
-
-@pytest.mark.unit
-class TestSuperAdminFilter:
-    """Test SuperAdminFilter."""
-
-    @pytest.fixture
-    def filter_instance(self):
-        return SuperAdminFilter()
-
-    @pytest.fixture
-    def mock_message(self):
-        message = AsyncMock(spec=types.Message)
-        message.from_user = AsyncMock()
-        return message
-
-    async def test_super_admin_allowed(self, filter_instance, mock_message):
-        """Test that super admin is allowed."""
-        with patch("app.presentation.telegram.utils.filters.settings") as mock_settings:
-            mock_settings.admin.super_admins = [123456789, 987654321]
-            mock_message.from_user.id = 123456789
-
-            result = await filter_instance(mock_message)
-
-            assert result is True
-
-    async def test_non_super_admin_denied(self, filter_instance, mock_message):
-        """Test that non-super admin is denied."""
-        with patch("app.presentation.telegram.utils.filters.settings") as mock_settings:
-            mock_settings.admin.super_admins = [123456789, 987654321]
-            mock_message.from_user.id = 555555555
-
-            result = await filter_instance(mock_message)
-
-            assert result is False
-
-    async def test_empty_super_admins_list(self, filter_instance, mock_message):
-        """Test with empty super admins list."""
-        with patch("app.presentation.telegram.utils.filters.settings") as mock_settings:
-            mock_settings.admin.super_admins = []
-            mock_message.from_user.id = 123456789
-
-            result = await filter_instance(mock_message)
-
-            assert result is False
-
-    async def test_super_admin_no_from_user(self, filter_instance):
-        """Test that message with no from_user returns False."""
-        msg = AsyncMock(spec=types.Message)
-        msg.from_user = None
-
-        with patch("app.presentation.telegram.utils.filters.settings") as mock_settings:
-            mock_settings.admin.super_admins = [123456789]
-
-            result = await filter_instance(msg)
-
-            assert result is False
-
-
-@pytest.mark.unit
-class TestAdminFilter:
-    """Test AdminFilter."""
-
-    @pytest.fixture
-    def filter_instance(self):
-        return AdminFilter()
-
-    @pytest.fixture
-    def mock_message(self):
-        message = AsyncMock(spec=types.Message)
-        message.from_user = AsyncMock()
-        return message
-
-    @pytest.fixture
-    def mock_db_session(self):
-        return AsyncMock()
-
-    async def test_admin_allowed(self, filter_instance, mock_message, mock_db_session):
-        """Test that admin is allowed."""
-        mock_message.from_user.id = 123456789
-
-        with patch("app.presentation.telegram.utils.filters.get_admin_repository") as mock_get_repo:
-            mock_repo = AsyncMock()
-
-            mock_admin1 = AsyncMock()
-            mock_admin1.id = 123456789
-            mock_admin2 = AsyncMock()
-            mock_admin2.id = 987654321
-
-            mock_repo.get_db_admins.return_value = [mock_admin1, mock_admin2]
-            mock_get_repo.return_value = mock_repo
-
-            result = await filter_instance(mock_message, mock_db_session)
-
-            assert result is True
-            mock_get_repo.assert_called_once_with(mock_db_session)
-
-    async def test_non_admin_denied(self, filter_instance, mock_message, mock_db_session):
-        """Test that non-admin is denied."""
-        mock_message.from_user.id = 555555555
-
-        with patch("app.presentation.telegram.utils.filters.get_admin_repository") as mock_get_repo:
-            mock_repo = AsyncMock()
-
-            mock_admin1 = AsyncMock()
-            mock_admin1.id = 123456789
-            mock_admin2 = AsyncMock()
-            mock_admin2.id = 987654321
-
-            mock_repo.get_db_admins.return_value = [mock_admin1, mock_admin2]
-            mock_get_repo.return_value = mock_repo
-
-            result = await filter_instance(mock_message, mock_db_session)
-
-            assert result is False
-
-    async def test_empty_admins_list(self, filter_instance, mock_message, mock_db_session):
-        """Test with empty admins list."""
-        mock_message.from_user.id = 123456789
-
-        with patch("app.presentation.telegram.utils.filters.get_admin_repository") as mock_get_repo:
-            mock_repo = AsyncMock()
-            mock_repo.get_db_admins.return_value = []
-            mock_get_repo.return_value = mock_repo
-
-            result = await filter_instance(mock_message, mock_db_session)
-
-            assert result is False
-
-    async def test_admin_no_from_user(self, filter_instance, mock_db_session):
-        """Test that message with no from_user returns False."""
-        msg = AsyncMock(spec=types.Message)
-        msg.from_user = None
-
-        with patch("app.presentation.telegram.utils.filters.get_admin_repository") as mock_get_repo:
-            result = await filter_instance(msg, mock_db_session)
-
-            assert result is False
-            mock_get_repo.assert_not_called()
+from app.presentation.telegram.utils.filters import ChatTypeFilter
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The administrator list was flat: one row per person, no chats attached. Trusting
somebody with one faculty chat trusted them with the other forty-four. Since the
table is empty in production this has never actually happened, which is the good
moment to fix it.

## Two levels, and a scope

**Super administrator** — the accounts in `ADMIN_SUPER_ADMINS`. Web console,
handing out moderator rights, the shared blacklist, every chat.

**Moderator** — a row in `admins` plus the chats it is linked to through the new
`admin_chats` table. No web console, no granting rights, and commands only in
the chats they were given.

Super administrators stay in configuration rather than the database on purpose.
They are the only people who can hand out rights, so one `INSERT` must not be
able to create another.

## Commands split by blast radius

Chat-scoped, for that chat's moderator: `!ban` `!unban` `!mute` `!unmute`
`!kick` `!del` `!purge` `!pin` `!unpin` `!info` `!welcome`.

Super administrator only: `!black` `!blacklist` `!spam` `!admin` `!unadmin`
`!json` `!adminlink`.

The line is how far a mistake travels. `!ban` spoils one chat. `!black` bans
somebody across all forty-five, and `!spam` teaches the corpus every chat is
matched against.

`!admin` and `!unadmin` now grant and revoke **the chat they were sent in**. The
chat is not an argument because a command that can name any of forty-five from
anywhere grants the wrong one eventually.

## What else changed

- `/adminlink` answers every super administrator, not only the first one listed.
  The web console already admitted all of them; the command was stricter than
  the thing it hands out.
- The five-minute administrator cache is gone. Sensible when the answer was the
  same everywhere, wrong now — a moderator removed from a chat would keep it
  until the cache expired.
- `AdminFilter` and `SuperAdminFilter` deleted. Nothing referenced them, and a
  second unreferenced answer to "who may do this" is worse than none, because
  only one of the two ever gets updated.
- Three English debugging strings, all visible to students, are now Russian:
  the two refusals and the spam notice.

## Checks

- `pytest` — 515 passed, 2 skipped (pre-existing skips)
- `ruff check` and `ruff format --check` on `app tests scripts` — clean
- `ty check` — 9 diagnostics, same as `main`
- migration applied to a scratch Postgres, `alembic check` reports no new
  operations, downgrade and re-upgrade both run

Nothing is migrated into `admin_chats`: production `admins` is empty, and
inventing a scope for a row that does not exist would invent authority.
