### PR TITLE
Open the catalogue as a Mini App, not a website

### DIFF
--- a/app/presentation/telegram/bot.py
+++ b/app/presentation/telegram/bot.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
+from aiogram.types import MenuButton, MenuButtonCommands, MenuButtonWebApp, WebAppInfo
 from aiogram.utils.callback_answer import CallbackAnswerMiddleware
 
 from app.core.config import settings
@@ -39,6 +40,27 @@ logger = get_logger("bot")
 # ---------------------------------------------------------------------------
 
 
+async def _publish_menu_button(bot: Bot) -> None:
+    """Put the catalogue on the chat menu, one tap from any private chat.
+
+    Telegram stores this on the bot rather than on a message, so it is set once
+    here and survives every restart — which is also why the plain-http and
+    unconfigured cases must reset it instead of doing nothing. A deployment
+    that turns the public site off would otherwise keep offering a button to an
+    address that no longer answers, set by a deployment that is long gone.
+    """
+    url = settings.webapi.public_url.rstrip("/")
+
+    # https is Telegram's requirement for a Mini App, not ours; local
+    # development runs over http and gets the ordinary command menu.
+    if url.startswith("https://"):
+        button: MenuButton = MenuButtonWebApp(text="Каталог", web_app=WebAppInfo(url=url))
+    else:
+        button = MenuButtonCommands()
+
+    await bot.set_chat_menu_button(menu_button=button)
+
+
 async def on_startup(bot: Bot) -> None:
     """Main bot startup: clear any leftover webhook before polling."""
     try:
@@ -47,6 +69,14 @@ async def on_startup(bot: Bot) -> None:
     except Exception as e:
         logger.error("startup_error", error=str(e), exc_info=True)
         raise
+
+    # Deliberately not fatal, and deliberately after the line above: a bot that
+    # could not draw its menu button still moderates, and refusing to start
+    # over a cosmetic call would trade the whole service for a nicety.
+    try:
+        await _publish_menu_button(bot)
+    except Exception as e:
+        logger.warning("menu_button_not_set", error=str(e))
 
 
 async def on_shutdown(bot: Bot) -> None:

--- a/app/presentation/telegram/handlers/start.py
+++ b/app/presentation/telegram/handlers/start.py
@@ -88,15 +88,21 @@ async def start_private(message: types.Message, admin_repo: AdminRepository) -> 
         text += "Все команды — /help"
 
     private = message.chat.type == "private"
+    shows_console = is_super_admin and bool(settings.webapi.public_url)
 
     builder = InlineKeyboardBuilder()
-    if is_super_admin and settings.webapi.public_url:
+    if shows_console:
         builder.button(text="⚙️ Открыть консоль", callback_data=AdminConsole().pack())
     if settings.webapi.public_url:
         builder.add(_open_button("🔎 Найти свой чат", _site(), private=private))
         builder.add(_open_button("📣 Реклама в чатах", f"{_site()}/ads", private=private))
     builder.add(types.InlineKeyboardButton(text="✉️ Написать нам", url=f"https://t.me/{CONTACT_USERNAME}"))
-    builder.adjust(1)
+
+    # A column of identical full-width buttons reads as a wall, and gives the
+    # same weight to the reason somebody opened the bot and to the two things
+    # nobody did. Advertising and the contact link share the last row; the
+    # shape depends on the console, which only a super administrator is shown.
+    builder.adjust(*([1, 1, 2] if shows_console else [1, 2]))
 
     # Deliberately not scheduled for deletion. This is the message somebody
     # comes back to; the справочник below is the one that may go.

--- a/app/presentation/telegram/handlers/start.py
+++ b/app/presentation/telegram/handlers/start.py
@@ -32,7 +32,7 @@ logger = get_logger("handlers.start")
 
 # Where somebody who wants to place an advertisement, or to say anything else,
 # is sent. The bot answers questions about chats; a person answers the rest.
-CONTACT_USERNAME = "czech_media_admin"
+CONTACT_USERNAME = "work_azamat"
 
 
 class AdminConsole(CallbackData, prefix="console"):
@@ -46,6 +46,23 @@ class AdminConsole(CallbackData, prefix="console"):
 
 def _site() -> str:
     return settings.webapi.public_url.rstrip("/")
