### PR TITLE
Put the switch that publishes a chat in the console

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -151,6 +151,7 @@ class Chat(Base):
         is_service_cleanup_enabled: bool = True,
         parent_chat_id: int | None = None,
         relation_notes: str | None = None,
+        public_link: str | None = None,
     ) -> None:
         self.id = id
         self.title = title
@@ -163,6 +164,7 @@ class Chat(Base):
         self.is_service_cleanup_enabled = is_service_cleanup_enabled
         self.parent_chat_id = parent_chat_id
         self.relation_notes = relation_notes
+        self.public_link = public_link
 
     def enable_welcome(self, message: str | None = None) -> None:
         """Enable welcome message for new members"""

--- a/app/webapi/schemas.py
+++ b/app/webapi/schemas.py
@@ -3,11 +3,24 @@
 from __future__ import annotations
 
 import datetime
+import re
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 ChatResourceStatus = Literal["discovered", "approved", "disabled"]
+
+# What may be stored as a chat's public link.
+#
+# Whatever goes in this column is rendered as an `href` on a page anybody can
+# open, so the shape is checked at the boundary rather than trusted because an
+# admin typed it. Telegram has three forms — a public username, a modern invite
+# hash, and the older joinchat one — and anything else is not a chat link. A
+# `javascript:` URL is the reason this is a whitelist and not a "does it look
+# like a URL" check.
+PUBLIC_LINK = re.compile(
+    r"^https://t\.me/(?:\+[\w-]{10,}|joinchat/[\w-]{10,}|[A-Za-z][\w]{3,31})$",
+)
 
 
 class PublicCatalogItem(BaseModel):
@@ -71,6 +84,25 @@ class ChatUpdate(BaseModel):
     # Setting this publishes the chat; clearing it takes it down. Nothing else
     # does either, which is why it is one field and not a field plus a switch.
     public_link: str | None = None
+
+    @field_validator("public_link")
+    @classmethod
+    def _check_public_link(cls, value: str | None) -> str | None:
+        """Reject anything that is not a Telegram chat link.
+
+        A cleared field arrives from a form as an empty string, which must mean
+        "take it down" rather than "publish with no link" — the catalogue keys
+        off the column being set, so an empty string would list a chat whose
+        card leads nowhere.
+        """
+        if value is None:
+            return None
+        link = value.strip()
+        if not link:
+            return None
+        if not PUBLIC_LINK.match(link):
+            raise ValueError("Public link must be a Telegram chat link, e.g. https://t.me/cvut_fit")
+        return link
 
 
 class ChatNode(BaseModel):

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -84,6 +84,19 @@ without a valid super-admin cookie whatever the client believes. What the
 front-end guard buys is honesty — a sign-in page instead of a console full of
 failed requests.
 
+**A public link is checked for shape before it is stored.** Its value is
+rendered as an `href` on a page anybody can open, which makes it the one
+admin-supplied field that leaves the console — so it must be a Telegram chat
+link and nothing else, refused at the schema rather than at the point of
+rendering. A cleared field means "take it down": an empty string would list a
+chat whose card leads nowhere, because the catalogue keys off the column being
+set.
+
+**Every way to publish goes through the console.** A script may fill the
+catalogue in bulk, but it must never be the only way to change it — a feature
+whose switch lives in a maintainer's terminal is a feature the operator cannot
+undo.
+
 **`/join` and `/login` stay outside both groups.** The join check is opened
 inside Telegram by an applicant who has no session and must not be sent to get
 one; the sign-in page is the seam between the halves and belongs to neither.

--- a/tests/webapi/test_chat_mutations.py
+++ b/tests/webapi/test_chat_mutations.py
@@ -112,6 +112,98 @@ async def test_update_chat_parent_cycle_422(client_factory, db_session_maker) ->
     assert resp.status_code == 422
 
 
