### PR TITLE
Страница рекламы обещала «≈0 участников»

### DIFF
--- a/webui/src/routes/(public)/ads/+page.svelte
+++ b/webui/src/routes/(public)/ads/+page.svelte
@@ -44,6 +44,12 @@
 	// so the member total can cover part of the catalogue. Saying "≈18 400"
 	// without saying that would be a number somebody pays against.
 	const partial = $derived(!!reach && reach.measured_chats < reach.chats);
+
+	// Nothing measured at all is not "zero people". It is "we have not counted",
+	// and the honest rendering of that is to say nothing — the same choice the
+	// catalogue makes for a chat whose activity it cannot ground. A tile reading
+	// "≈0 участников" is worse than an absent one: it is read, and believed.
+	const counted = $derived(!!reach && reach.measured_chats > 0);
 </script>
 
 <svelte:head><title>Реклама в студенческих чатах — Konnekt</title></svelte:head>
@@ -71,14 +77,16 @@
 					{plural(reach.chats, 'чат', 'чата', 'чатов')}
 				</div>
 			</div>
-			<div>
-				<div class="font-mono text-3xl font-semibold tabular-nums tracking-tight text-zinc-900">
-					{partial ? '≈' : ''}{num(reach.members)}
+			{#if counted}
+				<div>
+					<div class="font-mono text-3xl font-semibold tabular-nums tracking-tight text-zinc-900">
+						{partial ? '≈' : ''}{num(reach.members)}
+					</div>
+					<div class="mt-1 text-[10px] font-semibold tracking-wider text-zinc-500 uppercase">
+						{plural(reach.members, 'участник', 'участника', 'участников')}
+					</div>
 				</div>
-				<div class="mt-1 text-[10px] font-semibold tracking-wider text-zinc-500 uppercase">
-					{plural(reach.members, 'участник', 'участника', 'участников')}
-				</div>
-			</div>
+			{/if}
 			<div>
 				<div class="font-mono text-3xl font-semibold tabular-nums tracking-tight text-zinc-900">
 					{num(reach.groups.length)}
@@ -89,11 +97,15 @@
 			</div>
 		</div>
 
-		{#if partial}
+		{#if counted && partial}
 			<p class="-mt-6 max-w-xl text-xs text-zinc-500">
 				Участники посчитаны по {reach.measured_chats} из {reach.chats}
 				{plural(reach.chats, 'чата', 'чатов', 'чатов')} — Telegram отвечает не по всем. Настоящая
 				цифра выше этой, но обещать мы можем только измеренное.
+			</p>
+		{:else if !counted}
+			<p class="-mt-6 max-w-xl text-xs text-zinc-500">
+				Число участников сейчас не показываем — напишите, назовём его в ответе.
 			</p>
 		{/if}
 
@@ -114,11 +126,13 @@
 								>
 									Чатов
 								</th>
-								<th
-									class="pb-2 text-right text-[10px] font-semibold tracking-wider text-zinc-500 uppercase"
-								>
-									Участников
-								</th>
+								{#if counted}
+									<th
+										class="pb-2 text-right text-[10px] font-semibold tracking-wider text-zinc-500 uppercase"
+									>
+										Участников
+									</th>
+								{/if}
 							</tr>
 						</thead>
 						<tbody>
@@ -128,9 +142,11 @@
 									<td class="py-2 text-right font-mono tabular-nums text-zinc-600">
 										{num(group.chats)}
 									</td>
-									<td class="py-2 text-right font-mono tabular-nums text-zinc-600">
-										{group.members > 0 ? num(group.members) : '—'}
-									</td>
+									{#if counted}
+										<td class="py-2 text-right font-mono tabular-nums text-zinc-600">
+											{group.members > 0 ? num(group.members) : '—'}
+										</td>
+									{/if}
 								</tr>
 							{/each}
 						</tbody>


### PR DESCRIPTION
Найдено при живой проверке после #113.

`TELETHON_API_ID` и `TELETHON_API_HASH` **не заданы в секретах репозитория** — я проверил `gh secret list`. Значит `settings.telethon.active` ложно, клиент не создаётся, цикл снимков не стартует. Код из #112 и #113 верен; в продакшене просто нет учётных данных.

Эндпоинт отвечает честно: `measured_chats: 0`. Страница рендерила это как «≈0 участников» рядом с девятнадцатью настоящими чатами. Не измерено — это не ноль человек.

Теперь при нулевом измерении цифра и колонка отсутствуют, а страница говорит, что число назовут в ответе. Чаты и направления считаются по нашим собственным строкам и показываются как раньше.

`pnpm run check` — 0 ошибок, сборка проходит.

**Что нужно от вас, чтобы счётчики заработали** — расписал в ответе; коротко: два секрета и авторизованная сессия рабочего аккаунта на VPS. Сам я сессию аккаунта никуда не заливаю.

🤖 Generated with [Claude Code](https://claude.com/claude-code)