+
+
+def _open_button(text: str, url: str, *, private: bool) -> types.InlineKeyboardButton:
+    """Open the site inside Telegram where that is allowed, as a link where it is not.
+
+    A Mini App is the difference between reading the catalogue and using it: it
+    inherits the client's theme, and a tap on a chat opens that chat in place
+    instead of bouncing out to a browser and back.
+
+    Telegram accepts such a button only in a private chat, and only over https.
+    Both are checked rather than assumed, because a button it refuses fails the
+    whole message — `/start` in a group would answer nothing at all, and a
+    developer running against a plain-http URL would see the same.
+    """
+    if private and url.startswith("https://"):
+        return types.InlineKeyboardButton(text=text, web_app=types.WebAppInfo(url=url))
+    return types.InlineKeyboardButton(text=text, url=url)
 
 
 @router.message(Command("start", prefix="/!"))
@@ -70,13 +87,15 @@ async def start_private(message: types.Message, admin_repo: AdminRepository) -> 
     else:
         text += "Все команды — /help"
 
+    private = message.chat.type == "private"
+
     builder = InlineKeyboardBuilder()
     if is_super_admin and settings.webapi.public_url:
         builder.button(text="⚙️ Открыть консоль", callback_data=AdminConsole().pack())
     if settings.webapi.public_url:
-        builder.button(text="🔎 Найти свой чат", url=_site())
-        builder.button(text="📣 Реклама в чатах", url=f"{_site()}/ads")
-    builder.button(text="✉️ Написать нам", url=f"https://t.me/{CONTACT_USERNAME}")
+        builder.add(_open_button("🔎 Найти свой чат", _site(), private=private))
+        builder.add(_open_button("📣 Реклама в чатах", f"{_site()}/ads", private=private))
+    builder.add(types.InlineKeyboardButton(text="✉️ Написать нам", url=f"https://t.me/{CONTACT_USERNAME}"))
     builder.adjust(1)
 
     # Deliberately not scheduled for deletion. This is the message somebody

--- a/docs/deployment/telegram-accounts.md
+++ b/docs/deployment/telegram-accounts.md
@@ -42,7 +42,7 @@ uv run python scripts/tg_accounts.py status
 
 ```
 main       authorised    @azamat (id 268388996)
-work       authorised    @konnekt_ops (id ...)
+work       authorised    @work_azamat (id ...)
 ```
 
 This one never prompts. It is what anything unattended runs before acting, to
@@ -82,8 +82,8 @@ contents. The personal folder is excluded by default, and exclusion beats any
 Then the promotion pass, over a scope file of chat ids:
 
 ```bash
-uv run python scripts/tg_promote.py --account main --target @work --chats scope.txt            # plan
-uv run python scripts/tg_promote.py --account main --target @work --chats scope.txt --apply
+uv run python scripts/tg_promote.py --account main --target @work_azamat --chats scope.txt        # plan
+uv run python scripts/tg_promote.py --account main --target @work_azamat --chats scope.txt --apply
 ```
 
 It grants every administrator right, including `add_admins` — the second account

--- a/tests/handlers/test_start.py
+++ b/tests/handlers/test_start.py
@@ -53,6 +53,11 @@ def _in_group(factory, command: str, user):
     return factory.create_command_message(command=command, user=user, chat=factory.create_chat())
 
 
+def _rows(message) -> list[list]:
+    markup = message.answer.call_args[1].get("reply_markup")
+    return markup.inline_keyboard if markup else []
+
+
 def _answered(message) -> tuple[str, list]:
     text = message.answer.call_args[0][0]
     markup = message.answer.call_args[1].get("reply_markup")
@@ -122,6 +127,26 @@ class TestStart:
         _, buttons = _answered(message)
         assert all(b.web_app is None for b in buttons)
         assert buttons[0].url == "http://localhost:5173"