+class TestPublishingAChat:
+    """Setting the public link is what puts a chat on the public page.
+
+    It is the only field on this endpoint whose value is rendered to strangers
+    rather than shown back to the admin who typed it, so it is the only one with
+    a shape.
+    """
+
+    async def test_a_telegram_link_publishes(self, client_factory, db_session_maker) -> None:
+        async with db_session_maker() as s:
+            s.add(Chat(id=-2101, title="ČVUT FIT"))
+            await s.commit()
+
+        async with client_factory() as client:
+            resp = await client.patch("/api/chats/-2101", json={"public_link": "https://t.me/cvut_fit"})
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["public_link"] == "https://t.me/cvut_fit"
+
+    @pytest.mark.parametrize(
+        "link",
+        [
+            "https://t.me/+AAAAAAAAAAAAAAAA",
+            "https://t.me/joinchat/AAAAAAAAAAAAAAAA",
+        ],
+    )
+    async def test_an_invite_link_publishes(self, client_factory, db_session_maker, link: str) -> None:
+        """Closed chats have no username, so an invite hash is the only way in."""
+        async with db_session_maker() as s:
+            s.add(Chat(id=-2102, title="closed"))
+            await s.commit()
+
+        async with client_factory() as client:
+            resp = await client.patch("/api/chats/-2102", json={"public_link": link})
+
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.parametrize(
+        "link",
+        [
+            "javascript:alert(1)",
+            "http://t.me/cvut_fit",
+            "https://evil.example/t.me/cvut_fit",
+            "https://t.me.evil.example/cvut_fit",
+            "не ссылка",
+        ],
+    )
+    async def test_anything_that_is_not_a_chat_link_is_refused(
+        self, client_factory, db_session_maker, link: str
+    ) -> None:
+        """This value ends up in an href on a page anybody can open."""
+        async with db_session_maker() as s:
+            s.add(Chat(id=-2103, title="x"))
+            await s.commit()
+
+        async with client_factory() as client:
+            resp = await client.patch("/api/chats/-2103", json={"public_link": link})
+
+        assert resp.status_code == 422
+        async with db_session_maker() as s:
+            ch = (await s.execute(select(Chat).where(Chat.id == -2103))).scalar_one()
+            assert ch.public_link is None
+
+    async def test_clearing_the_field_takes_the_chat_down(self, client_factory, db_session_maker) -> None:
+        """A form sends an empty string for a cleared input, and it must mean
+        "take it down" — not "publish with a link that goes nowhere"."""
+        async with db_session_maker() as s:
+            s.add(Chat(id=-2104, title="listed", public_link="https://t.me/listed_chat"))
+            await s.commit()
+
+        async with client_factory() as client:
+            resp = await client.patch("/api/chats/-2104", json={"public_link": "   "})
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["public_link"] is None
+        async with db_session_maker() as s:
+            ch = (await s.execute(select(Chat).where(Chat.id == -2104))).scalar_one()
+            assert ch.public_link is None
+
+    async def test_a_patch_that_says_nothing_about_it_leaves_it_alone(self, client_factory, db_session_maker) -> None:
+        """Renaming a chat must not quietly unpublish it."""
+        async with db_session_maker() as s:
+            s.add(Chat(id=-2105, title="listed", public_link="https://t.me/listed_chat"))
+            await s.commit()
+
+        async with client_factory() as client:
+            resp = await client.patch("/api/chats/-2105", json={"title": "renamed"})
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["public_link"] == "https://t.me/listed_chat"
+
+
 async def test_update_chat_partial_keeps_other_fields(client_factory, db_session_maker) -> None:
     async with db_session_maker() as s:
         s.add(Chat(id=-2004, title="orig", welcome_message="orig-welcome"))

--- a/webui/src/lib/api/client.ts
+++ b/webui/src/lib/api/client.ts
@@ -13,6 +13,29 @@ export type ApiError = {
 	message: string;
 };
 
+/**
+ * What to show a person when the API refuses.
+ *
+ * FastAPI answers a rejected field with a list of per-field objects rather than
+ * a sentence, and putting that straight into a toast reads as
+ * "[object Object]" — so the one message that would have told the admin what
+ * they typed wrong is the one that never arrives. Flattened here because every
+ * form in the console posts through this function.
+ */
+function messageFrom(body: unknown, fallback: string): string {
+	const detail = (body as { detail?: unknown } | null)?.detail;
+	if (typeof detail === 'string') return detail;
+	if (Array.isArray(detail)) {
+		const written = detail
+			.map((entry) => (entry as { msg?: string })?.msg)
+			.filter((msg): msg is string => typeof msg === 'string')
+			// Pydantic prefixes its own wording; the sentence after it is ours.
+			.map((msg) => msg.replace(/^Value error, /, ''));
+		if (written.length > 0) return written.join('; ');
+	}
+	return fallback;
+}
+
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<ApiResult<T>> {
 	try {
 		const res = await fetch(path, {
@@ -38,7 +61,7 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<Api
 				error: {
 					status: res.status,
 					code: body?.error?.code ?? `http_${res.status}`,
-					message: body?.error?.message ?? body?.detail ?? res.statusText
+					message: body?.error?.message ?? messageFrom(body, res.statusText)
 				}
 			};
 		}

--- a/webui/src/routes/(admin)/admin/chats/+page.svelte
+++ b/webui/src/routes/(admin)/admin/chats/+page.svelte
@@ -7,7 +7,7 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
-	import { CheckCircle2, CircleDashed, RefreshCw, Search, Shield, XCircle } from '@lucide/svelte';
+	import { CheckCircle2, CircleDashed, Globe, RefreshCw, Search, Shield, XCircle } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
 	import type { components } from '$lib/api/types';
 
@@ -39,7 +39,11 @@
 			all: rows.length,
 			discovered: rows.filter((chat) => chat.resource_status === 'discovered').length,
 			approved: rows.filter((chat) => chat.resource_status === 'approved').length,
-			disabled: rows.filter((chat) => chat.resource_status === 'disabled').length
+			disabled: rows.filter((chat) => chat.resource_status === 'disabled').length,
+			// Counted the way the public endpoint counts: approved *and* carrying a
+			// link. A chat with a link but no approval is not on the site, and this
+			// number would be a small lie if it said otherwise.
+			listed: rows.filter((chat) => chat.resource_status === 'approved' && chat.public_link).length
 		};
 	});
 
