### PR TITLE
Pull the images as nobody

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,6 +125,20 @@ jobs:
           script: |
             set -e
             cd ~/deploy/supervisor-telegram
+
+            # Pull as nobody. Both images are public, so no credential is
+            # needed — and a stale one is worse than none, because the registry
+            # rejects what it is shown instead of falling back to anonymous.
+            # That is how every pull started failing with "denied" while the
+            # images were readable by anyone.
+            #
+            # The host is shared with unrelated projects, so clearing its
+            # ghcr.io login is not ours to do. A config directory of our own
+            # sidesteps whichever user or credential helper holds the bad
+            # entry, and has nothing in it that could expire later.
+            export DOCKER_CONFIG="$PWD/.docker"
+            mkdir -p "$DOCKER_CONFIG"
+
             docker compose pull
             docker compose up -d --remove-orphans
             echo "--- Container status ---"

--- a/tests/unit/test_deploy_config.py
+++ b/tests/unit/test_deploy_config.py
@@ -91,3 +91,17 @@ def test_nothing_writes_configuration_to_the_host() -> None:
     script = _deploy_step()["with"]["script"]
 
     assert ".env" not in script
+
+
+def test_the_pull_does_not_depend_on_the_host_docker_login() -> None:
+    """The images are public and the host is shared with other projects.
+
+    Depending on a login nobody here maintains is how a deploy comes to fail
+    with "denied" against images anyone can read: a rejected credential does
+    not fall back to anonymous. Our own config directory has nothing in it to
+    go stale.
+    """
+    script = _deploy_step()["with"]["script"]
+
+    assert "DOCKER_CONFIG" in script
+    assert script.index("DOCKER_CONFIG") < script.index("docker compose pull")


### PR DESCRIPTION
Every deploy since yesterday fails at `docker compose pull`:

```
Image ghcr.io/…/supervisor-telegram:f5c4b2e  Error error from registry: denied
```

**The images are public.** I pulled one anonymously with plain `docker` from a laptop, no credentials involved:

```
Status: Downloaded newer image for ghcr.io/vsem-azamat/supervisor-telegram:f5c4b2e…
```

So the host is presenting a credential the registry rejects. **A stale credential is worse than none** — the registry refuses what it is shown instead of falling back to anonymous, so a login nobody maintains breaks pulls that need no login at all. `docker logout` on the host did not take, most likely because the deploy runs as a different user than the one it was run for; each has its own `~/.docker/config.json`.

Rather than keep hunting for where the entry lives, the deploy gets a config directory of its own. That sidesteps whichever user or credential helper holds it, and leaves nothing behind that can expire in six months.

Clearing the host's entry properly was the other option and I did not take it: the machine is shared with unrelated projects, and `docker logout ghcr.io` would take their ghcr credential with it.

If our images are ever made private this breaks immediately and visibly, which is the right way round for a public repository.

A test pins that the deploy script sets `DOCKER_CONFIG` before it pulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)