+
+    async def test_the_two_asides_share_a_row(self, telegram_factory, admin_repo, site):
+        """Four identical full-width buttons is a wall, evenly weighted.
+
+        Finding a chat is why anybody opened this. Advertising and the contact
+        link are not, and a column gives all three the same emphasis.
+        """
+        message = _private(telegram_factory, "start", create_normal_user(id=555))
+
+        await start_handlers.start_private(message, admin_repo)
+
+        assert [len(row) for row in _rows(message)] == [1, 2]
+
+    async def test_the_console_does_not_disturb_that(self, telegram_factory, admin_repo, site):
+        """It is one button more, drawn for one person, and it keeps its row."""
+        message = _private(telegram_factory, "start", create_admin_user(id=SUPER_ADMIN_ID))
+
+        await start_handlers.start_private(message, admin_repo)
+
+        assert [len(row) for row in _rows(message)] == [1, 1, 2]
 
     async def test_the_greeting_is_not_deleted(self, telegram_factory, admin_repo, site):
         """It is the first screen of the product, not a service reply.

--- a/tests/handlers/test_start.py
+++ b/tests/handlers/test_start.py
@@ -49,6 +49,10 @@ def _private(factory, command: str, user):
     )
 
 
+def _in_group(factory, command: str, user):
+    return factory.create_command_message(command=command, user=user, chat=factory.create_chat())
+
+
 def _answered(message) -> tuple[str, list]:
     text = message.answer.call_args[0][0]
     markup = message.answer.call_args[1].get("reply_markup")
@@ -71,13 +75,19 @@ class TestStart:
         assert len(buttons) >= 2
 
     async def test_the_first_button_goes_to_the_catalogue(self, telegram_factory, admin_repo, site):
-        """The question people arrive with is "where is my faculty's chat"."""
+        """The question people arrive with is "where is my faculty's chat".
+
+        As a Mini App rather than a link: opened as a site, a tap on a chat
+        leaves Telegram for a browser which then reopens Telegram.
+        """
         message = _private(telegram_factory, "start", create_normal_user(id=555))
 
         await start_handlers.start_private(message, admin_repo)
 
         _, buttons = _answered(message)
-        assert buttons[0].url == SITE
+        assert buttons[0].web_app is not None
+        assert buttons[0].web_app.url == SITE
+        assert buttons[0].url is None
 
     async def test_an_advertiser_has_somewhere_to_go(self, telegram_factory, admin_repo, site):
         message = _private(telegram_factory, "start", create_normal_user(id=555))
@@ -85,7 +95,33 @@ class TestStart:
         await start_handlers.start_private(message, admin_repo)
 
         _, buttons = _answered(message)
-        assert any(b.url == f"{SITE}/ads" for b in buttons)
+        assert any(b.web_app and b.web_app.url == f"{SITE}/ads" for b in buttons)
+
+    async def test_in_a_group_the_site_stays_an_ordinary_link(self, telegram_factory, admin_repo, site):
+        """Telegram refuses a web_app button outside a private chat.
+
+        It refuses the message, not the button: `/start` in a group would answer
+        nothing at all rather than answer with one button missing.
+        """
+        message = _in_group(telegram_factory, "start", create_normal_user(id=555))
+
+        await start_handlers.start_private(message, admin_repo)
+
+        _, buttons = _answered(message)
+        assert all(b.web_app is None for b in buttons)
+        assert buttons[0].url == SITE
+
+    async def test_a_site_without_tls_stays_an_ordinary_link(self, telegram_factory, admin_repo, monkeypatch):
+        """Telegram requires https for a Mini App; local development has none."""
+        monkeypatch.setattr(start_handlers.settings.webapi, "public_url", "http://localhost:5173")
+        monkeypatch.setattr(start_handlers.settings.admin, "super_admins", [])
+        message = _private(telegram_factory, "start", create_normal_user(id=555))
+
+        await start_handlers.start_private(message, admin_repo)
+
+        _, buttons = _answered(message)
+        assert all(b.web_app is None for b in buttons)
+        assert buttons[0].url == "http://localhost:5173"
 
     async def test_the_greeting_is_not_deleted(self, telegram_factory, admin_repo, site):
         """It is the first screen of the product, not a service reply.