@@ -95,7 +99,7 @@
 		</div>
 	</header>
 
-	<div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+	<div class="grid grid-cols-2 gap-3 md:grid-cols-5">
 		<div class="rounded-md border border-zinc-200 bg-white px-3 py-2.5">
 			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Total</div>
 			<div class="text-lg font-semibold tracking-tight text-zinc-900">{counts.all}</div>
@@ -111,6 +115,10 @@
 		<div class="rounded-md border border-zinc-200 bg-white px-3 py-2.5">
 			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">Disabled</div>
 			<div class="text-lg font-semibold tracking-tight text-zinc-900">{counts.disabled}</div>
+		</div>
+		<div class="rounded-md border border-zinc-200 bg-white px-3 py-2.5">
+			<div class="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">On the site</div>
+			<div class="text-lg font-semibold tracking-tight text-zinc-900">{counts.listed}</div>
 		</div>
 	</div>
 
@@ -159,7 +167,12 @@
 								<div class="flex min-w-0 items-center gap-2">
 									<ChatAvatar chatId={chat.id} title={chat.title} hasPhoto={chat.has_photo} size="sm" />
 									<div class="min-w-0">
-										<div class="truncate font-medium text-zinc-900">{chat.title ?? `#${chat.id}`}</div>
+										<div class="flex items-center gap-1.5">
+											<span class="truncate font-medium text-zinc-900">{chat.title ?? `#${chat.id}`}</span>
+											{#if chat.public_link && chat.resource_status === 'approved'}
+												<Globe class="h-3 w-3 shrink-0 text-zinc-400" aria-label="On the public site" />
+											{/if}
+										</div>
 										<div class="truncate font-mono text-xs text-zinc-500">{chat.id}</div>
 									</div>
 								</div>

--- a/webui/src/routes/(admin)/admin/chats/[id]/+page.svelte
+++ b/webui/src/routes/(admin)/admin/chats/[id]/+page.svelte
@@ -10,7 +10,7 @@
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { useLivePoll } from '$lib/hooks/useLivePoll.svelte';
 	import { apiFetch } from '$lib/api/client';
-	import { RefreshCw } from '@lucide/svelte';
+	import { ExternalLink, RefreshCw } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
 	import type { components } from '$lib/api/types';
 
@@ -115,6 +115,35 @@
 			toast.success(`Resource is ${statusLabel(status).toLowerCase()}`);
 			await detail.refresh();
 		}
