### PR TITLE
Цикл снимков ждал Telethon целый час

### DIFF
--- a/app/telethon/snapshots.py
+++ b/app/telethon/snapshots.py
@@ -42,6 +42,10 @@ logger = get_logger("webapi.snapshot_loop")
 SNAPSHOT_INTERVAL_SECONDS = 3600  # 1 hour
 METADATA_STALENESS_HOURS = 24
 
+# How long to wait when the Telethon client is not connected yet. Short,
+# because the usual reason is that the process is thirty seconds old.
+RETRY_INTERVAL_SECONDS = 30
+
 
 def _refresh_stale_metadata(chat: Chat, info: Any, *, cutoff: datetime.datetime) -> bool:
     """Sync Chat.title from Telegram when the row's last_synced_at is past
@@ -127,11 +131,24 @@ async def run_snapshot_loop(
     telethon: TelethonClient | None,
     bot: Bot | None = None,
     interval_seconds: int = SNAPSHOT_INTERVAL_SECONDS,
+    retry_seconds: int = RETRY_INTERVAL_SECONDS,
 ) -> None:
-    """Forever-loop. Cancelled on app shutdown via task.cancel()."""
+    """Forever-loop. Cancelled on app shutdown via task.cancel().
+
+    Sleeps a short retry rather than the full hour whenever the client is not
+    connected. The loop is started alongside polling, and the client connects
+    from the dispatcher's startup hook — so the first tick reliably arrives
+    before Telethon is up. Sleeping an hour on that meant an empty table for an
+    hour after every deploy, which is indistinguishable from the loop being
+    broken, and was in fact how the loop being broken looked.
+    """
     while True:
-        try:
-            await snapshot_once(session_maker=session_maker, telethon=telethon, bot=bot)
-        except Exception:
-            logger.exception("snapshot_loop iteration failed")
-        await asyncio.sleep(interval_seconds)
+        connected = telethon is not None and telethon.is_available
+        if connected:
+            try:
+                await snapshot_once(session_maker=session_maker, telethon=telethon, bot=bot)
+            except Exception:
+                logger.exception("snapshot_loop iteration failed")
+        else:
+            logger.info("snapshot_loop waiting for telethon", retry_seconds=retry_seconds)
+        await asyncio.sleep(interval_seconds if connected else retry_seconds)

--- a/tests/unit/test_snapshot_loop_timing.py
+++ b/tests/unit/test_snapshot_loop_timing.py
@@ -1,0 +1,77 @@
+"""When the loop tries again.
+
+The client connects from the dispatcher's startup hook while the loop is
+started alongside polling, so the first tick arrives before Telegram has been
+reached. Sleeping the full hour on that leaves the table empty for an hour
+after every deploy — and an empty table for an hour is exactly what a broken
+loop looks like, which is how the last one hid.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from app.telethon import snapshots
+
+pytestmark = pytest.mark.unit
+
+
+class _StopLoopError(Exception):
+    """Breaks the forever-loop once the test has seen what it came for."""
+
+
+def _client(available: bool) -> MagicMock:
+    client = MagicMock()
+    client.is_available = available
+    return client
+
+
+async def _run_until_first_sleep(monkeypatch, telethon) -> float:
+    """Run the loop until it first sleeps, and return how long for."""
+    slept: list[float] = []
+
+    async def _sleep(seconds: float) -> None:
+        slept.append(seconds)
+        raise _StopLoopError
+
+    monkeypatch.setattr(snapshots.asyncio, "sleep", _sleep)
+    with pytest.raises(_StopLoopError):
+        await snapshots.run_snapshot_loop(
+            session_maker=MagicMock(),
+            telethon=telethon,
+            interval_seconds=3600,
+            retry_seconds=30,
+        )
+    return slept[0]
+
+
+async def test_it_retries_soon_when_not_connected_yet(monkeypatch) -> None:
+    assert await _run_until_first_sleep(monkeypatch, _client(available=False)) == 30
+
+
+async def test_it_waits_the_full_interval_after_a_tick(monkeypatch) -> None:
+    monkeypatch.setattr(snapshots, "snapshot_once", AsyncMock(return_value=3))
+
+    assert await _run_until_first_sleep(monkeypatch, _client(available=True)) == 3600
+
+
+async def test_a_missing_client_is_not_a_crash(monkeypatch) -> None:
+    """Telethon unconfigured is a deployment choice, not a fault."""
+    assert await _run_until_first_sleep(monkeypatch, None) == 30
+
+
+async def test_it_does_not_call_telegram_before_it_can(monkeypatch) -> None:
+    once = AsyncMock()
+    monkeypatch.setattr(snapshots, "snapshot_once", once)
+
+    await _run_until_first_sleep(monkeypatch, _client(available=False))
+
+    once.assert_not_awaited()
+
+
+async def test_a_failed_tick_still_waits_the_full_interval(monkeypatch) -> None:
+    """A raising tick must not become a hot retry against Telegram."""
+    monkeypatch.setattr(snapshots, "snapshot_once", AsyncMock(side_effect=RuntimeError("boom")))
+
+    assert await _run_until_first_sleep(monkeypatch, _client(available=True)) == 3600


### PR DESCRIPTION
Продолжение #112. После деплоя таблица снимков оставалась пустой десять минут, и я вернулся смотреть.

## Гонка

Цикл добавляется в `asyncio.gather` рядом с поллингом, а `telethon.start()` вызывается из `on_startup` — хука диспетчера. Первый тик стабильно приходит раньше, чем клиент подключился, видит `is_available == False`, ничего не пишет и **засыпает на час**.

То есть после каждого деплоя таблица пуста час. Что выглядит ровно так же, как сломанный цикл из #112 — мне пришлось лезть в исходник, чтобы отличить одно от другого. Это и есть цена, которую здесь платят.

## Починка

Не подключён — ждём 30 секунд. Тик, который отработал или упал, по-прежнему ждёт час: падающий тик не должен превращаться в горячий ретрай по Telegram.

`616 passed, 2 skipped`. Ruff чисто, `ty` — те же 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)