### PR TITLE
Print only this project's hostname, never the whole edge config

### DIFF
--- a/.github/workflows/host.yml
+++ b/.github/workflows/host.yml
@@ -9,6 +9,12 @@
 #
 # So the tasks are fixed in this file and chosen by name. Adding one is a pull
 # request, which is exactly the review that a command on production deserves.
+#
+# Two things about this particular host shape what may be printed. It is shared
+# with unrelated projects, and this repository is public, so a workflow log is a
+# published document. `cat`-ing a config or tailing a whole log would publish
+# somebody else's routes and possibly their credentials. Filter to this
+# project's own hostname and print nothing wider.
 name: Host
 
 on:
@@ -35,11 +41,12 @@ jobs:
         uses: appleboy/ssh-action@v1.2.5
         env:
           TASK: ${{ inputs.task }}
+          PUBLIC_URL: ${{ vars.WEBAPI_PUBLIC_URL }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          envs: TASK
+          envs: TASK,PUBLIC_URL
           # Every task reads. Nothing here restarts, rewrites or removes
           # anything — a fix belongs in a deploy, where it is version
           # controlled, not in a button somebody can press twice.
@@ -58,9 +65,10 @@ jobs:
                 ss -tln || true
 
                 section "what answers on 443"
-                curl -sS -o /dev/null -w 'localhost:443  %{http_code}  %{errormsg}\n' \
-                  -m 10 -k https://127.0.0.1 -H 'Host: moderator.azamat.io' || true
-                curl -sS -o /dev/null -w 'webui:18083    %{http_code}\n' \
+                host=$(echo "$PUBLIC_URL" | sed -e 's#^https\?://##' -e 's#/.*##')
+                curl -sS -o /dev/null -w 'edge:443    %{http_code}  %{errormsg}\n' \
+                  -m 10 -k "https://127.0.0.1" -H "Host: $host" || true
+                curl -sS -o /dev/null -w 'webui:18083 %{http_code}\n' \
                   -m 10 http://127.0.0.1:18083/ || true
 
                 section "edge proxy"
@@ -69,28 +77,29 @@ jobs:
                 docker ps --filter name=caddy --format '{{.Names}}\t{{.Status}}' || true
                 ;;
 
+              # This host is shared with unrelated projects and this repository
+              # is public, so nothing here prints a whole config or a whole log.
+              # Every command is filtered to this project's own hostname; the
+              # neighbours' domains, routes and credentials are none of a
+              # workflow log's business.
               edge-tls)
-                section "caddy config, wherever it lives"
-                for f in /etc/caddy/Caddyfile ~/caddy/Caddyfile ~/deploy/Caddyfile ~/Caddyfile; do
-                  [ -f "$f" ] && { echo "── $f"; cat "$f"; }
-                done
-                docker ps --filter name=caddy --format '{{.Names}}' | while read -r name; do
-                  [ -n "$name" ] || continue
-                  echo "── $name:/etc/caddy/Caddyfile"
-                  docker exec "$name" cat /etc/caddy/Caddyfile 2>/dev/null || echo "(not readable)"
-                done
+                host=$(echo "$PUBLIC_URL" | sed -e 's#^https\?://##' -e 's#/.*##')
+                if [ -z "$host" ]; then
+                  echo "WEBAPI_PUBLIC_URL is not set — nothing to look for."
+                  exit 1
+                fi
+                echo "looking only for: $host"
 
-                section "certificates on disk"
-                find /var/lib/caddy ~/.local/share/caddy -name '*.crt' 2>/dev/null | head -20 || true
-                docker ps --filter name=caddy --format '{{.Names}}' | while read -r name; do
-                  [ -n "$name" ] || continue
-                  docker exec "$name" find /data/caddy/certificates -name '*.crt' 2>/dev/null | head -20
-                done
+                section "does the edge know this name"
+                docker exec edge-caddy grep -n -A4 -- "$host" /etc/caddy/Caddyfile 2>/dev/null \
+                  || echo "no site block mentions $host"
 
-                section "recent proxy log"
-                journalctl -u caddy --no-pager -n 40 2>/dev/null \
-                  || docker ps --filter name=caddy --format '{{.Names}}' \
-                     | while read -r name; do [ -n "$name" ] && docker logs --tail 40 "$name" 2>&1; done \
-                  || echo "(no log reachable)"
+                section "is there a certificate for it"
+                docker exec edge-caddy find /data/caddy/certificates -name "*${host}*" 2>/dev/null \
+                  || echo "no certificate file names match $host"
+
+                section "what the edge said about this name"
+                docker logs --tail 4000 edge-caddy 2>&1 | grep -F -- "$host" | tail -30 \
+                  || echo "the edge log does not mention $host at all"
                 ;;
             esac


### PR DESCRIPTION
The host turns out to be shared. Four unrelated projects sit behind one
`edge-caddy`, and this repository is public, so a workflow log is a published
document.

As written, `edge-tls` would have `cat`-ed the shared Caddyfile and tailed the
shared log straight into it — every neighbour's routes, and whatever credentials
that config carries. I caught it before running the task, so nothing was
published.

It now derives the hostname from `WEBAPI_PUBLIC_URL` and looks for that alone:

- the site block, if one exists (`grep -A4`, not `cat`)
- certificate **file names** matching the host, not the files
- log lines naming the host, not the log

`diagnose` no longer hardcodes the domain either — same variable.

## What diagnose already established

- webui is healthy and answers `200` on `127.0.0.1:18083`, so the application is
  fine
- TLS to the edge with our `Host:` header fails with
  `tlsv1 alert internal error` — the edge is up and serving other names, it just
  has no certificate for ours
- the edge is `edge-caddy` (`edge-caddy-cloudflare:2.11.4`), so certificates
  come from DNS-01 through Cloudflare