+	}
+
+	// Publishing is kept apart from the moderation form on purpose: everything in
+	// that form is read back by the admin who set it, and this one field is read
+	// by everybody who opens the front page. Its own card, its own save.
+	let editingLink = $state(false);
+	let savingLink = $state(false);
+	let linkDraft = $state('');
+
+	// Same guard as the moderation form — the page polls every minute and would
+	// otherwise wipe a half-typed link out from under the person typing it.
+	$effect(() => {
+		if (detail.data && !editingLink) linkDraft = detail.data.public_link ?? '';
+	});
+
+	async function savePublicLink(): Promise<void> {
+		savingLink = true;
+		const res = await apiFetch<ChatRead>(`/api/chats/${chatId}`, {
+			method: 'PATCH',
+			body: JSON.stringify({ public_link: linkDraft.trim() || null })
+		});
+		savingLink = false;
+		if (res.error) {
+			toast.error(res.error.message);
+			return;
+		}
+		toast.success(res.data.public_link ? 'Listed on the public site' : 'Taken off the public site');
+		editingLink = false;
+		await detail.refresh();
 	}
 
 	function senderLabel(s: components['schemas']['ChatSender']): string {
@@ -276,6 +305,72 @@
 							<span class="text-zinc-400">Welcome:</span> {detail.data.welcome_message}
 						</div>
 					{/if}
+				{/if}
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root>
+			<Card.Header class="flex flex-row items-center justify-between">
+				<Card.Title class="text-sm">Public catalogue</Card.Title>
+				{#if !editingLink}
+					<Button variant="outline" size="sm" onclick={() => (editingLink = true)}>
+						{detail.data.public_link ? 'Change link' : 'Add link'}
+					</Button>
+				{/if}
+			</Card.Header>
+			<Card.Content class="space-y-3 text-sm">
+				{#if editingLink}
+					<label class="block space-y-1">
+						<span class="text-xs text-zinc-600">Public link</span>
+						<Input bind:value={linkDraft} placeholder="https://t.me/cvut_fit" />
+					</label>
+					<p class="text-xs text-zinc-500">
+						A Telegram link — a username, or an invite for a chat that has none. Clearing the
+						field takes the chat off the public site.
+					</p>
+					<div class="flex items-center justify-end gap-2">
+						<Button
+							variant="ghost"
+							size="sm"
+							disabled={savingLink}
+							onclick={() => {
+								editingLink = false;
+								linkDraft = detail.data?.public_link ?? '';
+							}}
+						>
+							Cancel
+						</Button>
+						<Button size="sm" onclick={savePublicLink} disabled={savingLink}>
+							{savingLink ? 'Saving…' : 'Save'}
+						</Button>
+					</div>
+				{:else if detail.data.public_link}
+					<div class="flex items-center gap-2">
+						<a
+							href={detail.data.public_link}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="inline-flex items-center gap-1.5 font-mono text-xs text-zinc-800 hover:underline"
+						>
+							{detail.data.public_link}
+							<ExternalLink class="h-3 w-3 text-zinc-400" />
+						</a>
+					</div>
+					{#if detail.data.resource_status === 'approved'}
+						<p class="text-xs text-zinc-500">Anyone can find this chat on the front page.</p>
+					{:else}
+						<!-- The link alone does not publish: the catalogue asks for an
+						     approved resource too. Said here rather than left to be
+						     worked out by opening the public page and not finding it. -->
+						<p class="text-xs text-amber-700">
+							Not listed — the resource is {statusLabel(detail.data.resource_status).toLowerCase()}.
+							Approve it above and this chat appears.
+						</p>
+					{/if}
+				{:else}
+					<p class="text-xs text-zinc-500">
+						Not on the public site. Add a link and students can find this chat themselves.
+					</p>
 				{/if}
 			</Card.Content>
 		</Card.Root>


### PR DESCRIPTION
The public catalogue shipped without a way to change it. `public_link` existed in the model, in `ChatUpdate` and in `ChatRead` — and nowhere in the console:

```
$ grep -rn "public_link" webui/src | grep -v api/types.ts
(nothing)
```

So taking a chat off the front page meant a shell against production.

## What this adds

**A card on the chat page.** Kept apart from the moderation form on purpose: everything in that form is read back by the admin who set it, and this one field is read by every stranger who opens the site. It shows which state the chat is in, and names the case where a link is set but the resource is not approved — otherwise that disagreement is found by looking at the public page and not finding the chat.

**A shape check.** The value ends up in an `href` on a page anybody can open, so it is a whitelist of the three Telegram link forms (username, invite hash, legacy `joinchat`) rather than a "looks like a URL" test. `javascript:alert(1)`, `http://`, and lookalike hosts like `t.me.evil.example` are refused. All nineteen links already in production pass unchanged — checked against the live database before writing the rule.

**A cleared field takes the chat down.** A form sends `''` for an empty input; the catalogue keys off the column being set, so without this an empty string would list a chat whose card leads nowhere.

**Readable validation errors.** FastAPI answers a rejected field with a list of objects, which `toast.error` renders as `[object Object]` — the one message that would say what was typed wrong was the one that never arrived. Flattened in `apiFetch`, which every form in the console already goes through.

**A count and a marker on the chats list**, counted the way the public endpoint counts: approved *and* carrying a link.

## Checks

- `uv run -m pytest` — 548 passed, 2 skipped
- `uv run ruff check` / `ruff format --check` / `ty check` — clean, no new diagnostics
- `pnpm --dir webui run check` — 0 errors; `build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)