### PR TITLE
Stop claiming a chat is active on one day of data

### DIFF
--- a/app/webapi/routes/public.py
+++ b/app/webapi/routes/public.py
@@ -29,19 +29,48 @@ ACTIVITY_WINDOW = datetime.timedelta(days=30)
 # Messages in that window. The bands are coarse deliberately: the reader is
 # deciding whether a chat is worth joining, not comparing two of them.
 BUSY_FROM = 100
-ACTIVE_FROM = 1
+ACTIVE_FROM = 10
+
+# Days within the window on which anything at all was recorded, below which the
+# window is not evidence about anybody.
+#
+# The bot was out of these chats between 22 May and 3 August, so on the day it
+# returned a thirty-day count held one day of traffic. Every chat that had seen
+# a single message read "active", including the one with seven thousand messages
+# to its name and the one with two. The count was correct and the claim was
+# false, which is the worst combination to ship: nothing looks broken.
+#
+# So the claim is withheld until there is a fortnight behind it, and it comes
+# back on its own. This is a property of the recording, not of any one chat —
+# a gap affects all of them at once.
+MIN_OBSERVED_DAYS = 14
 
 # Sorts after every real title, so ungrouped chats land at the end rather than
 # at the top where an empty string would put them.
 _UNGROUPED = "￿"
 
 
-def _activity(messages: int) -> Literal["quiet", "active", "busy"]:
+def _activity(messages: int, *, grounded: bool) -> Literal["unknown", "quiet", "active", "busy"]:
+    if not grounded:
+        return "unknown"
     if messages >= BUSY_FROM:
         return "busy"
     if messages >= ACTIVE_FROM:
         return "active"
     return "quiet"
+
+
+async def _observed_days(session: AsyncSession, since: datetime.datetime) -> int:
+    """Days in the window on which the bot recorded anything, anywhere.
+
+    Counted across the whole network rather than per chat: a quiet chat with no
+    messages is a fact about the chat, while a quiet *database* is a fact about
+    whether the bot was there to listen.
+    """
+    result = await session.execute(
+        select(func.count(func.distinct(func.date(Message.timestamp)))).where(Message.timestamp >= since)
+    )
+    return result.scalar() or 0
 
 
 @router.get("/catalog", response_model=list[PublicCatalogItem])