--- a/tests/unit/test_menu_button.py
+++ b/tests/unit/test_menu_button.py
@@ -1,0 +1,77 @@
+"""The chat menu button, which points at the catalogue.
+
+Telegram keeps this setting on the bot, not on a message: it is written once at
+startup and stays until something writes over it. That is the whole reason the
+unconfigured cases here assert a reset rather than a no-op — a deployment that
+stops publishing a site would otherwise leave the previous deployment's button
+pointing at an address that no longer answers, and nothing would ever clear it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.types import MenuButtonCommands, MenuButtonWebApp
+from app.presentation.telegram import bot as bot_module
+
+pytestmark = pytest.mark.unit
+
+SITE = "https://konnekt.example"
+
+
+async def _set_button(monkeypatch, public_url: str):
+    monkeypatch.setattr(bot_module.settings.webapi, "public_url", public_url)
+    bot = AsyncMock()
+
+    await bot_module._publish_menu_button(bot)
+
+    return bot.set_chat_menu_button.call_args[1]["menu_button"]
+
+
+class TestMenuButton:
+    async def test_a_configured_site_becomes_a_mini_app(self, monkeypatch) -> None:
+        button = await _set_button(monkeypatch, SITE)
+
+        assert isinstance(button, MenuButtonWebApp)
+        assert button.web_app.url == SITE
+
+    async def test_a_trailing_slash_does_not_reach_telegram(self, monkeypatch) -> None:
+        button = await _set_button(monkeypatch, f"{SITE}/")
+
+        assert isinstance(button, MenuButtonWebApp)
+        assert button.web_app.url == SITE
+
+    async def test_no_site_restores_the_command_menu(self, monkeypatch) -> None:
+        button = await _set_button(monkeypatch, "")
+
+        assert isinstance(button, MenuButtonCommands)
+
+    async def test_plain_http_restores_the_command_menu(self, monkeypatch) -> None:
+        """Telegram requires https for a Mini App; local development has none."""
+        button = await _set_button(monkeypatch, "http://localhost:5173")
+
+        assert isinstance(button, MenuButtonCommands)
+
+
+class TestStartupIsNotHeldHostage:
+    async def test_a_failed_menu_button_does_not_stop_the_bot(self, monkeypatch) -> None:
+        """Moderation is the job; the menu button is a nicety beside it."""
+        monkeypatch.setattr(bot_module.settings.webapi, "public_url", SITE)
+        bot = AsyncMock()
+        bot.set_chat_menu_button.side_effect = RuntimeError("Telegram said no")
+
+        await bot_module.on_startup(bot)
+
+        bot.delete_webhook.assert_awaited()
+
+    async def test_a_failed_webhook_clear_does_stop_it(self, monkeypatch) -> None:
+        """That one means the bot cannot receive updates at all."""
+        monkeypatch.setattr(bot_module.settings.webapi, "public_url", SITE)
+        bot = AsyncMock()
+        bot.delete_webhook.side_effect = RuntimeError("Telegram said no")
+
+        with pytest.raises(RuntimeError):
+            await bot_module.on_startup(bot)
+
+        bot.set_chat_menu_button.assert_not_awaited()

--- a/webui/src/routes/(public)/ads/+page.svelte
+++ b/webui/src/routes/(public)/ads/+page.svelte
@@ -15,7 +15,7 @@
 	type Reach = components['schemas']['PublicReach'];
 
 	// Who answers. The bot handles questions about chats; a person handles this.
-	const CONTACT = 'czech_media_admin';
+	const CONTACT = 'work_azamat';
 
 	let reach = $state<Reach | null>(null);
 	let loading = $state(true);


### PR DESCRIPTION
The button under `/start` handed out a plain URL, so Telegram opened the catalogue in its browser — address bar, no theme inheritance, and a tap on a chat leaving Telegram for a browser that immediately reopened Telegram. Three hops where there should be one.

## What changed

**`/start` buttons are Mini Apps.** `🔎 Найти свой чат` and `📣 Реклама в чатах` now open in place. The page inherits the client's theme and can open a chat without leaving Telegram; it also gets a signed identity, which is what the console login should eventually use instead of a magic link.

**Both fallbacks are real, not defensive padding.** Telegram accepts a `web_app` button only in a private chat and only over https, and it rejects the whole message rather than the offending button. Without the guard, `/start` in a group would have answered nothing at all, and anyone running against `http://localhost:5173` would have seen the same. Each case falls back to an ordinary link.

**The chat menu button carries the catalogue.** Set once at startup, because Telegram stores it on the bot rather than on a message. The unconfigured and plain-http cases reset it to the command menu instead of skipping — otherwise a deployment that stops publishing a site leaves the previous deployment's button aimed at a dead address, with nothing that would ever clear it. A failure here is logged and does not stop the bot: moderation is the job, the menu button is a nicety beside it.

**Contact is `@work_azamat`**, in the bot (which also changes `/contacts`) and on the ads page. The account doc still said `@konnekt_ops`, and gave the promotion command as `--target @work` — the session label rather than the username `tg_promote.py` actually resolves, so anyone copying it would have hit a name-resolution error.

## Checks

Full suite passes; `ruff` clean; `ty` reports the same 9 pre-existing diagnostics in untouched files; `pnpm --dir webui run check` reports 0 errors.

New tests cover the group fallback, the plain-http fallback, the menu button in all four configurations, and that a refused menu button does not prevent startup while a refused webhook clear still does.

## Not in this change

- The **direct Mini App link** from BotFather (`/newapp`), which is what lets the catalogue open as an app from groups too. That is an action in Telegram, not in this repository.
- The **prefilled `?text=`** on contact links — `?text=` on a link to a person rather than a bot is undocumented and needs checking on iOS, Android and Desktop first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)