@@ -57,6 +86,7 @@ async def get_public_catalog(
     """
     parent = aliased(Chat)
     since = utc_now() - ACTIVITY_WINDOW
+    grounded = await _observed_days(session, since) >= MIN_OBSERVED_DAYS
 
     recent_messages = (
         select(Message.chat_id, func.count().label("messages"))
@@ -85,7 +115,7 @@ async def get_public_catalog(
             title=row.title,
             link=row.public_link,
             group=row.group_title,
-            activity=_activity(row.messages),
+            activity=_activity(row.messages, grounded=grounded),
         )
         for row in rows
         if row.title and row.public_link

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -25,7 +25,10 @@ class PublicCatalogItem(BaseModel):
     title: str
     link: str
     group: str | None = None
-    activity: Literal["quiet", "active", "busy"]
+    # "unknown" is a real answer, not a missing one: it says the recording
+    # behind the other three values is too short to stand on. A page shows
+    # nothing for it rather than guessing.
+    activity: Literal["unknown", "quiet", "active", "busy"]
 
 
 class ChatRead(BaseModel):

--- a/tests/webapi/test_public_catalog.py
+++ b/tests/webapi/test_public_catalog.py
@@ -78,6 +78,22 @@ async def _messages(session_maker, chat_id: int, count: int, *, days_ago: int = 
         await session.commit()
 
 
+async def _recorded_for_days(session_maker, days: int, *, chat_id: int = CVUT) -> None:
+    """One message on each of the last `days` days, so the window has ground.
+
+    Every activity assertion needs this. Without it the endpoint answers
+    "unknown" for everybody, which is the whole point of the rule and would
+    otherwise make each band test pass or fail for the wrong reason.
+    """
+    async with session_maker() as session:
+        session.add(Chat(id=chat_id, title="ground", resource_status=Chat.STATUS_APPROVED))
+        for day in range(days):
+            message = Message(chat_id=chat_id, user_id=7, message_id=900_000 + day, message="ground")
+            message.timestamp = utc_now() - datetime.timedelta(days=day)
+            session.add(message)
+        await session.commit()
+
+
 class TestWhatGetsIn:
     async def test_an_approved_chat_with_a_link_is_listed(self, client_factory, db_session_maker) -> None:
         await _seed(db_session_maker, _chat(FIT, "ČVUT FIT", public_link="https://t.me/cvut_fit"))
@@ -146,43 +162,96 @@ class TestWhatComesBack:
         assert [row["title"] for row in rows] == ["ČVUT FIT", "ČVUT | ЧВУТ"]
 
 
-class TestActivity:
-    async def test_a_silent_chat_says_so(self, client_factory, db_session_maker) -> None:
-        """Joining a room where nobody has spoken since March should be a choice."""
-        await _seed(db_session_maker, _chat(FIT, "ČVUT FIT", public_link="https://t.me/cvut_fit"))
+class TestActivityIsWithheldUntilItMeansSomething:
+    async def test_a_fresh_database_claims_nothing(self, client_factory, db_session_maker) -> None:
+        """The failure this rule exists for.
 
-        async with client_factory() as client:
-            rows = (await client.get("/api/public/catalog")).json()
-
-        assert rows[0]["activity"] == "quiet"
-
-    async def test_a_handful_of_messages_reads_as_active(self, client_factory, db_session_maker) -> None:
+        When the bot returned after ten weeks away, a thirty-day count held one
+        day of traffic, and every chat that had seen a single message read
+        "active" — including the busiest in the network and one with two
+        messages to its name. The number was right and the claim was false.
+        """
         await _seed(db_session_maker, _chat(FIT, "ČVUT FIT", public_link="https://t.me/cvut_fit"))
         await _messages(db_session_maker, FIT, 5)
 
         async with client_factory() as client:
             rows = (await client.get("/api/public/catalog")).json()
 
-        assert rows[0]["activity"] == "active"
+        assert rows[0]["activity"] == "unknown"
+
+    async def test_a_fortnight_of_recording_is_enough_to_speak(self, client_factory, db_session_maker) -> None:
+        await _recorded_for_days(db_session_maker, 14)
+        await _seed(db_session_maker, _chat(FIT, "ČVUT FIT", public_link="https://t.me/cvut_fit"))
+
+        async with client_factory() as client:
+            rows = (await client.get("/api/public/catalog")).json()
+
+        assert {row["activity"] for row in rows} != {"unknown"}
+
+    async def test_the_gap_is_judged_across_the_network_not_per_chat(self, client_factory, db_session_maker) -> None:
+        """A silent chat is a fact about the chat. A silent database is not."""
+        await _recorded_for_days(db_session_maker, 14)
+        await _seed(db_session_maker, _chat(FIT, "ČVUT FIT", public_link="https://t.me/cvut_fit"))
+
+        async with client_factory() as client:
+            rows = (await client.get("/api/public/catalog")).json()
+
+        by_title = {row["title"]: row for row in rows}
+        assert by_title["ČVUT FIT"]["activity"] == "quiet"
+
+
+class TestTheBands:
+    async def test_a_silent_chat_says_so(self, client_factory, db_session_maker) -> None:
+        """Joining a room where nobody has spoken since March should be a choice."""
+        await _recorded_for_days(db_session_maker, 20)
+        await _seed(db_session_maker, _chat(FIT, "ČVUT FIT", public_link="https://t.me/cvut_fit"))
+
+        async with client_factory() as client:
+            rows = (await client.get("/api/public/catalog")).json()
+
+        assert next(r for r in rows if r["title"] == "ČVUT FIT")["activity"] == "quiet"
+
+    async def test_a_message_a_month_is_not_activity(self, client_factory, db_session_maker) -> None:
+        """One message in thirty days used to read "active". It is nearly dead."""
+        await _recorded_for_days(db_session_maker, 20)
+        await _seed(db_session_maker, _chat(FIT, "ČVUT FIT", public_link="https://t.me/cvut_fit"))
+        await _messages(db_session_maker, FIT, 1)
+
+        async with client_factory() as client:
+            rows = (await client.get("/api/public/catalog")).json()
+
+        assert next(r for r in rows if r["title"] == "ČVUT FIT")["activity"] == "quiet"
+
+    async def test_a_dozen_messages_reads_as_active(self, client_factory, db_session_maker) -> None:
+        await _recorded_for_days(db_session_maker, 20)
+        await _seed(db_session_maker, _chat(FIT, "ČVUT FIT", public_link="https://t.me/cvut_fit"))
+        await _messages(db_session_maker, FIT, 12)
+
+        async with client_factory() as client:
+            rows = (await client.get("/api/public/catalog")).json()
+
+        assert next(r for r in rows if r["title"] == "ČVUT FIT")["activity"] == "active"
 
     async def test_a_hundred_messages_reads_as_busy(self, client_factory, db_session_maker) -> None:
+        await _recorded_for_days(db_session_maker, 20)
         await _seed(db_session_maker, _chat(FIT, "ČVUT FIT", public_link="https://t.me/cvut_fit"))
         await _messages(db_session_maker, FIT, 100)
 
         async with client_factory() as client:
             rows = (await client.get("/api/public/catalog")).json()
 
-        assert rows[0]["activity"] == "busy"
+        assert next(r for r in rows if r["title"] == "ČVUT FIT")["activity"] == "busy"
 
     async def test_old_traffic_does_not_keep_a_dead_chat_alive(self, client_factory, db_session_maker) -> None:
         """A chat busy last spring and silent since is silent."""
+        await _recorded_for_days(db_session_maker, 20)
         await _seed(db_session_maker, _chat(FIT, "ČVUT FIT", public_link="https://t.me/cvut_fit"))
         await _messages(db_session_maker, FIT, 200, days_ago=90)
 
         async with client_factory() as client:
             rows = (await client.get("/api/public/catalog")).json()
 
-        assert rows[0]["activity"] == "quiet"
+        assert next(r for r in rows if r["title"] == "ČVUT FIT")["activity"] == "quiet"
 
 
 async def test_public_catalog_does_not_open_admin_routes(client_factory) -> None:

--- a/webui/src/lib/api/types.ts
+++ b/webui/src/lib/api/types.ts
@@ -793,7 +793,7 @@ export interface components {
              * Activity
              * @enum {string}
              */
-            activity: "quiet" | "active" | "busy";
+            activity: "unknown" | "quiet" | "active" | "busy";
         };
         /**
          * SpamPingRead

--- a/webui/src/routes/(public)/+page.svelte
+++ b/webui/src/routes/(public)/+page.svelte
@@ -15,9 +15,14 @@
 
 	type CatalogItem = components['schemas']['PublicCatalogItem'];
 
-	// Said plainly, because a badge that reads "quiet" is only useful if it
-	// stops somebody joining a room where nobody has spoken since March.
-	const ACTIVITY: Record<CatalogItem['activity'], { label: string; class: string }> = {
+	// Said plainly, because a badge that reads "тихий" is only useful if it stops
+	// somebody joining a room where nobody has spoken since March.
+	//
+	// `unknown` has no entry and renders nothing. The API says it when the
+	// recording behind the number is too short to stand on, and an empty space
+	// is the honest rendering of "we do not know yet" — a grey "тихий" would be
+	// a claim.
+	const ACTIVITY: Record<string, { label: string; class: string }> = {
 		busy: { label: 'оживлённый', class: 'bg-emerald-50 text-emerald-700' },
 		active: { label: 'активный', class: 'bg-zinc-100 text-zinc-600' },
 		quiet: { label: 'тихий', class: 'bg-zinc-100 text-zinc-500' }
@@ -131,13 +136,15 @@
 							</div>
 							<div class="min-w-0 flex-1">
 								<div class="truncate text-sm font-medium text-zinc-900">{chat.title}</div>
-								<span
-									class="mt-0.5 inline-block rounded-full px-2 py-0.5 text-[11px] font-medium {ACTIVITY[
-										chat.activity
-									].class}"
-								>
-									{ACTIVITY[chat.activity].label}
-								</span>
+								{#if ACTIVITY[chat.activity]}
+									<span
+										class="mt-0.5 inline-block rounded-full px-2 py-0.5 text-[11px] font-medium {ACTIVITY[
+											chat.activity
+										].class}"
+									>
+										{ACTIVITY[chat.activity].label}
+									</span>
+								{/if}
 							</div>
 							<ExternalLink class="h-3.5 w-3.5 shrink-0 text-zinc-400 group-hover:text-zinc-600" />
 						</a>


### PR DESCRIPTION
Shipped an hour ago and wrong on arrival.

The activity band counts messages over thirty days. The bot was out of these
chats from 22 May to 3 August, so the window held **one day** of traffic. Live
result before this fix:

```
active  ČVUT FIT     ← 7 426 messages all-time, 2 in the window
active  ČVUT FD      ← 1 in the window
quiet   Matfyz       ← 0 today, perfectly lively otherwise
```

Seventeen of nineteen listed chats read "активный". The count was correct and
the claim was false, which is the worst way to be wrong — nothing looks broken,
and a student picks a chat on a badge that means nothing.

## The fix

The band is withheld until there is a fortnight of recording behind it.

That is a property of the **recording**, not of any one chat: a silent chat is a
fact about the chat, a silent database is a fact about whether the bot was there
to listen. So the check counts days on which anything at all was recorded across
the network, and answers `unknown` for everybody when there are fewer than
fourteen. The page renders nothing for `unknown` — a grey "тихий" would be a
claim.

It self-heals around **17 August**, without anybody redeploying.

`ACTIVE_FROM` also goes from 1 to 10. One message in thirty days is not activity
even when the window is honest.

## Checks

Run standalone:

- `pytest` — 538 passed, 2 skipped (pre-existing)
- `ruff check` / `ruff format --check app tests scripts` — clean, 185 files
- `ty check app tests` — 9 diagnostics, same as `main`
- `pnpm --dir webui run check` — 0 errors

The band tests now seed a fortnight of recording first. Without it every one of
them would have passed or failed for the wrong reason.